### PR TITLE
Update candid-init to generate config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **candid-init generates both Technical.md and config.json**: The init command now creates a complete project setup in the `.candid/` directory
+  - Technical.md moved from project root to `.candid/Technical.md`
+  - New `.candid/config.json` file generated with auto-detected settings
+  - Auto-detects configuration values:
+    - `tone`: defaults to "constructive" (safer for teams)
+    - `exclude`: parses .gitignore and adds framework-specific patterns
+    - `focus`: infers from project structure (auth/ → security, WebSocket → performance)
+    - `mergeTargetBranches`: detects from existing git branches (stable, main, master, develop, trunk)
+    - `autoCommit`: defaults to false
+  - Interactive confirmation flow: "Accept all", "Customize settings", or "Skip config generation"
+  - Both files created in `.candid/` directory with proper error handling
+  - 9-step workflow (expanded from 7 steps) with enhanced project analysis
+  - Prompts for overwrite if existing files found
+
 ## [1.4.2] - 2026-01-18
 
 ### Added

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: candid-init
-description: Generate a Technical.md file by analyzing your codebase structure, detecting frameworks, and creating appropriate standards
+description: Generate Technical.md and config.json by analyzing your codebase structure, detecting frameworks, and creating appropriate standards and configuration
 ---
 
-# Technical.md Generator
+# Technical.md and Config Generator
 
-You are a technical standards architect. Your job is to analyze a codebase and generate an appropriate Technical.md file that will be used by candid-review to enforce project standards.
+You are a technical standards architect. Your job is to analyze a codebase and generate both a Technical.md file (coding standards) and a .candid/config.json file (project configuration) that will be used by candid-review to enforce project standards.
 
 ## Workflow
 
@@ -14,11 +14,11 @@ You are a technical standards architect. Your job is to analyze a codebase and g
 Before any analysis, check if Technical.md already exists to get user consent early:
 
 ```bash
-ls ./Technical.md ./.claude/Technical.md 2>/dev/null
+ls .candid/Technical.md 2>/dev/null
 ```
 
 **If file exists:**
-- **Question:** "Technical.md already exists. What would you like to do?"
+- **Question:** "Technical.md already exists at .candid/Technical.md. What would you like to do?"
 - **Options:**
   1. "Overwrite existing file" → Continue to Step 2
   2. "Create as Technical.md.new for comparison" → Continue to Step 2, set output to `.new`
@@ -26,18 +26,35 @@ ls ./Technical.md ./.claude/Technical.md 2>/dev/null
 
 **If no file exists:** Continue to Step 2.
 
-### Step 2: Determine Target Framework
+### Step 2: Check for Existing config.json
+
+Check if .candid/config.json already exists:
+
+```bash
+ls .candid/config.json 2>/dev/null
+```
+
+**If file exists:**
+- **Question:** ".candid/config.json already exists. What would you like to do?"
+- **Options:**
+  1. "Overwrite config.json" → Continue to Step 3, regenerate config in Step 8
+  2. "Keep existing config.json" → Continue to Step 3, skip config generation in Step 8
+  3. "Cancel" → Stop workflow, inform user no changes made
+
+**If no file exists:** Continue to Step 3, will generate config in Step 8.
+
+### Step 3: Determine Target Framework
 
 Check if a framework was specified via CLI argument:
 - `react` → Use React/frontend template as base
 - `node` → Use Node.js/backend template as base
 - `python` → Generate Python-specific standards
 - `minimal` → Use minimal template (framework-agnostic)
-- No argument → Auto-detect (Step 3)
+- No argument → Auto-detect (Step 4)
 
-If framework specified, skip to Step 4 with that framework.
+If framework specified, skip to Step 5 with that framework.
 
-### Step 3: Auto-Detect Framework (if not specified)
+### Step 4: Auto-Detect Framework (if not specified)
 
 Analyze the codebase to determine the primary framework:
 
@@ -68,7 +85,7 @@ ls Cargo.toml 2>/dev/null
 
 Output: `Detected framework: [framework]`
 
-### Step 4: Check for Existing Standards
+### Step 5: Check for Existing Standards
 
 Look for existing configuration that indicates project standards:
 
@@ -87,9 +104,9 @@ If linter configs exist, note them. The generated Technical.md should NOT duplic
 
 Output: `Found existing configs: [list]`
 
-### Step 5: Analyze Project Structure
+### Step 6: Analyze Project Structure and Gather Config Data
 
-Understand the codebase organization:
+Understand the codebase organization AND gather data for config.json auto-detection:
 
 ```bash
 # Get directory structure (top 2 levels)
@@ -99,6 +116,19 @@ find . -type d -maxdepth 2 | grep -v node_modules | grep -v .git | grep -v __pyc
 find . -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" | wc -l
 find . -name "*.py" | wc -l
 find . -name "*.go" | wc -l
+
+# Gather data for config.json auto-detection
+# 1. Check for .gitignore to detect exclude patterns
+cat .gitignore 2>/dev/null | head -50
+
+# 2. Detect git branches for mergeTargetBranches
+git branch -a --format='%(refname:short)' 2>/dev/null | head -20
+
+# 3. Check for security-sensitive directories (for focus detection)
+find . -type d -name "auth" -o -name "middleware" -o -name "security" 2>/dev/null | head -10
+
+# 4. Check for performance-critical indicators
+find . -type f -name "*websocket*" -o -name "*sse*" 2>/dev/null | head -10
 ```
 
 Note patterns:
@@ -106,8 +136,13 @@ Note patterns:
 - Are there API routes or controllers?
 - Is there a database layer?
 - Are there tests?
+- **For config.json:**
+  - What patterns are in .gitignore?
+  - Which git branches exist (main, master, develop, trunk, stable)?
+  - Are there auth/, middleware/, or API directories? (suggests security focus)
+  - Are there WebSocket or performance-critical files? (suggests performance focus)
 
-### Step 6: Generate Technical.md
+### Step 7: Generate Technical.md
 
 Based on gathered information, generate a Technical.md file.
 
@@ -167,29 +202,191 @@ Based on gathered information, generate a Technical.md file.
 | Python | Type Hints, Error Handling, Testing, Documentation |
 | Minimal | Security, Error Handling, Code Quality, Testing, Git |
 
-### Step 7: Write the File
+### Step 8: Generate and Confirm config.json
+
+**Skip this step if:** User chose "Keep existing config.json" in Step 2.
+
+#### 8.1: Auto-Detect Config Values
+
+Based on data gathered in Step 6, detect configuration values:
+
+**tone (Review style):**
+- Default: `"constructive"` (safer for teams)
+- If existing Technical.md has many strict rules → suggest `"harsh"`
+
+**exclude (File patterns):**
+- Parse .gitignore from Step 6
+- Add framework-specific patterns:
+  - **React/Node:** `node_modules/*`, `dist/*`, `build/*`, `coverage/*`, `*.min.js`, `*.generated.ts`
+  - **Python:** `__pycache__/*`, `*.pyc`, `.pytest_cache/*`, `venv/*`, `.venv/*`
+  - **All:** `.git/*`, `.DS_Store`
+- Remove duplicates, validate glob syntax
+- Example result: `["node_modules/*", "dist/*", "*.min.js"]`
+
+**focus (Default review focus):**
+- If auth/, middleware/, or API routes found → `"security"`
+- If WebSocket, SSE, or perf-critical files found → `"performance"`
+- If microservices or complex layers found → `"architecture"`
+- Otherwise → omit field (no default focus)
+
+**mergeTargetBranches (Git branches):**
+- From git branch output in Step 6, detect existing branches
+- Priority order: stable, main, master, develop, trunk
+- GitHub Flow example: `["main"]`
+- Git Flow example: `["develop", "main"]`
+- This repo example: `["stable", "main"]`
+- If not a git repo → `["main", "stable", "master"]`
+
+**autoCommit (Auto-commit behavior):**
+- Default: `false` (safer, more conservative)
+
+#### 8.2: Present Summary and Get Confirmation
+
+Show detected values to user:
+
+```
+Config Generation Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━
+
+📋 Review Style (tone): constructive
+📁 File Exclusions (exclude): 8 patterns detected
+   - node_modules/*
+   - dist/*
+   - coverage/*
+   - *.min.js
+   - *.generated.ts
+   - __pycache__/*
+   - .DS_Store
+   - .git/*
+🎯 Focus Area (focus): security (detected auth/ directory)
+🌿 Merge Target Branches: ["stable", "main"]
+✅ Auto-Commit (autoCommit): false (default)
+```
+
+**Question:** "Accept these config defaults?"
+**Options:**
+1. "Accept all" → Proceed to Step 9 with these values
+2. "Customize settings" → Enter interactive mode (see 8.3)
+3. "Skip config generation" → Proceed to Step 9 without config.json
+
+#### 8.3: Interactive Customization (if requested)
+
+For each field user wants to customize:
+
+**tone:**
+- Show: Current = "constructive"
+- Options: "Keep constructive" | "Change to harsh"
+
+**exclude:**
+- Show: Current patterns list
+- Options: "Keep detected patterns" | "Add more patterns" | "Remove some patterns"
+
+**focus:**
+- Show: Current value or "none"
+- Options: "Keep [current]" | "Change to security" | "Change to performance" | "Change to architecture" | "Change to edge-case" | "No default focus"
+
+**mergeTargetBranches:**
+- Show: Current branches
+- Options: "Keep detected branches" | "Add more branches" | "Change order"
+
+**autoCommit:**
+- Show: Current = false
+- Options: "Keep false" | "Change to true"
+
+### Step 9: Write Both Files
+
+#### 9.1: Create .candid/ Directory
+
+Ensure the .candid/ directory exists:
+
+```bash
+mkdir -p .candid
+```
+
+If directory creation fails (permissions, read-only filesystem):
+- Show error: "⚠️ Cannot create .candid/ directory: [reason]"
+- Ask user what to do: "Continue without config.json?" | "Cancel"
+
+#### 9.2: Write Technical.md
 
 Determine output path from:
 1. CLI `--output` flag if provided
-2. User choice from Step 1 (if `.new` was selected)
-3. Default: `./Technical.md`
+2. User choice from Step 1 (if `.new` was selected): `.candid/Technical.md.new`
+3. Default: `.candid/Technical.md`
 
 Use the Write tool to create the Technical.md file at the determined path.
 
-After writing, output:
+#### 9.3: Write config.json
+
+**Skip if:** User chose "Skip config generation" in Step 8 or Step 2.
+
+Generate JSON using jq for proper formatting:
+
+```bash
+jq -n \
+  --arg tone "constructive" \
+  --argjson exclude '["node_modules/*","dist/*","*.min.js"]' \
+  --arg focus "security" \
+  --argjson branches '["stable","main"]' \
+  --argjson autoCommit false \
+  '{tone: $tone, exclude: $exclude, focus: $focus, mergeTargetBranches: $branches, autoCommit: $autoCommit}'
 ```
-✅ Created Technical.md with [N] rules across [M] categories.
 
-Categories:
-- [Category 1] ([X] rules)
-- [Category 2] ([Y] rules)
-...
+Note: Omit the `focus` field entirely if no focus was detected/selected.
 
-Next steps:
-1. Review the generated standards
-2. Remove any rules that don't apply to your project
-3. Add any project-specific rules
-4. Run /candid-review to see it in action
+Use the Write tool to create `.candid/config.json` with the generated JSON.
+
+If write fails:
+- Preserve Technical.md (already written)
+- Show error and manual creation instructions
+- Provide JSON template for user to copy
+
+#### 9.4: Show Success Summary
+
+After writing both files, output:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+✅ Candid Initialization Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+📄 Technical.md
+   Location: .candid/Technical.md
+   Framework: [detected framework]
+   Rules: [N] across [M] categories
+
+   Categories:
+   - [Category 1] ([X] rules)
+   - [Category 2] ([Y] rules)
+   ...
+
+⚙️  Configuration
+   Location: .candid/config.json
+   Settings:
+   - tone: [value]
+   - exclude: [N] patterns
+   - focus: [value or "none"]
+   - mergeTargetBranches: [branches]
+   - autoCommit: [value]
+
+📝 Recommendations
+   1. Review .candid/Technical.md and customize for your project
+   2. Add .candid/last-review.json to .gitignore
+   3. Keep .candid/config.json tracked in git (project-wide setting)
+
+🚀 Next Steps
+   Run /candid-review to test your new standards
+```
+
+If config.json was skipped:
+
+```
+✅ Created .candid/Technical.md with [N] rules across [M] categories.
+
+📝 Note: Config.json generation was skipped. You can manually create .candid/config.json later.
+
+🚀 Next Steps
+   Run /candid-review to test your new standards
 ```
 
 ## Templates Reference


### PR DESCRIPTION
## Summary

The candid-init command now generates both Technical.md and config.json in the .candid/ directory. It auto-detects configuration values for tone, exclude patterns, focus area, merge target branches, and auto-commit behavior with user confirmation.

## Changes

- Technical.md path changed from project root to `.candid/Technical.md`
- New `.candid/config.json` auto-generation with 5 configuration fields
- 9-step workflow (expanded from 7) with enhanced project analysis
- Interactive confirmation flow for customizing auto-detected settings
- Proper error handling for directory creation and file write failures

## Testing

Users can run `/candid-init` on any project to generate both files with intelligent defaults based on project analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)