### PR TITLE
Add Candid logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/logo.svg" alt="Candid Logo" width="250"/>
+</p>
+
 # Candid
 
 A Claude Code plugin for configurable code reviews that combine thoroughness with actionable feedback. Based on Kim Scott's Radical Candor framework: **Care Personally + Challenge Directly**.

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,20 @@
+<svg viewBox="0 0 150 32" width="150" height="32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Comment Bubble Icon -->
+  <path
+    d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z"
+    fill="white"
+    stroke="#d4a27f"
+    stroke-width="2.5"
+  />
+
+  <!-- "candid" Text -->
+  <text
+    x="38"
+    y="20"
+    font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+    font-size="18"
+    font-weight="600"
+    fill="#2c2c2c"
+    letter-spacing="0.5"
+  >candid</text>
+</svg>


### PR DESCRIPTION
Add a professional centered logo to the README featuring the comment bubble icon and "candid" text from the documentation site. The logo is stored in the `assets/` directory for clean project organization.

The logo displays at 250px width and is positioned at the top of the README for immediate visual impact while maintaining the existing content structure.