### PR TITLE
Use react-github-btn package for GitHub star button

### DIFF
--- a/docs/app/components/GitHubStars.jsx
+++ b/docs/app/components/GitHubStars.jsx
@@ -1,31 +1,17 @@
 'use client'
 
-import { useEffect } from 'react'
+import GitHubButton from 'react-github-btn'
 
 export default function GitHubStars({ repo = 'ron-myers/candid' }) {
-  useEffect(() => {
-    // Load the GitHub buttons script
-    const existingScript = document.querySelector('script[src="https://buttons.github.io/buttons.js"]')
-    if (!existingScript) {
-      const script = document.createElement('script')
-      script.src = 'https://buttons.github.io/buttons.js'
-      script.async = true
-      script.defer = true
-      document.body.appendChild(script)
-    }
-  }, [])
-
   return (
-    <a
-      className="github-btn"
+    <GitHubButton
       href={`https://github.com/${repo}`}
       data-color-scheme="no-preference: light; light: light; dark: dark;"
-      data-icon="octicon-star"
       data-size="large"
       data-show-count="true"
       aria-label={`Star ${repo} on GitHub`}
     >
-      GitHub Project
-    </a>
+      Star
+    </GitHubButton>
   )
 }

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14,7 +14,8 @@
         "nextra": "^4.6.1",
         "nextra-theme-docs": "^4.6.1",
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "react-github-btn": "^1.4.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -3011,6 +3012,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/github-buttons": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/github-buttons/-/github-buttons-2.30.0.tgz",
+      "integrity": "sha512-8LysiSd/6I0dIsVnI0tJp0NDNWpFXPYjx8o4BsOZcvLER4CV3Vd8/+uXCMZnQwHSXHBayDbYq0IZrwFJd1GxRA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -5373,6 +5380,18 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-github-btn": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-github-btn/-/react-github-btn-1.4.0.tgz",
+      "integrity": "sha512-lV4FYClAfjWnBfv0iNlJUGhamDgIq6TayD0kPZED6VzHWdpcHmPfsYOZ/CFwLfPv4Zp+F4m8QKTj0oy2HjiGXg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "github-buttons": "^2.22.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/react-medium-image-zoom": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "react-github-btn": "^1.4.0"
   }
 }


### PR DESCRIPTION
Replace custom GitHub button implementation with the official react-github-btn package. This simplifies the code by removing manual script loading and improves React integration.