### PR TITLE
Add plugin update documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ I'm a big fan of [Superpowers](https://github.com/obra/superpowers) and recommen
 
 Then restart Claude Code.
 
+## Updating
+
+To update Candid to the latest version:
+
+```bash
+claude plugin update candid@candid
+```
+
+Or from within Claude Code:
+
+```bash
+/plugin install candid@candid
+```
+
+Then restart Claude Code.
+
+See [CHANGELOG.md](CHANGELOG.md) for what's new in each version.
+
 ## Usage
 
 ### Basic Review


### PR DESCRIPTION
Adds an "Updating" section to the README that explains how users can update the Candid plugin to the latest version. Includes both CLI and in-session commands, plus a reference to the CHANGELOG for version history. This fills a documentation gap for users who want to keep their plugin current.