### PR TITLE
Update install command to npx skills add

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ The review process follows these steps:
 ## Installation
 
 ```bash
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 Then restart Claude Code.

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -181,8 +181,7 @@ export default function HomePage() {
             transition: 'opacity 600ms ease-out 400ms, transform 600ms ease-out 400ms'
           }}
         >
-          <code>{`claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid`}</code>
+          <code>{`npx skills add https://github.com/ron-myers/candid`}</code>
         </Pre>
       </section>
 
@@ -335,8 +334,7 @@ claude plugin install candid@candid`}</code>
               <strong>Install Candid.</strong>
               <span>Add Candid to Claude Code with two commands from your terminal.</span>
               <Pre className="step-code" trackingId="step_install">
-                <code>{`claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid`}</code>
+                <code>{`npx skills add https://github.com/ron-myers/candid`}</code>
               </Pre>
             </div>
           </li>
@@ -426,8 +424,7 @@ claude plugin install candid@candid`}</code>
         <h2>Get started in 5 minutes</h2>
         <Pre className="code-block" trackingId="cta_full_install">
           <code>{`# From a terminal
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 
 # start claude (pass any args you normally would)
 claude

--- a/docs/app/docs/get-started/page.mdx
+++ b/docs/app/docs/get-started/page.mdx
@@ -12,8 +12,7 @@ Get Candid running in under 5 minutes.
 From a terminal, run:
 
 ```bash
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 This adds the plugin to Claude Code in your environment.

--- a/docs/app/docs/get-started/updating/page.mdx
+++ b/docs/app/docs/get-started/updating/page.mdx
@@ -51,8 +51,7 @@ If the quick fix doesn't work:
 
 ```bash
 claude plugin uninstall candid@candid
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 Then restart Claude Code.

--- a/docs/app/docs/how-to-guides/conductor/page.mdx
+++ b/docs/app/docs/how-to-guides/conductor/page.mdx
@@ -43,8 +43,7 @@ Same Technical.md applies to local development and PR reviews.
 Candid should already be available if you've installed it:
 
 ```bash
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 The plugin travels with your Claude Code configuration.

--- a/docs/app/docs/how-to-guides/team-setup/page.mdx
+++ b/docs/app/docs/how-to-guides/team-setup/page.mdx
@@ -18,8 +18,7 @@ When everyone uses Candid with shared standards:
 Each team member installs Candid:
 
 ```bash
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 ### 2. Create Shared Technical.md

--- a/docs/app/docs/quickstart/nextjs/page.mdx
+++ b/docs/app/docs/quickstart/nextjs/page.mdx
@@ -5,8 +5,7 @@ Get Candid running with your Next.js project.
 ## Install Candid
 
 ```bash
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 ## Initialize Standards

--- a/docs/app/docs/quickstart/python/page.mdx
+++ b/docs/app/docs/quickstart/python/page.mdx
@@ -5,8 +5,7 @@ Get Candid running with your Python project.
 ## Install Candid
 
 ```bash
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 ## Initialize Standards

--- a/docs/app/docs/quickstart/react/page.mdx
+++ b/docs/app/docs/quickstart/react/page.mdx
@@ -5,8 +5,7 @@ Get Candid running with your React project.
 ## Install Candid
 
 ```bash
-claude plugin marketplace add ron-myers/candid
-claude plugin install candid@candid
+npx skills add https://github.com/ron-myers/candid
 ```
 
 ## Initialize Standards

--- a/docs/app/docs/quickstart/request-framework/page.mdx
+++ b/docs/app/docs/quickstart/request-framework/page.mdx
@@ -24,8 +24,7 @@ For any framework, you can:
 
 1. Install Candid:
    ```bash
-   claude plugin marketplace add ron-myers/candid
-   claude plugin install candid@candid
+   npx skills add https://github.com/ron-myers/candid
    ```
 
 2. Auto-generate standards:

--- a/docs/app/docs/tips-troubleshooting/page.mdx
+++ b/docs/app/docs/tips-troubleshooting/page.mdx
@@ -11,8 +11,7 @@ Common issues and how to solve them.
 3. Reinstall if needed:
    ```bash
    claude plugin uninstall candid@candid
-   claude plugin marketplace add ron-myers/candid
-   claude plugin install candid@candid
+   npx skills add https://github.com/ron-myers/candid
    ```
 
 ### No issues found


### PR DESCRIPTION
## Summary
Simplified the installation process across all documentation by replacing the two-step Claude Code plugin commands with the single `npx skills add` command.

## Changes
- Updated README.md and 10 documentation files
- Replaced old: `claude plugin marketplace add` + `claude plugin install`
- New: `npx skills add https://github.com/ron-myers/candid`
- Updated reinstall procedures in troubleshooting guides

## Testing
Documentation now consistently shows the simplified install command in all quickstart guides, how-to guides, and marketing materials.