### PR TITLE
Update homepage hero to display v1.4

### DIFF
--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -10,7 +10,7 @@ export default function HomePage() {
       <section className="hero">
         <div className="version-badge">
           <span className="version-dot"></span>
-          v1.3 Now Available for Claude Code
+          v1.4 Now Available for Claude Code
         </div>
         <h1>Code Review for the AI Era</h1>
         <p className="hero-subtitle">


### PR DESCRIPTION
Update the version badge on the homepage to reflect the newly released v1.4.0. The hero section now displays the correct version number.