### PR TITLE
Fix: create changelog directory if it doesn't exist

### DIFF
--- a/docs/scripts/copy-changelog.js
+++ b/docs/scripts/copy-changelog.js
@@ -7,6 +7,9 @@ const dest = path.join(__dirname, '..', 'app', 'docs', 'resources', 'changelog',
 // Read the source changelog
 const content = fs.readFileSync(source, 'utf-8')
 
+// Create the destination directory if it doesn't exist
+fs.mkdirSync(path.dirname(dest), { recursive: true })
+
 // Write to the destination
 fs.writeFileSync(dest, content)
 


### PR DESCRIPTION
The build script was failing because it tried to write to a directory that hadn't been created yet. This change adds recursive directory creation to ensure the script works in fresh clones and after directory removal.