### PR TITLE
Add mobile hamburger menu to homepage header

### DIFF
--- a/docs/app/(marketing)/layout.jsx
+++ b/docs/app/(marketing)/layout.jsx
@@ -1,11 +1,42 @@
 'use client'
 
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { trackEvent, EVENTS } from '../components/trackEvent'
 import Logo from '../components/Logo'
 import GitHubStars from '../components/GitHubStars'
 
 export default function MarketingLayout({ children }) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const toggleMenu = () => setIsMenuOpen(!isMenuOpen)
+  const closeMenu = () => setIsMenuOpen(false)
+
+  // Prevent body scroll when menu is open
+  useEffect(() => {
+    if (isMenuOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [isMenuOpen])
+
+  // Close menu on window resize to desktop
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth > 768 && isMenuOpen) {
+        setIsMenuOpen(false)
+      }
+    }
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [isMenuOpen])
+
   return (
     <div className="marketing-layout">
       <header className="marketing-header">
@@ -13,18 +44,52 @@ export default function MarketingLayout({ children }) {
           <Link href="/">
             <Logo />
           </Link>
-          <div className="marketing-nav-links">
-            <Link href="/docs">Documentation</Link>
+
+          <button
+            className="hamburger-button"
+            onClick={toggleMenu}
+            aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+            aria-expanded={isMenuOpen}
+          >
+            <svg className="hamburger-icon" viewBox="0 0 24 24" fill="none">
+              {isMenuOpen ? (
+                <>
+                  <line x1="18" y1="6" x2="6" y2="18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <line x1="6" y1="6" x2="18" y2="18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </>
+              ) : (
+                <>
+                  <line x1="3" y1="6" x2="21" y2="6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <line x1="3" y1="12" x2="21" y2="12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <line x1="3" y1="18" x2="21" y2="18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </>
+              )}
+            </svg>
+          </button>
+
+          <div className={`marketing-nav-links ${isMenuOpen ? 'mobile-menu-open' : ''}`}>
+            <Link href="/docs" onClick={closeMenu}>Documentation</Link>
             <GitHubStars />
             <a
               href="https://join.slack.com/t/candid-knc4230/shared_invite/zt-3norwiria-gvg9iQ0Dkg8x43diCcKLrw"
               target="_blank"
               rel="noopener noreferrer"
-              onClick={() => trackEvent(EVENTS.SLACK_CLICK)}
+              onClick={() => {
+                trackEvent(EVENTS.SLACK_CLICK)
+                closeMenu()
+              }}
             >
               Slack
             </a>
           </div>
+
+          {isMenuOpen && (
+            <div
+              className="mobile-menu-backdrop"
+              onClick={closeMenu}
+              aria-hidden="true"
+            />
+          )}
         </nav>
       </header>
       <main className="marketing-main">

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -149,6 +149,92 @@ header a:has(.logo):hover {
   color: var(--text-primary);
 }
 
+/* ===== Mobile Menu ===== */
+
+/* Hamburger button - hidden by default, shown on mobile */
+.hamburger-button {
+  display: none;
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: color 0.15s ease;
+  z-index: 1001;
+}
+
+.hamburger-button:hover {
+  color: var(--text-primary);
+}
+
+.hamburger-icon {
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+/* Mobile menu backdrop */
+.mobile-menu-backdrop {
+  display: none;
+}
+
+/* Mobile-specific styles */
+@media (max-width: 768px) {
+  .hamburger-button {
+    display: block;
+  }
+
+  .mobile-menu-backdrop {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+    animation: fadeIn 0.3s ease;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .marketing-nav-links {
+    position: fixed;
+    top: 0;
+    right: -100%;
+    height: 100vh;
+    width: 280px;
+    max-width: 80vw;
+    background: var(--bg-light);
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+    padding: 5rem 2rem 2rem;
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+    transition: right 0.3s ease;
+    z-index: 1000;
+    overflow-y: auto;
+  }
+
+  .marketing-nav-links.mobile-menu-open {
+    right: 0;
+  }
+
+  .marketing-nav-links a {
+    width: 100%;
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--border-light);
+    font-size: 1.1rem;
+  }
+
+  .marketing-nav-links a:last-child {
+    border-bottom: none;
+  }
+}
+
 .marketing-main {
   flex: 1;
   max-width: 1200px;
@@ -706,6 +792,30 @@ html.dark .marketing-nav-links a {
 
 html.dark .marketing-nav-links a:hover {
   color: var(--text-primary-dark);
+}
+
+/* Dark mode mobile menu */
+html.dark .hamburger-button {
+  color: var(--text-secondary-dark);
+}
+
+html.dark .hamburger-button:hover {
+  color: var(--text-primary-dark);
+}
+
+html.dark .mobile-menu-backdrop {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+@media (max-width: 768px) {
+  html.dark .marketing-nav-links {
+    background: var(--bg-dark);
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.5);
+  }
+
+  html.dark .marketing-nav-links a {
+    border-color: var(--border-dark);
+  }
 }
 
 html.dark .marketing-footer {


### PR DESCRIPTION
Fixes the squished navigation on mobile by implementing a functional hamburger menu that slides in from the right. The menu includes a semi-transparent backdrop overlay, auto-closes on link clicks or window resize, and features full dark mode support. Body scroll is locked when the menu is open to prevent background scrolling. All navigation functionality is preserved with proper event tracking.