### PR TITLE
Improve logo with background and better proportions

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,20 +1,23 @@
-<svg viewBox="0 0 150 32" width="150" height="32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Comment Bubble Icon -->
-  <path
-    d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z"
-    fill="white"
-    stroke="#d4a27f"
-    stroke-width="2.5"
-  />
+<svg viewBox="-20 -12 190 56" width="380" height="112" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect x="-20" y="-12" width="190" height="56" rx="14" fill="#d4a27f"/>
+
+  <!-- Comment Bubble Icon (scaled 1.15x to match text proportions) -->
+  <g transform="scale(1.15)">
+    <path
+      d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z"
+      fill="white"
+    />
+  </g>
 
   <!-- "candid" Text -->
   <text
-    x="38"
-    y="20"
+    x="44"
+    y="21"
     font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
-    font-size="18"
+    font-size="24"
     font-weight="600"
     fill="#2c2c2c"
-    letter-spacing="0.5"
+    letter-spacing="1"
   >candid</text>
 </svg>


### PR DESCRIPTION
## Summary
- Add tan background to logo for improved visibility on dark backgrounds
- Scale logo from 150x32px to 380x112px for better visibility
- Increase font size from 18px to 24px and scale icon to maintain visual balance
- Improve styling with 14px border radius and better spacing

## Design Changes
The logo now has a professional appearance with a tan background (#d4a27f) that provides excellent contrast on both light and dark themes. Text and icon proportions are properly balanced.

🤖 Generated with Claude Code