### PR TITLE
Add Candid Loop skill for automated review cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [1.5.0] - 2026-01-22
+## [1.6.0] - 2026-01-27
 
 ### Added
 
-### Changed
-
-### Fixed
+- **Candid Loop** (`/candid-loop`): New skill that runs candid-review in a loop until all issues are resolved
+  - **Three execution modes**:
+    - `auto` (default): Automatically applies all fixes without prompting
+    - `review-each`: Go through each fix one by one with simple Yes/No prompts
+    - `interactive`: Full control with skip, ignore list, and batch options
+  - **Configurable max iterations**: Prevent infinite loops with `--max-iterations N` (default: 5)
+  - **Category filtering**: Only enforce specific categories with `--categories critical,major`
+  - **Ignored issues**: Permanently skip false positives via `.candid/config.json`:
+    - `loop.ignored.categories`: Skip entire categories (e.g., `["edge_case"]`)
+    - `loop.ignored.patterns`: Skip by title regex (e.g., `["Unicode", "timezone"]`)
+    - `loop.ignored.ids`: Skip specific issue IDs from `last-review.json`
+  - **Add-to-ignore workflow**: In interactive mode, choose "Add to ignore list" to persist skips
+  - **Progress tracking**: Shows iteration count, issues fixed, and detailed summary
+  - **Documentation**: New feature page, how-to guide for automated review loops, updated slash commands reference
 
 ## [1.5.0] - 2026-01-22
 

--- a/docs/app/docs/core-features/_meta.js
+++ b/docs/app/docs/core-features/_meta.js
@@ -5,5 +5,6 @@ export default {
   'technical-md': 'Technical.md',
   'auto-commit': 'Auto-Commit',
   're-review': 'Re-Review',
+  'candid-loop': 'Candid Loop',
   'slash-commands': 'Slash Commands',
 }

--- a/docs/app/docs/core-features/candid-loop/page.mdx
+++ b/docs/app/docs/core-features/candid-loop/page.mdx
@@ -1,0 +1,221 @@
+# Candid Loop
+
+Run code review repeatedly until all issues are resolved.
+
+## Usage
+
+```
+/candid-loop
+```
+
+Candid Loop automates the fix-review-fix cycle. It runs `candid-review`, applies fixes, and repeats until your code is clean (or max iterations is reached).
+
+## Modes
+
+### Auto Mode (Default)
+
+```
+/candid-loop
+```
+
+Automatically applies all fixes without prompting. Best for:
+- Fast iteration during development
+- CI/CD pipelines
+- Pre-commit hooks
+
+### Review-Each Mode
+
+```
+/candid-loop --mode review-each
+```
+
+Go through each fix one by one with simple Yes/No prompts. Best for:
+- Understanding what issues exist
+- Learning the codebase
+- Quick selective fixing
+
+### Interactive Mode
+
+```
+/candid-loop --mode interactive
+```
+
+Full control with skip, ignore, and batch options. Best for:
+- Building an ignore list for false positives
+- Complex review sessions
+- When you need to skip entire batches
+
+## How It Works
+
+```
+[1/5] Run candid-review → Found 3 issues → Apply fixes
+[2/5] Run candid-review → Found 1 issue → Apply fix
+[3/5] Run candid-review → No issues found → Done!
+```
+
+The loop continues until:
+- No issues remain (success)
+- Max iterations reached (stops with warning)
+- User cancels (interactive mode only)
+
+## Configuration
+
+### CLI Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--mode <auto\|review-each\|interactive>` | Execution mode | `auto` |
+| `--max-iterations <N>` | Maximum loop iterations | `5` |
+| `--categories <list>` | Categories to enforce | `all` |
+
+### Config File
+
+Add to `.candid/config.json`:
+
+```json
+{
+  "loop": {
+    "mode": "auto",
+    "maxIterations": 5,
+    "enforceCategories": ["all"],
+    "ignored": {
+      "categories": [],
+      "patterns": [],
+      "ids": []
+    }
+  }
+}
+```
+
+## Ignoring Issues
+
+Prevent specific issues from blocking your loop.
+
+### Ignore by Category
+
+Skip entire categories of issues:
+
+```json
+{
+  "loop": {
+    "ignored": {
+      "categories": ["edge_case", "architectural"]
+    }
+  }
+}
+```
+
+### Ignore by Pattern
+
+Skip issues matching title patterns (regex):
+
+```json
+{
+  "loop": {
+    "ignored": {
+      "patterns": ["Unicode", "timezone", "DST"]
+    }
+  }
+}
+```
+
+### Ignore by ID
+
+Skip specific issues by their unique ID (found in `.candid/last-review.json`):
+
+```json
+{
+  "loop": {
+    "ignored": {
+      "ids": ["a1b2c3d4e5f6"]
+    }
+  }
+}
+```
+
+> **Tip:** In interactive mode, you can choose "Add to ignore list" for any issue to automatically add its ID to the config.
+
+## Enforcing Specific Categories
+
+Only fix certain types of issues:
+
+```
+/candid-loop --categories critical
+/candid-loop --categories critical,major
+```
+
+Valid categories: `critical`, `major`, `standards`, `smell`, `edge_case`, `architectural`, `all`
+
+## Examples
+
+```bash
+# Default: auto-fix all issues, max 5 iterations
+/candid-loop
+
+# Review-each: go through fixes one by one
+/candid-loop --mode review-each
+
+# Interactive: full control with skip/ignore options
+/candid-loop --mode interactive
+
+# Quick pass: only fix critical issues, max 3 tries
+/candid-loop --categories critical --max-iterations 3
+
+# Thorough: fix critical and major, up to 10 iterations
+/candid-loop --categories critical,major --max-iterations 10
+```
+
+## Output Examples
+
+### Success
+
+```
+[Auto Mode] Running candid-loop with max 5 iterations...
+
+[1/5] Found 3 issues. Applying fixes...
+      ✓ Fixed: Null check missing in user.ts:42
+      ✓ Fixed: SQL injection in db.ts:15
+      ✓ Fixed: N+1 query in orders.ts:88
+
+[2/5] Found 1 issue. Applying fix...
+      ✓ Fixed: Missing error handling in auth.ts:20
+
+[3/5] No issues found!
+
+Summary:
+- Iterations: 3
+- Issues fixed: 4
+- Status: PASS
+```
+
+### Max Iterations Reached
+
+```
+[Auto Mode] Running candid-loop with max 5 iterations...
+
+[5/5] Found 2 issues. Applying fixes...
+      ✓ Fixed: Issue A
+      ✓ Fixed: Issue B
+
+Max iterations (5) reached. 1 issue remains.
+
+Remaining issues:
+  💭 Complex architectural concern in core.ts:100
+
+Consider:
+- Increasing --max-iterations
+- Adding to ignore list for false positives
+- Manually reviewing complex issues
+```
+
+## Combining with Other Features
+
+Candid Loop respects your other settings:
+
+```
+# Use harsh tone in the underlying reviews
+/candid-loop  # (with "tone": "harsh" in config)
+
+# Focus reviews on security issues only
+/candid-loop --categories critical
+```

--- a/docs/app/docs/core-features/page.mdx
+++ b/docs/app/docs/core-features/page.mdx
@@ -15,6 +15,7 @@ Everything Candid can do for your code reviews.
 
 - [Auto-Commit](/docs/core-features/auto-commit) — Automatically commit applied fixes
 - [Re-Review](/docs/core-features/re-review) — Track progress on fixing issues
+- [Candid Loop](/docs/core-features/candid-loop) — Run reviews in a loop until clean
 
 ## Commands
 

--- a/docs/app/docs/core-features/slash-commands/page.mdx
+++ b/docs/app/docs/core-features/slash-commands/page.mdx
@@ -30,6 +30,38 @@ Run a code review on your changes.
 /candid-review --re-review
 ```
 
+## /candid-loop
+
+Run code review in a loop until all issues are resolved.
+
+```
+/candid-loop
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--mode <auto\|review-each\|interactive>` | Execution mode (default: auto) |
+| `--max-iterations <N>` | Maximum loop iterations (default: 5) |
+| `--categories <list>` | Categories to enforce: critical, major, standards, smell, edge_case, architectural, or all (default: all) |
+
+### Modes
+
+- **auto** (default): Automatically applies all fixes until clean
+- **review-each**: Go through each fix one by one (Yes/No for each)
+- **interactive**: Full control with skip, ignore, and batch options
+
+### Examples
+
+```
+/candid-loop
+/candid-loop --mode review-each
+/candid-loop --mode interactive
+/candid-loop --max-iterations 3
+/candid-loop --categories critical,major
+```
+
 ## /candid-init
 
 Generate a Technical.md file by analyzing your codebase.

--- a/docs/app/docs/how-to-guides/_meta.js
+++ b/docs/app/docs/how-to-guides/_meta.js
@@ -4,4 +4,5 @@ export default {
   conductor: 'Using with Conductor',
   'custom-standards': 'Creating Custom Standards',
   'reviewing-before-prs': 'Reviewing Before PRs',
+  'automated-review-loops': 'Automated Review Loops',
 }

--- a/docs/app/docs/how-to-guides/automated-review-loops/page.mdx
+++ b/docs/app/docs/how-to-guides/automated-review-loops/page.mdx
@@ -1,0 +1,171 @@
+# Automated Review Loops
+
+Set up Candid to automatically fix issues until your code is clean.
+
+## Quick Start
+
+Run the loop with default settings:
+
+```
+/candid-loop
+```
+
+This will:
+1. Run `candid-review` to find issues
+2. Automatically apply all fixes
+3. Re-run the review
+4. Repeat until no issues remain (or max 5 iterations)
+
+## Setting Up for CI/CD
+
+### GitHub Actions
+
+Add to your workflow:
+
+```yaml
+- name: Run Candid Loop
+  run: |
+    claude /candid-loop --max-iterations 3
+```
+
+### Pre-commit Hook
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+- repo: local
+  hooks:
+    - id: candid-loop
+      name: Candid Loop
+      entry: claude /candid-loop --categories critical,major
+      language: system
+      pass_filenames: false
+```
+
+## Managing Ignored Issues
+
+When the loop keeps finding the same issue that you've decided is acceptable:
+
+### Option 1: Ignore During Review (Interactive Mode)
+
+```
+/candid-loop --mode interactive
+```
+
+When prompted, select "Add to ignore list" for false positives.
+
+### Option 2: Pre-configure Ignores
+
+Add to `.candid/config.json`:
+
+```json
+{
+  "loop": {
+    "ignored": {
+      "patterns": ["Unicode handling", "timezone"],
+      "categories": ["edge_case"]
+    }
+  }
+}
+```
+
+### Option 3: Ignore Specific Issues
+
+Find the issue ID in `.candid/last-review.json`, then add:
+
+```json
+{
+  "loop": {
+    "ignored": {
+      "ids": ["a1b2c3d4e5f6"]
+    }
+  }
+}
+```
+
+## Team Consistency
+
+Share ignore patterns across your team by committing `.candid/config.json`:
+
+```json
+{
+  "tone": "harsh",
+  "loop": {
+    "mode": "auto",
+    "maxIterations": 5,
+    "enforceCategories": ["critical", "major"],
+    "ignored": {
+      "patterns": ["legacy API compatibility"],
+      "categories": []
+    }
+  }
+}
+```
+
+## Best Practices
+
+### Choose the Right Max Iterations
+
+- **3 iterations**: Quick pass, catches most issues
+- **5 iterations** (default): Good balance
+- **10 iterations**: Thorough, for complex codebases
+
+### Start with Critical Issues Only
+
+For large codebases, start narrow:
+
+```
+/candid-loop --categories critical
+```
+
+Then expand:
+
+```
+/candid-loop --categories critical,major
+```
+
+### Use Review-Each Mode for Learning
+
+When working with an unfamiliar codebase:
+
+```
+/candid-loop --mode review-each
+```
+
+This shows you each fix one by one with simple Yes/No prompts, helping you understand what issues exist.
+
+### Use Interactive Mode for Full Control
+
+When you need to skip batches or build an ignore list:
+
+```
+/candid-loop --mode interactive
+```
+
+This gives you full control with skip, ignore, and batch options.
+
+## Troubleshooting
+
+### Loop Never Completes
+
+If the loop keeps finding issues:
+
+1. Check if the same issue keeps reappearing (fix might not be persisting)
+2. Add persistent false positives to the ignore list
+3. Increase `--max-iterations` if legitimate issues remain
+
+### Loop Exits Too Early
+
+If the loop stops before you expect:
+
+1. Check the summary for "Max iterations reached"
+2. Increase `--max-iterations`
+3. Ensure fixes are being applied correctly
+
+### Issues Keep Coming Back
+
+If fixed issues reappear in subsequent iterations:
+
+1. The fix might introduce a new issue in a different category
+2. Check if your linter/formatter is reverting changes
+3. Review the fix logic in the skill output

--- a/skills/candid-loop/SKILL.md
+++ b/skills/candid-loop/SKILL.md
@@ -1,0 +1,494 @@
+---
+name: candid-loop
+description: Run candid-review in a loop until all issues are resolved, with configurable auto, review-each, or interactive modes and support for ignored issues
+---
+
+# Candid Loop
+
+Run `candid-review` repeatedly until your code is clean. This skill automates the fix-review-fix cycle, applying fixes and re-running reviews until no issues remain (or max iterations is reached).
+
+## Workflow
+
+Execute these steps in order:
+
+### Step 1: Load Configuration
+
+Load loop configuration from CLI flags and config files.
+
+**Precedence (highest to lowest):**
+1. CLI flags
+2. Project config (`.candid/config.json` → `loop` field)
+3. User config (`~/.candid/config.json` → `loop` field)
+4. Defaults
+
+#### Check CLI Arguments
+
+Parse CLI arguments for loop options:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--mode <auto\|review-each\|interactive>` | Execution mode | `auto` |
+| `--max-iterations <N>` | Maximum loop iterations | `5` |
+| `--categories <list>` | Categories to enforce (comma-separated) | `all` |
+
+**Valid modes:**
+- `auto` - Automatically apply all fixes
+- `review-each` - Go through each fix one by one (Yes/No for each)
+- `interactive` - Full control with skip, ignore, and batch options
+
+**Valid categories:** `critical`, `major`, `standards`, `smell`, `edge_case`, `architectural`, `all`
+
+If CLI flags are provided, use them and skip config file checks for those specific options.
+
+#### Check Project Config
+
+Read `.candid/config.json` and extract the `loop` field:
+
+```bash
+jq -r '.loop // null' .candid/config.json 2>/dev/null
+```
+
+If the `loop` field exists:
+- Extract `mode` if not set by CLI
+- Extract `maxIterations` if not set by CLI
+- Extract `enforceCategories` if not set by CLI
+- Extract `ignored` object (categories, patterns, ids)
+
+Output when loading from config: `Using loop settings from project config`
+
+#### Check User Config
+
+Same procedure for `~/.candid/config.json` if project config doesn't have `loop` field.
+
+Output when loading from user config: `Using loop settings from user config`
+
+#### Apply Defaults
+
+For any options not set by CLI or config:
+
+```
+mode = "auto"
+maxIterations = 5
+enforceCategories = ["all"]
+ignored = { categories: [], patterns: [], ids: [] }
+```
+
+### Step 2: Initialize Loop State
+
+Set up tracking variables:
+
+```
+iteration = 0
+totalFixesApplied = 0
+allFixedIssues = []
+```
+
+Display mode banner:
+
+**Auto mode:**
+```
+[Auto Mode] Running candid-loop with max [N] iterations...
+```
+
+**Review-each mode:**
+```
+[Review-Each Mode] Running candid-loop with max [N] iterations...
+You will review each fix one by one.
+```
+
+**Interactive mode:**
+```
+[Interactive Mode] Running candid-loop with max [N] iterations...
+Full control: skip, ignore, or batch process fixes.
+```
+
+### Step 3: Run Review Loop
+
+Execute the main loop:
+
+```
+WHILE iteration < maxIterations:
+    iteration++
+
+    Execute Step 3.1 through Step 3.6
+
+    IF exitLoop == true:
+        BREAK
+
+IF iteration >= maxIterations AND remainingIssues > 0:
+    Output warning: "Max iterations ([N]) reached. [M] issues remain."
+    List remaining issues
+```
+
+#### Step 3.1: Run candid-review
+
+Display iteration header:
+```
+[Iteration [N]/[MAX]]
+Running candid-review...
+```
+
+Invoke the candid-review skill to analyze current code:
+- Use the Skill tool to run `/candid-review`
+- Pass through tone settings if configured
+- Wait for review to complete and save state to `.candid/last-review.json`
+
+**Note:** candid-review will present its own fix selection prompt. In auto mode, we need to handle this by selecting "Apply all fixes". In interactive mode, we defer to the user's choices within candid-review.
+
+#### Step 3.2: Read Review Results
+
+After candid-review completes, read the saved review state:
+
+```bash
+cat .candid/last-review.json 2>/dev/null
+```
+
+Parse the JSON to extract:
+- `issues` array with all found issues
+- Each issue has: `id`, `file`, `line`, `category`, `title`, `description`
+
+If file doesn't exist or is empty:
+```
+No review state found. candid-review may not have completed.
+```
+Exit with error.
+
+#### Step 3.3: Filter Issues by Category
+
+If `enforceCategories` is NOT `["all"]`:
+
+Filter the issues array to only include issues matching enforceCategories:
+
+```
+filteredIssues = issues.filter(issue =>
+    enforceCategories.includes(issue.category)
+)
+```
+
+**Category mapping:**
+- `critical` → issues with category "critical"
+- `major` → issues with category "major"
+- `standards` → issues with category "standards"
+- `smell` → issues with category "smell"
+- `edge_case` → issues with category "edge_case"
+- `architectural` → issues with category "architectural"
+
+Output: `Enforcing categories: [list]. Filtered to [N] issues.`
+
+#### Step 3.4: Filter Out Ignored Issues
+
+Apply the ignored filters from config:
+
+**1. Filter by ignored categories:**
+```
+filteredIssues = filteredIssues.filter(issue =>
+    !ignored.categories.includes(issue.category)
+)
+```
+
+**2. Filter by ignored patterns (regex match on title):**
+```
+filteredIssues = filteredIssues.filter(issue =>
+    !ignored.patterns.some(pattern =>
+        new RegExp(pattern, 'i').test(issue.title)
+    )
+)
+```
+
+**3. Filter by ignored IDs:**
+```
+filteredIssues = filteredIssues.filter(issue =>
+    !ignored.ids.includes(issue.id)
+)
+```
+
+If any issues were filtered:
+```
+Filtered out [N] ignored issues ([M] remaining)
+```
+
+#### Step 3.5: Check for Completion
+
+If `filteredIssues.length === 0`:
+
+```
+[Iteration [N]/[MAX]] No issues found!
+
+exitLoop = true
+```
+
+Skip to Step 4 (Summary).
+
+#### Step 3.6: Handle Issues Based on Mode
+
+**If mode == "auto":**
+
+Display found issues:
+```
+[N/MAX] Found [M] issues. Applying fixes...
+```
+
+The candid-review skill will have already applied fixes if the user selected "Apply all fixes" in its prompt. Since we're in auto mode, we should have configured candid-review to auto-apply.
+
+For each issue that was fixed, log:
+```
+      ✓ [icon] Fixed: [title] in [file]:[line]
+```
+
+Track fixes:
+```
+totalFixesApplied += appliedCount
+allFixedIssues.push(...appliedIssues)
+```
+
+Continue to next iteration.
+
+**If mode == "review-each":**
+
+Go through each fix one by one with simple Yes/No prompts.
+
+Display found issues:
+```
+[N/MAX] Found [M] issues. Reviewing each...
+```
+
+For each issue, use AskUserQuestion:
+
+```
+[1/M] [icon] [title]
+File: [file]:[line]
+Problem: [description]
+```
+
+**Question:** "Apply this fix?"
+
+**Options:**
+1. "Yes, apply this fix"
+2. "No, skip this fix"
+
+Track user choices:
+- If "Yes" → Apply the fix, increment totalFixesApplied
+- If "No" → Continue to next issue
+
+After processing all issues, if any fixes were applied, continue to next iteration.
+
+**If mode == "interactive":**
+
+Full control mode with additional options for skipping, ignoring, and batch processing.
+
+Display found issues:
+```
+Found [M] issues:
+```
+
+For each issue, use AskUserQuestion:
+
+```
+[1/M] [icon] [title]
+File: [file]:[line]
+Problem: [description]
+```
+
+**Question:** "How would you like to handle this issue?"
+
+**Options:**
+1. "Apply fix" - Apply this fix and continue
+2. "Skip" - Skip this issue and continue to next
+3. "Add to ignore list" - Add this issue ID to ignored.ids and skip
+4. "Skip all remaining" - Exit the loop with remaining issues listed
+
+Track user choices:
+- If "Apply fix" → Apply the fix, increment totalFixesApplied
+- If "Skip" → Continue to next issue
+- If "Add to ignore list" → Add issue.id to ignored.ids in config, continue
+- If "Skip all remaining" → Set exitLoop = true, break inner loop
+
+After processing all issues in interactive mode, if any fixes were applied, continue to next iteration.
+
+### Step 3.7: Update Ignore List (If Requested)
+
+If user chose "Add to ignore list" for any issues:
+
+1. Read current `.candid/config.json` (or create if doesn't exist)
+2. Add issue IDs to `loop.ignored.ids` array
+3. Write updated config back to file
+
+```bash
+# Read, modify, write
+jq '.loop.ignored.ids += ["issue-id-1", "issue-id-2"]' .candid/config.json > tmp.json
+mv tmp.json .candid/config.json
+```
+
+Output: `Added [N] issues to ignore list in .candid/config.json`
+
+### Step 4: Display Summary
+
+After loop exits (success or max iterations), display final summary:
+
+**Success (no issues remaining):**
+```
+Candid Loop Complete
+
+Summary:
+- Iterations: [N]
+- Issues fixed: [M]
+- Status: PASS
+
+Your code is clean!
+```
+
+**Max iterations reached:**
+```
+Candid Loop Stopped
+
+Summary:
+- Iterations: [N] (max reached)
+- Issues fixed: [M]
+- Issues remaining: [P]
+- Status: INCOMPLETE
+
+Remaining issues:
+  [icon] [title] in [file]:[line]
+  [icon] [title] in [file]:[line]
+  ...
+
+Consider:
+- Increasing --max-iterations
+- Adding persistent ignores for false positives
+- Manually reviewing complex issues
+```
+
+**User cancelled (interactive mode):**
+```
+Candid Loop Cancelled
+
+Summary:
+- Iterations: [N]
+- Issues fixed: [M]
+- Issues skipped: [P]
+- Status: CANCELLED
+
+Skipped issues:
+  [icon] [title] in [file]:[line]
+  ...
+```
+
+## Configuration
+
+### Config File Schema
+
+Add to `.candid/config.json`:
+
+```json
+{
+  "version": 1,
+  "tone": "harsh",
+  "loop": {
+    "mode": "auto",
+    "maxIterations": 5,
+    "enforceCategories": ["all"],
+    "ignored": {
+      "categories": [],
+      "patterns": [],
+      "ids": []
+    }
+  }
+}
+```
+
+### Field Descriptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `loop.mode` | string | `"auto"` | `"auto"`, `"review-each"`, or `"interactive"` |
+| `loop.maxIterations` | number | `5` | Maximum review-fix cycles |
+| `loop.enforceCategories` | array | `["all"]` | Categories to enforce |
+| `loop.ignored.categories` | array | `[]` | Categories to skip entirely |
+| `loop.ignored.patterns` | array | `[]` | Regex patterns to match issue titles |
+| `loop.ignored.ids` | array | `[]` | Specific issue IDs to skip |
+
+### Examples
+
+**Ignore all edge cases and architectural issues:**
+```json
+{
+  "loop": {
+    "ignored": {
+      "categories": ["edge_case", "architectural"]
+    }
+  }
+}
+```
+
+**Ignore issues mentioning Unicode or timezone:**
+```json
+{
+  "loop": {
+    "ignored": {
+      "patterns": ["Unicode", "timezone", "DST"]
+    }
+  }
+}
+```
+
+**Only enforce critical and major issues:**
+```json
+{
+  "loop": {
+    "enforceCategories": ["critical", "major"]
+  }
+}
+```
+
+## CLI Examples
+
+```bash
+# Run with defaults (auto mode, all categories, max 5 iterations)
+/candid-loop
+
+# Review-each mode - go through each fix one by one (Yes/No)
+/candid-loop --mode review-each
+
+# Interactive mode - full control with skip, ignore, batch options
+/candid-loop --mode interactive
+
+# Limit iterations
+/candid-loop --max-iterations 3
+
+# Only fix critical issues
+/candid-loop --categories critical
+
+# Fix critical and major issues
+/candid-loop --categories critical,major
+
+# Combine options
+/candid-loop --mode review-each --max-iterations 10 --categories critical,major
+```
+
+## Issue Categories Reference
+
+| Category | Icon | Description |
+|----------|------|-------------|
+| `critical` | 🔥 | Production killers: crashes, security holes, data loss |
+| `major` | ⚠️ | Serious problems: performance, missing error handling |
+| `standards` | 📜 | Technical.md violations |
+| `smell` | 📋 | Maintainability: complexity, duplication |
+| `edge_case` | 🤔 | Unhandled scenarios: null, empty, concurrent |
+| `architectural` | 💭 | Design concerns: coupling, SRP violations |
+
+## Remember
+
+The goal of candid-loop is to **automate the review-fix cycle** so you can quickly get your code to a clean state.
+
+**Mode selection:**
+- **auto** - Fast iteration, applies all fixes automatically
+- **review-each** - Go through each fix one by one with simple Yes/No
+- **interactive** - Full control with skip, ignore list, and batch options
+
+**Best practices:**
+- Start with auto mode for quick cleanup
+- Use review-each mode to understand what's being fixed
+- Use interactive mode when you need to ignore or skip specific issues
+- Add patterns to ignore list for known false positives
+- Keep maxIterations reasonable (5-10) to avoid infinite loops
+- Review the summary to understand what was fixed


### PR DESCRIPTION
Add new `/candid-loop` skill that runs candid-review in a loop until all issues are resolved. Features three execution modes (auto, review-each, interactive), configurable max iterations, category filtering, and persistent ignore lists via .candid/config.json. Includes comprehensive documentation with feature page, how-to guide, and updated references. Release v1.6.0.

🔄 Modes:
- **auto**: Automatically applies all fixes
- **review-each**: Go through each fix with Yes/No prompts
- **interactive**: Full control with skip/ignore options

📚 Documentation includes feature explanation, CLI examples, ignore list management, and best practices for CI/CD integration.

✨ This enables rapid, automated code cleanup workflows while maintaining user control over specific issues.