### PR TITLE
Fix copy button hover visibility on light backgrounds

### DIFF
--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -967,7 +967,7 @@ header a:has(.logo):hover {
 
 .copy-button:hover {
   background: rgba(255, 255, 255, 0.2);
-  color: #fff;
+  color: #1a1612;
 }
 
 .copy-button:active {


### PR DESCRIPTION
## Problem
The copy button hover state used white text, making it invisible on light backgrounds like the .install-command block.

## Solution
Changed the hover text color from white (#fff) to dark (#1a1612), which provides good contrast on both light and dark backgrounds.

## Testing
Verify the copy button is now clearly visible when hovering on light backgrounds (hero section) and dark backgrounds (code blocks).