### PR TITLE
Fix pagefind search index generation with error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Conductor workspace files
 .context/
+
+# Candid review state (user-specific)
+.candid/

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16,6 +16,9 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-github-btn": "^1.4.0"
+      },
+      "devDependencies": {
+        "pagefind": "^1.4.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1204,6 +1207,90 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@react-aria/focus": {
       "version": "3.21.3",
@@ -5158,6 +5245,24 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "copy-changelog": "node scripts/copy-changelog.js",
     "dev": "npm run copy-changelog && next dev",
     "build": "npm run copy-changelog && next build",
-    "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
+    "postbuild": "node scripts/generate-search-index.js",
     "start": "next start",
     "lint": "next lint"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,6 +7,7 @@
     "copy-changelog": "node scripts/copy-changelog.js",
     "dev": "npm run copy-changelog && next dev",
     "build": "npm run copy-changelog && next build",
+    "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
     "start": "next start",
     "lint": "next lint"
   },
@@ -19,5 +20,8 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-github-btn": "^1.4.0"
+  },
+  "devDependencies": {
+    "pagefind": "^1.4.0"
   }
 }

--- a/docs/scripts/generate-search-index.js
+++ b/docs/scripts/generate-search-index.js
@@ -1,0 +1,35 @@
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const sourceDir = path.join(__dirname, '..', '.next', 'server', 'app')
+const outputDir = path.join(__dirname, '..', 'public', '_pagefind')
+const indexFile = path.join(outputDir, 'pagefind.js')
+
+// Check that the Next.js build output exists
+if (!fs.existsSync(sourceDir)) {
+  console.error('✗ Error: .next/server/app directory not found.')
+  console.error('  Next.js build may have failed or not completed.')
+  process.exit(1)
+}
+
+// Run pagefind to generate search index
+try {
+  console.log('Running pagefind to generate search index...')
+  execSync('pagefind --site .next/server/app --output-path public/_pagefind', {
+    stdio: 'inherit'
+  })
+} catch (error) {
+  console.error('✗ Failed to generate search index:', error.message)
+  process.exit(1)
+}
+
+// Verify that pagefind actually generated the index
+if (!fs.existsSync(indexFile)) {
+  console.error('✗ Error: pagefind.js was not generated.')
+  console.error('  Check that HTML files have data-pagefind-body attributes.')
+  console.error('  Expected file:', indexFile)
+  process.exit(1)
+}
+
+console.log('✓ Search index generated successfully')


### PR DESCRIPTION
## Summary

Adds robust error handling to the pagefind search index generation during build. The postbuild script now verifies that the Next.js build output exists, catches pagefind failures, and validates that the search index was actually generated before the build completes.

## Test plan

- Verify local build completes successfully: `npm run build` in docs directory
- Check that `public/_pagefind/pagefind.js` is generated
- Test search functionality works on the homepage
- Deploy to Vercel and confirm search works on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)