### PR TITLE
Add configurable merge target branch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-01-17
+
+### Added
+
+- **Configurable Merge Target Branches**: Specify which branches to compare against when reviewing branch diffs, replacing the hardcoded `main → stable → master` fallback chain.
+  - **Config field**: `mergeTargetBranches` accepts an array of branch names (e.g., `["develop", "main"]`)
+  - **CLI flag**: `--merge-target <branch>` (repeatable) for one-off overrides
+  - **Four-tier precedence**: CLI flags → project config → user config → default (`["main", "stable", "master"]`)
+  - **Workflow examples**: New example configs for Git Flow, trunk-based, and GitHub Flow in `examples/`
+  - **Graceful fallback**: Tries each branch in order, uses first that exists
+  - **Backward compatible**: Default behavior unchanged for existing users
+
+- **New Example Configs**:
+  - `examples/git-flow/config.json`: Git Flow workflow (develop → main)
+  - `examples/trunk-based/config.json`: Trunk-based development (trunk)
+  - `examples/github-flow/config.json`: GitHub Flow (main only)
+
+- **New Test Cases**: 5 validation test files for merge target branch configuration
+  - `valid-merge-target-single.json`, `valid-merge-target-multiple.json`, `valid-merge-target-with-remote.json`
+  - `invalid-merge-target-empty.json`, `invalid-merge-target-string.json`
+
+### Changed
+
+- **Documentation updates**: README.md, review-scope.md, troubleshooting.md, and ci-cd.md updated with merge target configuration guidance
+- **New Step 2.5**: Load Merge Target Branches procedure added to SKILL.md with full validation logic
+- **CONFIG.md schema expanded**: Added `mergeTargetBranches` field with validation rules
+
 ## [1.1.0] - 2026-01-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -190,8 +190,15 @@ Using constructive tone (from interactive prompt)
 ### Example Configs
 
 See the `examples/` directory for ready-to-use config files:
-- `examples/harsh/config.json` - Harsh tone config (just copy to `.candid/` or `~/.candid/`)
-- `examples/constructive/config.json` - Constructive tone config
+
+**By tone:**
+- `examples/harsh/config.json` - Harsh tone
+- `examples/constructive/config.json` - Constructive tone
+
+**By workflow:**
+- `examples/git-flow/config.json` - Git Flow (develop → main)
+- `examples/trunk-based/config.json` - Trunk-based development
+- `examples/github-flow/config.json` - GitHub Flow (main only)
 
 ### Invalid Configs
 
@@ -200,6 +207,36 @@ If a config file is malformed or has an invalid tone value, candid shows a warni
 ```
 ⚠️  Invalid config at .candid/config.json: malformed JSON. Falling back to user config.
 ```
+
+### Merge Target Branches
+
+Specify which branches to compare against when reviewing branch diffs.
+
+**Config file:**
+```json
+{
+  "mergeTargetBranches": ["develop", "main"]
+}
+```
+
+**CLI flag:**
+```bash
+/candid-review --merge-target develop
+/candid-review --merge-target develop --merge-target main  # Fallback chain
+```
+
+**Common configurations:**
+
+| Workflow | Config |
+|----------|--------|
+| GitHub Flow | `["main"]` |
+| Git Flow | `["develop", "main"]` |
+| Trunk-based | `["trunk"]` |
+| CI (remote branches) | `["origin/main", "main"]` |
+
+**Default:** If not specified, uses `["main", "stable", "master"]`.
+
+**How it works:** Candid tries each branch in order and uses the first that exists. You'll see which branch was selected in the output.
 
 ## Technical.md
 

--- a/docs/integration/ci-cd.md
+++ b/docs/integration/ci-cd.md
@@ -303,9 +303,16 @@ Speed up CI by caching the plugin:
 
 For large repos, review only changed paths:
 
+**Tip:** For Git Flow or custom workflows, configure merge target in `.candid/config.json`:
+```json
+{"mergeTargetBranches": ["develop"]}
+```
+
 ```bash
 # Get changed files
-CHANGED_FILES=$(git diff --name-only origin/main...HEAD | grep -E '\.(ts|js|py)$' | head -20)
+# Automatically uses configured merge target
+# Or specify explicitly for CI:
+CHANGED_FILES=$(git diff --name-only origin/develop...HEAD | grep -E '\.(ts|js|py)$' | head -20)
 
 # Review them
 claude code "/candid-review $CHANGED_FILES"

--- a/docs/review-scope.md
+++ b/docs/review-scope.md
@@ -8,7 +8,7 @@ Candid detects changes in this priority order:
 
 1. **Staged changes** (`git diff --cached`) - Files you've `git add`ed
 2. **Unstaged changes** (`git diff`) - Modified files not yet staged
-3. **Branch diff** (`git diff main...HEAD`) - All commits since branching from main/stable
+3. **Branch diff** - All commits since branching from the merge target (configurable via `mergeTargetBranches`, defaults to main/stable/master)
 
 The first non-empty result is reviewed. This means:
 - If you have staged changes, only those are reviewed
@@ -140,6 +140,36 @@ Focus can also be set in config:
 ```
 
 CLI flag overrides config.
+
+## Merge Target Configuration
+
+### Default Behavior
+By default, Candid compares your branch to the first available: `main`, `stable`, or `master`.
+
+### Custom Merge Targets
+
+**Git Flow (develop as integration branch):**
+```json
+{"mergeTargetBranches": ["develop", "main"]}
+```
+
+**Trunk-based development:**
+```json
+{"mergeTargetBranches": ["trunk"]}
+```
+
+**CI/CD with remote branches:**
+```json
+{"mergeTargetBranches": ["origin/main", "main"]}
+```
+
+### CLI Override
+```bash
+/candid-review --merge-target develop
+```
+
+### Branch Selection
+Candid tries each branch in order until one succeeds. The selected branch is shown in the output.
 
 ## Binary Files
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,8 +26,12 @@ Common issues and how to fix them.
    ```
 
 3. **Check your branch**
-   If you're on a feature branch with no local changes, Candid compares to main/stable:
+   If you're on a feature branch with no local changes, Candid compares to your configured merge target branches (default: main/stable/master):
    ```bash
+   # Check which branches exist
+   git branch -a
+
+   # Try your merge target
    git diff main...HEAD --stat
    ```
    If nothing shows, your branch has no new commits.
@@ -65,6 +69,29 @@ Common issues and how to fix them.
    ```
    ⚠️ Invalid config at .candid/config.json: malformed JSON. Falling back to user config.
    ```
+
+---
+
+## Wrong Merge Target Branch
+
+**Symptoms:** Review compares to the wrong branch, missing or including unexpected commits.
+
+**Diagnosis:**
+1. Check which branch was used (shown in review output)
+2. Verify config: `jq '.mergeTargetBranches' .candid/config.json`
+3. Check precedence: CLI flags > project config > user config > default
+
+**Solutions:**
+```bash
+# Override for this review
+/candid-review --merge-target develop
+
+# Set project default
+echo '{"mergeTargetBranches": ["develop"]}' > .candid/config.json
+
+# Check current setting
+jq '.mergeTargetBranches' .candid/config.json
+```
 
 ---
 

--- a/examples/git-flow/config.json
+++ b/examples/git-flow/config.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "tone": "constructive",
+  "mergeTargetBranches": ["develop", "main"]
+}

--- a/examples/github-flow/config.json
+++ b/examples/github-flow/config.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "tone": "constructive",
+  "mergeTargetBranches": ["main"]
+}

--- a/examples/trunk-based/config.json
+++ b/examples/trunk-based/config.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "tone": "harsh",
+  "mergeTargetBranches": ["trunk"]
+}

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -14,7 +14,8 @@ Valid config file format:
   "version": 1,
   "tone": "harsh" | "constructive",
   "exclude": ["*.generated.ts", "vendor/*"],
-  "focus": "security" | "performance" | "architecture"
+  "focus": "security" | "performance" | "architecture",
+  "mergeTargetBranches": ["main", "develop", "master"]
 }
 ```
 
@@ -27,6 +28,11 @@ Valid config file format:
   - `vendor/*` - Third-party code
   - `**/*.test.ts` - Test files (if you want to skip them)
 - `focus` (optional): Default focus area for reviews. Must be exactly `"security"`, `"performance"`, or `"architecture"`. CLI `--focus` flag overrides this. When set, only relevant issue categories are checked.
+- `mergeTargetBranches` (optional): Array of branch names for comparing branch diffs. Candid tries each in order, using the first that exists. Defaults to `["main", "stable", "master"]`. Common patterns:
+  - `["main"]` - GitHub Flow
+  - `["develop", "main"]` - Git Flow
+  - `["trunk"]` - Trunk-based development
+  - `["origin/main", "main"]` - CI environments
 
 ## Validation Rules
 
@@ -34,8 +40,9 @@ Valid config file format:
 2. **Tone field type** - If `tone` field is present, must be a string (not boolean, number, array, or object)
 3. **Tone field validation** - If `tone` is a string, value must be exactly `"harsh"` or `"constructive"` (case-sensitive)
 4. **Focus field validation** - If `focus` field is present, must be exactly `"security"`, `"performance"`, or `"architecture"` (case-sensitive). Invalid values show warning and are ignored.
-5. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, and `focus` are ignored for forward compatibility
-6. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
+5. **mergeTargetBranches field validation** - If present, must be an array of non-empty strings. Empty arrays or invalid values show warning and are ignored.
+6. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, and `mergeTargetBranches` are ignored for forward compatibility
+7. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
 
 ## Config Validation Procedure
 

--- a/skills/candid-review/SKILL.md
+++ b/skills/candid-review/SKILL.md
@@ -42,19 +42,64 @@ git diff --cached --stat
 # Then unstaged changes
 git diff --stat
 
-# If on a branch, compare to main/stable
-git diff main...HEAD --stat 2>/dev/null || git diff stable...HEAD --stat 2>/dev/null || git diff master...HEAD --stat 2>/dev/null
+# If on a branch, compare to configured merge target branches (from Step 2.5)
+# Build fallback chain dynamically from mergeTargetBranches
+# For each branch: git diff <branch>...HEAD --stat 2>/dev/null
+# Example for ["develop", "main"]: git diff develop...HEAD --stat 2>/dev/null || git diff main...HEAD --stat 2>/dev/null
 ```
 
 **3. Decide what to review:**
 - If staged changes exist → review with `git diff --cached`
 - Else if unstaged changes exist → review with `git diff`
-- Else if branch differs from main → review with `git diff main...HEAD`
+- Else if branch differs from merge target → review with `git diff <branch>...HEAD` (using first successful branch from mergeTargetBranches)
 - Else → inform user: "No changes detected to review"
 
 **4. Handle special cases:**
 - Skip binary files (note them but don't review content)
 - For diffs over 500 lines, consider reviewing in batches or asking user which files to prioritize
+
+### Step 2.5: Load Merge Target Branches
+
+Determine which branches to compare against, following config precedence.
+
+**Precedence (highest to lowest):**
+1. CLI flags (`--merge-target <branch>`, repeatable)
+2. Project config (`.candid/config.json` → `mergeTargetBranches`)
+3. User config (`~/.candid/config.json` → `mergeTargetBranches`)
+4. Default (`["main", "stable", "master"]`)
+
+#### Check CLI Arguments
+If `--merge-target` flags provided:
+- Build array from args (e.g., `--merge-target develop --merge-target main` → `["develop", "main"]`)
+- Output: `Using merge target branches: [list] (from CLI flags)`
+- Skip to Step 3
+
+#### Check Project Config
+Read `.candid/config.json`:
+1. Check file existence → if missing, continue to user config
+2. Validate JSON (use `jq empty`) → if invalid, warn and continue
+3. Extract field: `jq -r '.mergeTargetBranches // null'`
+4. Validate:
+   - If null → continue to user config
+   - If not array → warn and continue
+   - If empty array → warn and continue
+   - If contains non-strings → warn and continue
+5. Success: Output `Using merge target branches: [list] (from project config)`, skip to Step 3
+
+#### Check User Config
+Same procedure as project config, using `~/.candid/config.json`.
+Success: Output `Using merge target branches: [list] (from user config)`, skip to Step 3
+
+#### Use Default
+Set to `["main", "stable", "master"]` (silent, no output)
+
+#### Runtime Branch Selection (used in Step 2)
+When executing the git diff command:
+1. For each branch in `mergeTargetBranches`:
+   - Try `git diff <branch>...HEAD --stat 2>/dev/null`
+   - If successful (exit 0, non-empty), use this result
+   - Track which branch succeeded for messaging
+2. If all fail: Output `Could not find merge target branch. Tried: [list]`
 
 ### Step 3: Parse Review Options
 

--- a/tests/config-validation/TESTING-GUIDE.md
+++ b/tests/config-validation/TESTING-GUIDE.md
@@ -96,6 +96,30 @@ Run `/candid-review` in each scenario and verify behavior:
     - Expected: Treated as invalid JSON
     - Verify: Warning shown, fallback occurs
 
+### Merge Target Branch Tests
+
+16. **Valid single merge target**
+    - Config: `valid-merge-target-single.json`
+    - Expected: Uses `["develop"]`
+    - Verify: Shows "Using merge target branches: ["develop"] (from project config)"
+
+17. **Valid multiple merge targets**
+    - Config: `valid-merge-target-multiple.json`
+    - Expected: Tries in order, uses first available
+
+18. **Invalid empty array**
+    - Config: `invalid-merge-target-empty.json`
+    - Expected: Warning shown, uses default `["main", "stable", "master"]`
+
+19. **Invalid type (string not array)**
+    - Config: `invalid-merge-target-string.json`
+    - Expected: Warning shown, falls back to default
+
+20. **CLI override test**
+    - Config with `["main"]`, run with `--merge-target develop`
+    - Expected: Uses `["develop"]` from CLI
+    - Verify: Shows "(from CLI flags)"
+
 ## Quick Test Commands
 
 ```bash

--- a/tests/config-validation/invalid-merge-target-empty.json
+++ b/tests/config-validation/invalid-merge-target-empty.json
@@ -1,0 +1,1 @@
+{"mergeTargetBranches": []}

--- a/tests/config-validation/invalid-merge-target-string.json
+++ b/tests/config-validation/invalid-merge-target-string.json
@@ -1,0 +1,1 @@
+{"mergeTargetBranches": "develop"}

--- a/tests/config-validation/valid-merge-target-multiple.json
+++ b/tests/config-validation/valid-merge-target-multiple.json
@@ -1,0 +1,1 @@
+{"mergeTargetBranches": ["develop", "main", "master"]}

--- a/tests/config-validation/valid-merge-target-single.json
+++ b/tests/config-validation/valid-merge-target-single.json
@@ -1,0 +1,1 @@
+{"mergeTargetBranches": ["develop"]}

--- a/tests/config-validation/valid-merge-target-with-remote.json
+++ b/tests/config-validation/valid-merge-target-with-remote.json
@@ -1,0 +1,1 @@
+{"mergeTargetBranches": ["origin/main", "main"]}


### PR DESCRIPTION
## Summary
Adds configurable merge target branches to replace the hardcoded `main → stable → master` fallback chain. Users can now specify merge targets via config files or CLI flags to support different branching strategies (Git Flow, trunk-based, GitHub Flow).

## Changes
- New `mergeTargetBranches` config field with validation rules
- Step 2.5 implementation for loading merge target branches with precedence logic (CLI → project → user → default)
- CLI flag support (`--merge-target <branch>`, repeatable)
- Workflow-specific example configs (git-flow, trunk-based, github-flow)
- Comprehensive documentation updates and 5 test case files
- Version 1.2.0 changelog entry

## Testing
Run `/candid-review` on a Git Flow project and verify it compares to the `develop` branch when configured. Invalid configs show warnings and fall back gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)