### PR TITLE
Add autoCommit config option to default auto-commit behavior

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, and seamless todo integration.",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, and seamless todo integration.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-01-18
+
+### Added
+
+- **Auto-commit config option** (#12): `autoCommit` field in config files allows defaulting auto-commit behavior
+  - Set `"autoCommit": true` in `.candid/config.json` or `~/.candid/config.json` to enable auto-commit by default
+  - CLI flag `--auto-commit` still overrides config files
+  - Defaults to `false` for backward compatibility
+  - Follows same precedence rules as other config options: CLI flag → project config → user config → default
+
 ## [1.4.1] - 2026-01-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -100,16 +100,26 @@ Review state is automatically saved to `.candid/last-review.json` after each rev
 
 ### Commit Applied Fixes Automatically
 
+**Via CLI flag:**
 ```
 /candid-review --auto-commit
 ```
 
-Automatically create a git commit after successfully applying fixes.
+**Via config file:**
+```json
+{
+  "autoCommit": true
+}
+```
+
+Automatically creates a git commit after successfully applying fixes.
 
 - Only commits files modified by candid-review (not other unstaged changes)
 - Commit message includes detailed list of all fixes with file locations
 - Includes co-author tag
 - Commit failures preserve applied fixes
+
+The CLI flag always overrides config files.
 
 Example combining with other flags:
 ```
@@ -149,10 +159,13 @@ This means you can set a user-wide default and override it per-project, while CL
 ### Config Format
 
 ```json
-{"tone": "harsh"}
+{
+  "tone": "harsh",
+  "autoCommit": true
+}
 ```
 
-All fields are optional. See [CONFIG.md](skills/candid-review/CONFIG.md) for the full schema specification including `exclude` patterns and `focus` areas.
+All fields are optional. See [CONFIG.md](skills/candid-review/CONFIG.md) for the full schema specification including `exclude` patterns, `focus` areas, and `autoCommit` behavior.
 
 ### Example Setup
 

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -10,7 +10,7 @@ export default function HomePage() {
       <section className="hero">
         <div className="version-badge">
           <span className="version-dot"></span>
-          v1.4.1 Now Available for Claude Code
+          v1.4.2 Now Available for Claude Code
         </div>
         <h1>Code Review for the AI Era</h1>
         <p className="hero-subtitle">

--- a/docs/app/docs/core-features/auto-commit/page.mdx
+++ b/docs/app/docs/core-features/auto-commit/page.mdx
@@ -10,7 +10,35 @@ Automatically commit applied fixes.
 
 After you select fixes to apply, Candid creates a commit with a detailed message.
 
-> **Note:** Auto-commit is disabled by default. You must explicitly pass `--auto-commit` to enable it.
+> **Note:** Auto-commit is disabled by default. You can enable it via CLI flag (`--auto-commit`) or config file (`autoCommit: true`).
+
+## Configuration
+
+### Via CLI Flag
+
+```
+/candid-review --auto-commit
+```
+
+### Via Config File
+
+Set `autoCommit` in your config file to enable by default:
+
+**Project config** (`.candid/config.json`):
+```json
+{
+  "autoCommit": true
+}
+```
+
+**User config** (`~/.candid/config.json`):
+```json
+{
+  "autoCommit": true
+}
+```
+
+The CLI flag always overrides config files.
 
 ## Commit Message Format
 

--- a/examples/harsh/config.json
+++ b/examples/harsh/config.json
@@ -1,4 +1,5 @@
 {
   "version": 1,
-  "tone": "harsh"
+  "tone": "harsh",
+  "autoCommit": true
 }

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -34,7 +34,7 @@ Valid config file format:
   - `["develop", "main"]` - Git Flow
   - `["trunk"]` - Trunk-based development
   - `["origin/main", "main"]` - CI environments
-- `autoCommit` (optional): Default auto-commit behavior. If `true`, automatically creates git commits after applying fixes (equivalent to always using `--commit` flag). If `false` or omitted, commits only when `--commit` flag is provided. Defaults to `false`.
+- `autoCommit` (optional): Default auto-commit behavior. If `true`, automatically creates git commits after applying fixes (equivalent to always using `--auto-commit` flag). If `false` or omitted, commits only when `--auto-commit` flag is provided. Defaults to `false`.
 
 ## Validation Rules
 

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -15,7 +15,8 @@ Valid config file format:
   "tone": "harsh" | "constructive",
   "exclude": ["*.generated.ts", "vendor/*"],
   "focus": "security" | "performance" | "architecture",
-  "mergeTargetBranches": ["main", "develop", "master"]
+  "mergeTargetBranches": ["main", "develop", "master"],
+  "autoCommit": true | false
 }
 ```
 
@@ -33,6 +34,7 @@ Valid config file format:
   - `["develop", "main"]` - Git Flow
   - `["trunk"]` - Trunk-based development
   - `["origin/main", "main"]` - CI environments
+- `autoCommit` (optional): Default auto-commit behavior. If `true`, automatically creates git commits after applying fixes (equivalent to always using `--commit` flag). If `false` or omitted, commits only when `--commit` flag is provided. Defaults to `false`.
 
 ## Validation Rules
 
@@ -41,8 +43,9 @@ Valid config file format:
 3. **Tone field validation** - If `tone` is a string, value must be exactly `"harsh"` or `"constructive"` (case-sensitive)
 4. **Focus field validation** - If `focus` field is present, must be exactly `"security"`, `"performance"`, `"architecture"`, or `"edge-case"` (case-sensitive). Invalid values show warning and are ignored.
 5. **mergeTargetBranches field validation** - If present, must be an array of non-empty strings. Empty arrays or invalid values show warning and are ignored.
-6. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, and `mergeTargetBranches` are ignored for forward compatibility
-7. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
+6. **AutoCommit field validation** - If `autoCommit` field is present, must be a boolean (`true` or `false`). Invalid values show warning and are ignored.
+7. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, and `autoCommit` are ignored for forward compatibility
+8. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
 
 ## Config Validation Procedure
 
@@ -203,7 +206,8 @@ Using constructive tone (from interactive prompt)
   "version": 1,
   "tone": "harsh",
   "exclude": ["*.generated.ts", "vendor/*"],
-  "focus": "performance"
+  "focus": "performance",
+  "autoCommit": true
 }
 ```
 

--- a/skills/candid-review/SKILL.md
+++ b/skills/candid-review/SKILL.md
@@ -201,7 +201,7 @@ If `--auto-commit` flag is provided, automatically create git commit after succe
 
 **Output when enabled:** `Commit enabled: will create git commit after applying fixes (from CLI flag)`
 
-### Step 4: Load Tone Preference
+### Step 4: Load Tone Preference and Commit Mode
 
 #### Check for --auto-commit flag
 
@@ -210,9 +210,41 @@ Parse CLI arguments to determine if automatic commit is requested.
 If `--auto-commit` flag is provided:
 - Set `commitEnabled = true`
 - Output: `Commit enabled: will create git commit after applying fixes (from CLI flag)`
-- Note: Commit will only be created if fixes are successfully applied
+- Skip to tone preference loading
 
-If `--auto-commit` flag is NOT provided:
+If `--auto-commit` flag is NOT provided, check config files:
+
+#### Check Project Config for Commit
+
+Read `.candid/config.json`:
+1. Check file existence → if missing, continue to user config
+2. Validate JSON (use `jq empty .candid/config.json 2>&1`) → if invalid, skip to user config
+3. Extract field: `jq -r '.autoCommit // null' .candid/config.json`
+4. Validate:
+   - If null or missing → continue to user config
+   - If not boolean → warn "⚠️  Invalid config at .candid/config.json: invalid type for autoCommit field (must be boolean). Falling back to user config." and continue to user config
+5. Success:
+   - Set `commitEnabled` to config value (true or false)
+   - If true: Output `Commit enabled: will create git commit after applying fixes (from project config)`
+   - Continue to tone preference loading
+
+#### Check User Config for Commit
+
+Read `~/.candid/config.json`:
+1. Check file existence → if missing, continue to default
+2. Validate JSON (use `jq empty ~/.candid/config.json 2>&1`) → if invalid, use default
+3. Extract field: `jq -r '.autoCommit // null' ~/.candid/config.json`
+4. Validate:
+   - If null or missing → use default
+   - If not boolean → warn "⚠️  Invalid config at ~/.candid/config.json: invalid type for autoCommit field (must be boolean). Using default." and use default
+5. Success:
+   - Set `commitEnabled` to config value (true or false)
+   - If true: Output `Commit enabled: will create git commit after applying fixes (from user config)`
+   - Continue to tone preference loading
+
+#### Default Commit Behavior
+
+If no CLI flag and no config specifies commit:
 - Set `commitEnabled = false`
 - (No output - default behavior)
 
@@ -625,7 +657,7 @@ After creating todos, confirm to user how many were added and remind them they c
 ### Step 9.5: Create Git Commit (Optional)
 
 **Pre-condition:** Only execute this step if ALL of the following are true:
-1. `commitEnabled = true` (--auto-commit flag was provided in Step 4)
+1. `commitEnabled = true` (--auto-commit flag was provided or config enabled in Step 4)
 2. `selectedFixes` is not empty (fixes were applied in Step 9)
 3. Git repository is available (detected in Step 2)
 

--- a/tests/config-validation/TESTING-GUIDE.md
+++ b/tests/config-validation/TESTING-GUIDE.md
@@ -120,6 +120,34 @@ Run `/candid-review` in each scenario and verify behavior:
     - Expected: Uses `["develop"]` from CLI
     - Verify: Shows "(from CLI flags)"
 
+### Commit Config Tests
+
+21. **Valid autoCommit true**
+    - Config: `{"autoCommit": true}`
+    - Expected: Auto-commit enabled
+    - Verify: Shows "Commit enabled: will create git commit after applying fixes (from project config)"
+
+22. **Valid autoCommit false**
+    - Config: `{"autoCommit": false}`
+    - Expected: Auto-commit disabled (explicit)
+    - Verify: No commit message shown, no auto-commit occurs
+
+23. **Invalid autoCommit type (string)**
+    - Config: `{"autoCommit": "yes"}`
+    - Expected: Warning shown, falls back to next source
+    - Verify: Shows "⚠️  Invalid config: invalid type for autoCommit field (must be boolean)"
+
+24. **CLI override of config**
+    - Config: `{"autoCommit": false}`, run with `--commit`
+    - Expected: Uses CLI flag (auto-commit enabled)
+    - Verify: Shows "Commit enabled: will create git commit after applying fixes (from CLI flag)"
+
+25. **Project overrides user**
+    - User config: `{"autoCommit": true}`
+    - Project config: `{"autoCommit": false}`
+    - Expected: Uses project config (no auto-commit)
+    - Verify: No commit occurs
+
 ## Quick Test Commands
 
 ```bash

--- a/tests/config-validation/TESTING-GUIDE.md
+++ b/tests/config-validation/TESTING-GUIDE.md
@@ -138,7 +138,7 @@ Run `/candid-review` in each scenario and verify behavior:
     - Verify: Shows "⚠️  Invalid config: invalid type for autoCommit field (must be boolean)"
 
 24. **CLI override of config**
-    - Config: `{"autoCommit": false}`, run with `--commit`
+    - Config: `{"autoCommit": false}`, run with `--auto-commit`
     - Expected: Uses CLI flag (auto-commit enabled)
     - Verify: Shows "Commit enabled: will create git commit after applying fixes (from CLI flag)"
 

--- a/tests/config-validation/invalid-autocommit-string.json
+++ b/tests/config-validation/invalid-autocommit-string.json
@@ -1,0 +1,3 @@
+{
+  "autoCommit": "yes"
+}

--- a/tests/config-validation/valid-autocommit-false.json
+++ b/tests/config-validation/valid-autocommit-false.json
@@ -1,0 +1,3 @@
+{
+  "autoCommit": false
+}

--- a/tests/config-validation/valid-autocommit-true.json
+++ b/tests/config-validation/valid-autocommit-true.json
@@ -1,0 +1,3 @@
+{
+  "autoCommit": true
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #12 by adding an `autoCommit` field to config files that allows users to default auto-commit behavior to enabled. This complements the existing `--auto-commit` CLI flag.

- Config precedence: CLI flag → project config → user config → default (false)
- Backward compatible: defaults to false to maintain existing behavior
- Version bump: 1.4.2 (patch release for new feature)
- Includes comprehensive tests, docs, and examples

🤖 Generated with Claude Code