### PR TITLE
Add brand guidelines page with design system documentation

### DIFF
--- a/docs/app/(marketing)/brand/BrandPageClient.jsx
+++ b/docs/app/(marketing)/brand/BrandPageClient.jsx
@@ -1,0 +1,672 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+
+// Brand colors data
+const brandColors = [
+  {
+    name: 'Warm Tan',
+    variable: '--accent-main',
+    hex: { light: '#d4a27f', dark: '#d4a27f' },
+    usage: 'Primary brand accent. CTAs, highlights, interactive elements, and brand moments.',
+  },
+  {
+    name: 'Parchment',
+    variable: '--bg-light / --bg-dark',
+    hex: { light: '#fdfdf7', dark: '#09090b' },
+    usage: 'Page backgrounds. Warm cream in light mode, deep charcoal in dark mode.',
+  },
+  {
+    name: 'Canvas',
+    variable: '--surface-light / --surface-dark',
+    hex: { light: '#f8f7f3', dark: '#111113' },
+    usage: 'Elevated surfaces. Cards, code blocks, and interactive containers.',
+  },
+  {
+    name: 'Ink',
+    variable: '--text-primary',
+    hex: { light: '#1a1612', dark: '#f3f3f3' },
+    usage: 'Primary text. Headlines, body copy, and important content.',
+  },
+  {
+    name: 'Graphite',
+    variable: '--text-secondary',
+    hex: { light: '#5c5850', dark: '#a8a6a0' },
+    usage: 'Secondary text. Captions, metadata, and supporting content.',
+  },
+  {
+    name: 'Stroke',
+    variable: '--border-light / --border-dark',
+    hex: { light: '#e8e6df', dark: '#2a2926' },
+    usage: 'Borders and dividers. Subtle visual separation between elements.',
+  },
+]
+
+// Type scale data
+const typeScale = [
+  { name: 'Hero', size: '4.5rem', px: '72px', variable: '--text-hero', sample: 'Page Headlines' },
+  { name: 'Section', size: '3rem', px: '48px', variable: '--text-section', sample: 'Section Titles' },
+  { name: 'Card Title', size: '1.5rem', px: '24px', variable: '--text-card-title', sample: 'Card Headers' },
+  { name: 'Body', size: '1.125rem', px: '18px', variable: '--text-body', sample: 'Body copy and paragraphs' },
+  { name: 'Small', size: '0.875rem', px: '14px', variable: '--text-small', sample: 'Captions and metadata' },
+  { name: 'Code', size: '0.875rem', px: '14px', variable: '--text-code', sample: 'npx skills add candid' },
+]
+
+// Constants
+const TOAST_DURATION_MS = 2000
+
+export default function BrandPageClient() {
+  const [showToast, setShowToast] = useState(false)
+  const [toastMessage, setToastMessage] = useState('')
+  const [heroLoaded, setHeroLoaded] = useState(false)
+  const [isDark, setIsDark] = useState(false)
+
+  // Refs for scroll animations
+  const logoRef = useRef(null)
+  const colorsRef = useRef(null)
+  const typographyRef = useRef(null)
+  const voiceRef = useRef(null)
+
+  useEffect(() => {
+    setHeroLoaded(true)
+    // Check for dark mode
+    setIsDark(document.documentElement.classList.contains('dark'))
+
+    // Watch for dark mode changes
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+
+    return () => observer.disconnect()
+  }, [])
+
+  // Scroll-triggered animations
+  useEffect(() => {
+    const observerOptions = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0.1
+    }
+
+    const observerCallback = (entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('animate-in')
+        }
+      })
+    }
+
+    const observer = new IntersectionObserver(observerCallback, observerOptions)
+
+    // Capture refs at effect execution time to avoid stale refs in cleanup
+    const currentRefs = [logoRef, colorsRef, typographyRef, voiceRef]
+      .map(ref => ref.current)
+      .filter(Boolean)
+
+    currentRefs.forEach(el => observer.observe(el))
+
+    return () => {
+      currentRefs.forEach(el => observer.unobserve(el))
+    }
+  }, [])
+
+  const handleCopy = async (value, label) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setToastMessage(`Copied ${label}`)
+    } catch (err) {
+      console.error('Failed to copy:', err)
+      setToastMessage('Copy failed - try selecting manually')
+    }
+    setShowToast(true)
+    setTimeout(() => setShowToast(false), TOAST_DURATION_MS)
+  }
+
+  const downloadSVG = (type) => {
+    let svgContent = ''
+    let filename = ''
+
+    if (type === 'full') {
+      svgContent = `<svg viewBox="-2 0 110 32" width="220" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z" fill="white" stroke="#d4a27f" stroke-width="2.5"/>
+  <text x="36" y="22" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif" font-size="22" font-weight="500" fill="#1a1612" letter-spacing="-0.5">candid</text>
+</svg>`
+      filename = 'candid-logo-full.svg'
+    } else if (type === 'icon') {
+      svgContent = `<svg viewBox="-2 0 34 32" width="68" height="64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z" fill="white" stroke="#d4a27f" stroke-width="2.5"/>
+</svg>`
+      filename = 'candid-icon.svg'
+    } else if (type === 'wordmark') {
+      svgContent = `<svg viewBox="0 0 80 28" width="160" height="56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <text x="0" y="22" font-family="Inter, -apple-system, BlinkMacSystemFont, sans-serif" font-size="22" font-weight="500" fill="#1a1612" letter-spacing="-0.5">candid</text>
+</svg>`
+      filename = 'candid-wordmark.svg'
+    }
+
+    try {
+      const blob = new Blob([svgContent], { type: 'image/svg+xml' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+      setToastMessage(`Downloaded ${filename}`)
+    } catch (err) {
+      console.error('Download failed:', err)
+      setToastMessage('Download failed')
+    }
+    setShowToast(true)
+    setTimeout(() => setShowToast(false), TOAST_DURATION_MS)
+  }
+
+  return (
+    <>
+      {/* Hero Section */}
+      <section className="brand-hero">
+        <div
+          className="brand-hero-badge"
+          style={{
+            opacity: heroLoaded ? 1 : 0,
+            transform: heroLoaded ? 'translateY(0)' : 'translateY(20px)',
+            transition: 'opacity 600ms ease-out, transform 600ms ease-out'
+          }}
+        >
+          Brand Guidelines
+        </div>
+        <h1
+          className="brand-hero-wordmark"
+          style={{
+            opacity: heroLoaded ? 1 : 0,
+            transform: heroLoaded ? 'translateY(0)' : 'translateY(20px)',
+            transition: 'opacity 600ms ease-out 100ms, transform 600ms ease-out 100ms'
+          }}
+        >
+          candid
+        </h1>
+        <p
+          className="brand-hero-tagline"
+          style={{
+            opacity: heroLoaded ? 1 : 0,
+            transform: heroLoaded ? 'translateY(0)' : 'translateY(20px)',
+            transition: 'opacity 600ms ease-out 200ms, transform 600ms ease-out 200ms'
+          }}
+        >
+          Code Review for the AI Era
+        </p>
+        <p
+          className="brand-hero-intro"
+          style={{
+            opacity: heroLoaded ? 1 : 0,
+            transform: heroLoaded ? 'translateY(0)' : 'translateY(20px)',
+            transition: 'opacity 600ms ease-out 300ms, transform 600ms ease-out 300ms'
+          }}
+        >
+          Our brand embodies radical honesty in code review. These guidelines ensure
+          Candid is represented consistently across all touchpoints.
+        </p>
+      </section>
+
+      {/* Logo Section */}
+      <section className="brand-section scroll-animate" ref={logoRef}>
+        <span className="brand-section-label">01</span>
+        <h2 className="brand-heading">Logo</h2>
+        <p className="brand-subheading">Our mark represents honest conversation</p>
+
+        {/* Primary Logo Display */}
+        <div className="brand-logo-display">
+          <div className="brand-logo-primary">
+            <svg viewBox="-2 0 110 32" width="320" height="93" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z"
+                fill="white"
+                stroke="#d4a27f"
+                strokeWidth="2.5"
+              />
+              <text
+                x="36"
+                y="22"
+                fontFamily="Inter, -apple-system, BlinkMacSystemFont, sans-serif"
+                fontSize="22"
+                fontWeight="500"
+                fill="currentColor"
+                letterSpacing="-0.5"
+              >
+                candid
+              </text>
+            </svg>
+          </div>
+        </div>
+
+        {/* Logo Anatomy */}
+        <div className="brand-logo-anatomy">
+          <div className="brand-anatomy-item">
+            <div className="brand-anatomy-icon">
+              <svg viewBox="-2 0 34 32" width="48" height="45" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z" fill="white" stroke="#d4a27f" strokeWidth="2.5"/>
+              </svg>
+            </div>
+            <div className="brand-anatomy-content">
+              <strong>The Comment Bubble</strong>
+              <span>Represents honest dialogue and open communication. The foundation of meaningful code review.</span>
+            </div>
+          </div>
+          <div className="brand-anatomy-item">
+            <div className="brand-anatomy-icon">
+              <span className="brand-anatomy-wordmark">candid</span>
+            </div>
+            <div className="brand-anatomy-content">
+              <strong>The Wordmark</strong>
+              <span>Lowercase, approachable, and direct. Set in Inter Medium for clarity and warmth.</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Logo Variations */}
+        <h3 className="brand-subsection-title">Variations</h3>
+        <div className="brand-logo-variations">
+          <div className="brand-logo-variation">
+            <div className="brand-variation-preview">
+              <svg viewBox="-2 0 110 32" width="180" height="52" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z" fill="white" stroke="#d4a27f" strokeWidth="2.5"/>
+                <text x="36" y="22" fontFamily="Inter, -apple-system, sans-serif" fontSize="22" fontWeight="500" fill="currentColor" letterSpacing="-0.5">candid</text>
+              </svg>
+            </div>
+            <span className="brand-variation-label">Full Logo</span>
+            <span className="brand-variation-usage">Primary usage</span>
+            <button className="brand-download-btn" onClick={() => downloadSVG('full')}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                <polyline points="7 10 12 15 17 10"/>
+                <line x1="12" y1="15" x2="12" y2="3"/>
+              </svg>
+              SVG
+            </button>
+          </div>
+          <div className="brand-logo-variation">
+            <div className="brand-variation-preview">
+              <svg viewBox="-2 0 34 32" width="52" height="49" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 4H22C25.3137 4 28 6.68629 28 10V18C28 21.3137 25.3137 24 22 24H14L8 28V24H6C2.68629 24 0 21.3137 0 18V10C0 6.68629 2.68629 4 6 4Z" fill="white" stroke="#d4a27f" strokeWidth="2.5"/>
+              </svg>
+            </div>
+            <span className="brand-variation-label">Icon Only</span>
+            <span className="brand-variation-usage">Favicons, small spaces</span>
+            <button className="brand-download-btn" onClick={() => downloadSVG('icon')}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                <polyline points="7 10 12 15 17 10"/>
+                <line x1="12" y1="15" x2="12" y2="3"/>
+              </svg>
+              SVG
+            </button>
+          </div>
+          <div className="brand-logo-variation">
+            <div className="brand-variation-preview">
+              <span className="brand-wordmark-only">candid</span>
+            </div>
+            <span className="brand-variation-label">Wordmark</span>
+            <span className="brand-variation-usage">Text-heavy contexts</span>
+            <button className="brand-download-btn" onClick={() => downloadSVG('wordmark')}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                <polyline points="7 10 12 15 17 10"/>
+                <line x1="12" y1="15" x2="12" y2="3"/>
+              </svg>
+              SVG
+            </button>
+          </div>
+        </div>
+
+        {/* Logo Do's and Don'ts */}
+        <h3 className="brand-subsection-title">Usage Guidelines</h3>
+        <div className="brand-dos-donts">
+          <div className="brand-guideline brand-guideline--do">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <span>Use on light backgrounds with sufficient contrast</span>
+          </div>
+          <div className="brand-guideline brand-guideline--do">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <span>Maintain the original aspect ratio</span>
+          </div>
+          <div className="brand-guideline brand-guideline--do">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <span>Give the logo breathing room (min. icon height on all sides)</span>
+          </div>
+          <div className="brand-guideline brand-guideline--dont">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </div>
+            <span>Don't stretch, skew, or distort</span>
+          </div>
+          <div className="brand-guideline brand-guideline--dont">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </div>
+            <span>Don't add shadows, gradients, or effects</span>
+          </div>
+          <div className="brand-guideline brand-guideline--dont">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </div>
+            <span>Don't change the brand colors</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Color Section */}
+      <section className="brand-section scroll-animate" ref={colorsRef}>
+        <span className="brand-section-label">02</span>
+        <h2 className="brand-heading">Color</h2>
+        <p className="brand-subheading">A warm, sophisticated palette inspired by honest conversation</p>
+
+        <div className="brand-color-mode-indicator">
+          Currently viewing: <strong>{isDark ? 'Dark Mode' : 'Light Mode'}</strong>
+        </div>
+
+        <div className="brand-color-grid">
+          {brandColors.map((color, index) => (
+            <div
+              key={index}
+              className="brand-color-swatch"
+              onClick={() => handleCopy(isDark ? color.hex.dark : color.hex.light, color.name)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  handleCopy(isDark ? color.hex.dark : color.hex.light, color.name)
+                }
+              }}
+            >
+              <div
+                className="brand-color-preview"
+                style={{ background: isDark ? color.hex.dark : color.hex.light }}
+              />
+              <div className="brand-color-info">
+                <span className="brand-color-name">{color.name}</span>
+                <span className="brand-color-variable">{color.variable}</span>
+                <div className="brand-color-values">
+                  <span className="brand-color-hex">
+                    {isDark ? color.hex.dark : color.hex.light}
+                    <svg className="brand-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+                      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                    </svg>
+                  </span>
+                </div>
+                <span className="brand-color-usage">{color.usage}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Typography Section */}
+      <section className="brand-section scroll-animate" ref={typographyRef}>
+        <span className="brand-section-label">03</span>
+        <h2 className="brand-heading">Typography</h2>
+        <p className="brand-subheading">Three typefaces, carefully paired for clarity and warmth</p>
+
+        {/* Fraunces Specimen */}
+        <div className="brand-type-specimen brand-type-specimen--fraunces">
+          <div className="brand-type-specimen-header">
+            <span className="brand-type-name">Fraunces</span>
+            <span className="brand-type-category">Display Serif</span>
+          </div>
+          <div className="brand-type-display">Aa</div>
+          <div className="brand-type-alphabet">
+            ABCDEFGHIJKLMNOPQRSTUVWXYZ<br/>
+            abcdefghijklmnopqrstuvwxyz<br/>
+            0123456789
+          </div>
+          <div className="brand-type-meta">
+            <div className="brand-type-meta-item">
+              <strong>Weights</strong>
+              <span>600 (Semibold)</span>
+            </div>
+            <div className="brand-type-meta-item">
+              <strong>Usage</strong>
+              <span>Headlines, section titles, brand moments</span>
+            </div>
+            <div className="brand-type-meta-item">
+              <strong>Character</strong>
+              <span>Warm, elegant, with soft terminals and optical sizing</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Inter Specimen */}
+        <div className="brand-type-specimen brand-type-specimen--inter">
+          <div className="brand-type-specimen-header">
+            <span className="brand-type-name" style={{ fontFamily: 'var(--font-sans)' }}>Inter</span>
+            <span className="brand-type-category">Sans Serif</span>
+          </div>
+          <div className="brand-type-display" style={{ fontFamily: 'var(--font-sans)', fontWeight: 400 }}>Aa</div>
+          <div className="brand-type-alphabet" style={{ fontFamily: 'var(--font-sans)' }}>
+            ABCDEFGHIJKLMNOPQRSTUVWXYZ<br/>
+            abcdefghijklmnopqrstuvwxyz<br/>
+            0123456789
+          </div>
+          <div className="brand-type-meta">
+            <div className="brand-type-meta-item">
+              <strong>Weights</strong>
+              <span>400 (Regular), 500 (Medium)</span>
+            </div>
+            <div className="brand-type-meta-item">
+              <strong>Usage</strong>
+              <span>Body text, UI elements, navigation</span>
+            </div>
+            <div className="brand-type-meta-item">
+              <strong>Character</strong>
+              <span>Clean, highly legible, with tall x-height</span>
+            </div>
+          </div>
+        </div>
+
+        {/* JetBrains Mono Specimen */}
+        <div className="brand-type-specimen brand-type-specimen--mono">
+          <div className="brand-type-specimen-header">
+            <span className="brand-type-name" style={{ fontFamily: 'var(--font-mono)' }}>JetBrains Mono</span>
+            <span className="brand-type-category">Monospace</span>
+          </div>
+          <div className="brand-type-display" style={{ fontFamily: 'var(--font-mono)', fontWeight: 400 }}>01</div>
+          <div className="brand-type-alphabet" style={{ fontFamily: 'var(--font-mono)' }}>
+            ABCDEFGHIJKLMNOPQRSTUVWXYZ<br/>
+            abcdefghijklmnopqrstuvwxyz<br/>
+            {`=> -> !== === <= >= () {} []`}
+          </div>
+          <div className="brand-type-meta">
+            <div className="brand-type-meta-item">
+              <strong>Weights</strong>
+              <span>400 (Regular), 500 (Medium)</span>
+            </div>
+            <div className="brand-type-meta-item">
+              <strong>Usage</strong>
+              <span>Code blocks, CLI commands, technical content</span>
+            </div>
+            <div className="brand-type-meta-item">
+              <strong>Character</strong>
+              <span>Ligatures for programming, high character distinction</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Type Scale */}
+        <h3 className="brand-subsection-title">Type Scale</h3>
+        <div className="brand-type-scale">
+          {typeScale.map((item, index) => (
+            <div
+              key={index}
+              className="brand-type-scale-item"
+              onClick={() => handleCopy(item.variable, item.name)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  handleCopy(item.variable, item.name)
+                }
+              }}
+            >
+              <span
+                className="brand-type-scale-sample"
+                style={{
+                  fontSize: item.name === 'Code' ? item.size : undefined,
+                  fontFamily: item.name === 'Code' ? 'var(--font-mono)' : (item.name === 'Hero' || item.name === 'Section' || item.name === 'Card Title') ? 'var(--font-display)' : 'var(--font-sans)'
+                }}
+              >
+                {item.sample}
+              </span>
+              <span className="brand-type-scale-name">{item.name}</span>
+              <span className="brand-type-scale-size">{item.px}</span>
+              <span className="brand-type-scale-variable">{item.variable}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Voice & Tone Section */}
+      <section className="brand-section scroll-animate" ref={voiceRef}>
+        <span className="brand-section-label">04</span>
+        <h2 className="brand-heading">Voice & Tone</h2>
+        <p className="brand-subheading">Rooted in Radical Candor: caring personally while challenging directly</p>
+
+        <div className="brand-philosophy">
+          <blockquote className="brand-philosophy-quote">
+            "The best feedback cares personally and challenges directly.
+            It shows understanding of context and difficulty, while never
+            hedging or softening real issues."
+          </blockquote>
+          <span className="brand-philosophy-source">Radical Candor Principles</span>
+        </div>
+
+        <div className="brand-voice-grid">
+          <div className="brand-voice-panel brand-voice-panel--harsh">
+            <div className="brand-voice-header">
+              <span className="brand-voice-badge brand-voice-badge--harsh">Harsh Mode</span>
+            </div>
+            <div className="brand-voice-example">
+              "This function is a mess. Six levels of nesting? Seriously?
+              Refactor this before it infects the rest of the codebase."
+            </div>
+            <div className="brand-voice-description">
+              Brutally honest feedback that doesn't sugar-coat issues.
+            </div>
+            <ul className="brand-voice-usecases">
+              <li>Pre-commit self-review</li>
+              <li>Finding edge cases</li>
+              <li>Security audits</li>
+              <li>When you want brutal honesty</li>
+            </ul>
+          </div>
+
+          <div className="brand-voice-panel brand-voice-panel--constructive">
+            <div className="brand-voice-header">
+              <span className="brand-voice-badge brand-voice-badge--constructive">Constructive Mode</span>
+            </div>
+            <div className="brand-voice-example">
+              "This function has grown complex. Consider extracting the
+              validation logic into a helper function. Here's a suggested approach..."
+            </div>
+            <div className="brand-voice-description">
+              Caring but direct feedback based on Radical Candor.
+            </div>
+            <ul className="brand-voice-usecases">
+              <li>Team code reviews</li>
+              <li>Mentoring situations</li>
+              <li>Documentation reviews</li>
+              <li>When teaching is the goal</li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Writing Guidelines */}
+        <h3 className="brand-subsection-title">Writing Guidelines</h3>
+        <div className="brand-dos-donts">
+          <div className="brand-guideline brand-guideline--do">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <span>Be specific: "Line 42 has a potential null reference"</span>
+          </div>
+          <div className="brand-guideline brand-guideline--do">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <span>Provide context: Explain why something matters</span>
+          </div>
+          <div className="brand-guideline brand-guideline--do">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </div>
+            <span>Offer solutions: Don't just point out problems</span>
+          </div>
+          <div className="brand-guideline brand-guideline--dont">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </div>
+            <span>Don't use vague language: "This could be better"</span>
+          </div>
+          <div className="brand-guideline brand-guideline--dont">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </div>
+            <span>Don't be condescending: "Obviously you should..."</span>
+          </div>
+          <div className="brand-guideline brand-guideline--dont">
+            <div className="brand-guideline-icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </div>
+            <span>Don't skip the why: Context builds understanding</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Toast Notification */}
+      <div className={`brand-toast ${showToast ? 'brand-toast--visible' : ''}`}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12"/>
+        </svg>
+        {toastMessage}
+      </div>
+    </>
+  )
+}

--- a/docs/app/(marketing)/brand/page.jsx
+++ b/docs/app/(marketing)/brand/page.jsx
@@ -1,0 +1,18 @@
+import BrandPageClient from './BrandPageClient'
+
+export const metadata = {
+  title: 'Brand Guidelines | Candid',
+  description: 'Official brand guidelines for Candid - logos, colors, typography, and voice.',
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
+}
+
+export default function BrandPage() {
+  return <BrandPageClient />
+}

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -1578,3 +1578,917 @@ html.dark .screenshot-caption {
     right: 0.5rem;
   }
 }
+
+/* ===== Brand Guidelines Page ===== */
+
+/* Hero */
+.brand-hero {
+  padding: 6rem 0 4rem;
+  text-align: center;
+  position: relative;
+  background: radial-gradient(ellipse at top, rgba(212, 162, 127, 0.04) 0%, rgba(253, 253, 247, 0) 70%);
+}
+
+.brand-hero-badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--accent-main);
+  background: rgba(212, 162, 127, 0.1);
+  border: 1px solid var(--accent-main);
+  border-radius: 9999px;
+  padding: 0.5rem 1.25rem;
+  margin-bottom: 2.5rem;
+}
+
+.brand-hero-wordmark {
+  font-family: var(--font-sans);
+  font-size: 9rem;
+  font-weight: 500;
+  letter-spacing: -0.04em;
+  text-transform: lowercase;
+  color: var(--text-primary);
+  margin: 0;
+  line-height: 1;
+}
+
+.brand-hero-tagline {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-style: italic;
+  font-weight: 400;
+  color: var(--accent-main);
+  margin: 1.5rem 0 0;
+}
+
+.brand-hero-intro {
+  max-width: 560px;
+  margin: 2rem auto 0;
+  font-size: 1.125rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* Sections */
+.brand-section {
+  padding: 5rem 0;
+  border-top: 1px solid var(--border-light);
+}
+
+.brand-section-label {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--accent-main);
+  margin-bottom: 0.5rem;
+}
+
+.brand-heading {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+}
+
+.brand-subheading {
+  font-size: 1.125rem;
+  color: var(--text-secondary);
+  margin: 0 0 3rem;
+  line-height: 1.6;
+}
+
+.brand-subsection-title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 4rem 0 2rem;
+  color: var(--text-primary);
+}
+
+/* Logo Section */
+.brand-logo-display {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4rem;
+  background: var(--surface-light);
+  border-radius: 20px;
+  border: 2px solid var(--border-light);
+  margin-bottom: 3rem;
+}
+
+.brand-logo-primary svg {
+  color: var(--text-primary);
+}
+
+.brand-logo-anatomy {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.brand-anatomy-item {
+  display: flex;
+  gap: 1.5rem;
+  padding: 2rem;
+  background: var(--surface-light);
+  border-radius: 16px;
+  border: 2px solid var(--border-light);
+}
+
+.brand-anatomy-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 60px;
+}
+
+.brand-anatomy-wordmark {
+  font-family: var(--font-sans);
+  font-size: 1.375rem;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  color: var(--text-primary);
+}
+
+.brand-anatomy-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.brand-anatomy-content strong {
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.brand-anatomy-content span {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* Logo Variations */
+.brand-logo-variations {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.brand-logo-variation {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  background: var(--surface-light);
+  border-radius: 16px;
+  border: 2px solid var(--border-light);
+  text-align: center;
+  transition: all 200ms ease;
+}
+
+.brand-logo-variation:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-elevated);
+}
+
+.brand-variation-preview {
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-primary);
+}
+
+.brand-wordmark-only {
+  font-family: var(--font-sans);
+  font-size: 1.5rem;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  color: var(--text-primary);
+}
+
+.brand-variation-label {
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.brand-variation-usage {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.brand-download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 150ms ease;
+  margin-top: 0.5rem;
+}
+
+.brand-download-btn:hover {
+  background: var(--accent-main);
+  border-color: var(--accent-main);
+  color: white;
+}
+
+/* Do's and Don'ts */
+.brand-dos-donts {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.brand-guideline {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 12px;
+  border: 2px solid var(--border-light);
+  background: var(--surface-light);
+}
+
+.brand-guideline--do {
+  border-color: rgba(74, 170, 136, 0.3);
+  background: rgba(74, 170, 136, 0.04);
+}
+
+.brand-guideline--dont {
+  border-color: rgba(204, 102, 102, 0.3);
+  background: rgba(204, 102, 102, 0.04);
+}
+
+.brand-guideline-icon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brand-guideline--do .brand-guideline-icon {
+  color: #4aaa88;
+}
+
+.brand-guideline--dont .brand-guideline-icon {
+  color: #c66;
+}
+
+.brand-guideline span {
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+/* Color Section */
+.brand-color-mode-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+  padding: 0.5rem 1rem;
+  background: var(--surface-light);
+  border-radius: 8px;
+  border: 1px solid var(--border-light);
+}
+
+.brand-color-mode-indicator strong {
+  color: var(--accent-main);
+}
+
+.brand-color-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.brand-color-swatch {
+  background: var(--surface-light);
+  border: 2px solid var(--border-light);
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 200ms ease;
+}
+
+.brand-color-swatch:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-elevated);
+}
+
+.brand-color-swatch:focus {
+  outline: 2px solid var(--accent-main);
+  outline-offset: 2px;
+}
+
+.brand-color-preview {
+  height: 120px;
+  transition: transform 200ms ease;
+}
+
+.brand-color-swatch:hover .brand-color-preview {
+  transform: scale(1.02);
+}
+
+.brand-color-info {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.brand-color-name {
+  font-weight: 600;
+  font-size: 1.0625rem;
+  color: var(--text-primary);
+}
+
+.brand-color-variable {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.brand-color-values {
+  margin-top: 0.25rem;
+}
+
+.brand-color-hex {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--accent-main);
+}
+
+.brand-copy-icon {
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.brand-color-swatch:hover .brand-copy-icon {
+  opacity: 0.7;
+}
+
+.brand-color-usage {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-top: 0.5rem;
+}
+
+/* Typography Section */
+.brand-type-specimen {
+  margin-bottom: 3rem;
+  padding: 2.5rem;
+  background: var(--surface-light);
+  border-radius: 20px;
+  border: 2px solid var(--border-light);
+}
+
+.brand-type-specimen-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.brand-type-name {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.brand-type-category {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-secondary);
+}
+
+.brand-type-display {
+  font-family: var(--font-display);
+  font-size: 10rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  margin-bottom: 2rem;
+}
+
+.brand-type-specimen--inter .brand-type-display,
+.brand-type-specimen--mono .brand-type-display {
+  font-family: inherit;
+}
+
+.brand-type-alphabet {
+  font-size: 1.25rem;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+  line-height: 2;
+  margin-bottom: 2rem;
+}
+
+.brand-type-meta {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.brand-type-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.brand-type-meta-item strong {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-secondary);
+}
+
+.brand-type-meta-item span {
+  font-size: 0.9375rem;
+  color: var(--text-primary);
+}
+
+/* Type Scale */
+.brand-type-scale {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  background: var(--surface-light);
+  border-radius: 16px;
+  border: 2px solid var(--border-light);
+  overflow: hidden;
+}
+
+.brand-type-scale-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-light);
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.brand-type-scale-item:last-child {
+  border-bottom: none;
+}
+
+.brand-type-scale-item:hover {
+  background: rgba(212, 162, 127, 0.04);
+}
+
+.brand-type-scale-sample {
+  font-size: 1.125rem;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.brand-type-scale-name {
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  min-width: 80px;
+}
+
+.brand-type-scale-size {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  min-width: 50px;
+  text-align: right;
+}
+
+.brand-type-scale-variable {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--accent-main);
+  min-width: 140px;
+  text-align: right;
+}
+
+/* Voice & Tone */
+.brand-philosophy {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding: 3rem;
+  background: linear-gradient(135deg, rgba(212, 162, 127, 0.08) 0%, rgba(212, 162, 127, 0.02) 100%);
+  border-radius: 20px;
+  border: 2px solid var(--accent-main);
+}
+
+.brand-philosophy-quote {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-style: italic;
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--text-primary);
+  margin: 0 0 1.5rem;
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.brand-philosophy-source {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent-main);
+}
+
+.brand-voice-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+
+.brand-voice-panel {
+  padding: 2rem;
+  border-radius: 20px;
+  border: 2px solid var(--border-light);
+  background: var(--surface-light);
+}
+
+.brand-voice-panel--harsh {
+  background: linear-gradient(135deg, rgba(204, 102, 102, 0.06) 0%, transparent 100%);
+  border-color: rgba(204, 102, 102, 0.3);
+}
+
+.brand-voice-panel--constructive {
+  background: linear-gradient(135deg, rgba(212, 162, 127, 0.08) 0%, transparent 100%);
+  border-color: var(--accent-main);
+}
+
+.brand-voice-header {
+  margin-bottom: 1.5rem;
+}
+
+.brand-voice-badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.375rem 0.75rem;
+  border-radius: 6px;
+}
+
+.brand-voice-badge--harsh {
+  background: rgba(204, 102, 102, 0.15);
+  color: #b55;
+}
+
+.brand-voice-badge--constructive {
+  background: rgba(212, 162, 127, 0.2);
+  color: var(--accent-main);
+}
+
+.brand-voice-example {
+  font-family: var(--font-display);
+  font-size: 1.125rem;
+  font-style: italic;
+  line-height: 1.6;
+  color: var(--text-primary);
+  margin-bottom: 1.5rem;
+  padding: 1.25rem;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 12px;
+}
+
+.brand-voice-description {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+}
+
+.brand-voice-usecases {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.brand-voice-usecases li {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  padding: 0.375rem 0;
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.brand-voice-usecases li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.75rem;
+  width: 6px;
+  height: 6px;
+  background: var(--accent-main);
+  border-radius: 50%;
+}
+
+/* Toast */
+.brand-toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(100px);
+  background: var(--text-primary);
+  color: var(--bg-light);
+  padding: 0.875rem 1.5rem;
+  border-radius: 9999px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  box-shadow: var(--shadow-hover);
+  opacity: 0;
+  transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.brand-toast--visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* Brand Dark Mode */
+html.dark .brand-hero {
+  background: radial-gradient(ellipse at top, rgba(212, 162, 127, 0.08) 0%, rgba(9, 9, 11, 0) 70%);
+}
+
+html.dark .brand-hero-wordmark {
+  color: var(--text-primary-dark);
+}
+
+html.dark .brand-hero-intro {
+  color: var(--text-secondary-dark);
+}
+
+html.dark .brand-section {
+  border-color: var(--border-light-dark);
+}
+
+html.dark .brand-heading {
+  color: var(--text-primary-dark);
+}
+
+html.dark .brand-subheading {
+  color: var(--text-secondary-dark);
+}
+
+html.dark .brand-subsection-title {
+  color: var(--text-primary-dark);
+}
+
+html.dark .brand-logo-display,
+html.dark .brand-anatomy-item,
+html.dark .brand-logo-variation,
+html.dark .brand-type-specimen,
+html.dark .brand-type-scale,
+html.dark .brand-voice-panel {
+  background: var(--surface-dark);
+  border-color: var(--border-light-dark);
+}
+
+html.dark .brand-logo-variation:hover {
+  border-color: var(--border-strong-dark);
+}
+
+html.dark .brand-logo-primary svg,
+html.dark .brand-variation-preview {
+  color: var(--text-primary-dark);
+}
+
+html.dark .brand-wordmark-only,
+html.dark .brand-anatomy-wordmark {
+  color: var(--text-primary-dark);
+}
+
+html.dark .brand-anatomy-content strong,
+html.dark .brand-color-name,
+html.dark .brand-type-name,
+html.dark .brand-type-display,
+html.dark .brand-type-meta-item span,
+html.dark .brand-type-scale-sample,
+html.dark .brand-voice-example,
+html.dark .brand-philosophy-quote {
+  color: var(--text-primary-dark);
+}
+
+html.dark .brand-anatomy-content span,
+html.dark .brand-variation-label,
+html.dark .brand-variation-usage,
+html.dark .brand-color-variable,
+html.dark .brand-color-usage,
+html.dark .brand-type-alphabet,
+html.dark .brand-type-category,
+html.dark .brand-type-meta-item strong,
+html.dark .brand-type-scale-name,
+html.dark .brand-type-scale-size,
+html.dark .brand-voice-description,
+html.dark .brand-voice-usecases li {
+  color: var(--text-secondary-dark);
+}
+
+html.dark .brand-download-btn {
+  border-color: var(--border-light-dark);
+  color: var(--text-secondary-dark);
+}
+
+html.dark .brand-download-btn:hover {
+  background: var(--accent-main-dark);
+  border-color: var(--accent-main-dark);
+  color: white;
+}
+
+html.dark .brand-guideline {
+  background: var(--surface-dark);
+  border-color: var(--border-light-dark);
+}
+
+html.dark .brand-guideline--do {
+  border-color: rgba(74, 170, 136, 0.3);
+  background: rgba(74, 170, 136, 0.08);
+}
+
+html.dark .brand-guideline--dont {
+  border-color: rgba(204, 102, 102, 0.3);
+  background: rgba(204, 102, 102, 0.08);
+}
+
+html.dark .brand-guideline span {
+  color: var(--text-primary-dark);
+}
+
+html.dark .brand-color-mode-indicator {
+  background: var(--surface-dark);
+  border-color: var(--border-light-dark);
+  color: var(--text-secondary-dark);
+}
+
+html.dark .brand-color-swatch {
+  background: var(--surface-dark);
+  border-color: var(--border-light-dark);
+}
+
+html.dark .brand-color-swatch:hover {
+  border-color: var(--border-strong-dark);
+}
+
+html.dark .brand-type-specimen-header,
+html.dark .brand-type-meta,
+html.dark .brand-type-scale-item {
+  border-color: var(--border-light-dark);
+}
+
+html.dark .brand-type-scale-item:hover {
+  background: rgba(212, 162, 127, 0.08);
+}
+
+html.dark .brand-philosophy {
+  background: linear-gradient(135deg, rgba(212, 162, 127, 0.12) 0%, rgba(212, 162, 127, 0.04) 100%);
+}
+
+html.dark .brand-voice-panel--harsh {
+  background: linear-gradient(135deg, rgba(204, 102, 102, 0.12) 0%, transparent 100%);
+}
+
+html.dark .brand-voice-panel--constructive {
+  background: linear-gradient(135deg, rgba(212, 162, 127, 0.12) 0%, transparent 100%);
+}
+
+html.dark .brand-voice-example {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+html.dark .brand-toast {
+  background: var(--text-primary-dark);
+  color: var(--bg-dark);
+}
+
+/* Brand Responsive */
+@media (max-width: 1024px) {
+  .brand-color-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .brand-logo-variations {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .brand-type-meta {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .brand-hero {
+    padding: 4rem 0 3rem;
+  }
+
+  .brand-hero-wordmark {
+    font-size: 4.5rem;
+  }
+
+  .brand-hero-tagline {
+    font-size: 1.375rem;
+  }
+
+  .brand-section {
+    padding: 3rem 0;
+  }
+
+  .brand-heading {
+    font-size: 2rem;
+  }
+
+  .brand-logo-anatomy {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-logo-variations {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-dos-donts {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-color-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-type-display {
+    font-size: 6rem;
+  }
+
+  .brand-type-scale-item {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    text-align: left;
+  }
+
+  .brand-type-scale-size,
+  .brand-type-scale-variable {
+    text-align: left;
+  }
+
+  .brand-voice-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-philosophy {
+    padding: 2rem;
+  }
+
+  .brand-philosophy-quote {
+    font-size: 1.25rem;
+  }
+}

--- a/docs/app/sitemap.js
+++ b/docs/app/sitemap.js
@@ -4,6 +4,9 @@ import { execSync } from 'child_process'
 
 const SITE_URL = 'https://www.candid.tools'
 
+// Paths to exclude from sitemap
+const EXCLUDED_PATHS = ['/brand']
+
 /**
  * Get the last git modification date for a file
  */
@@ -114,13 +117,19 @@ export default async function sitemap() {
   const docRoutes = await discoverDocRoutes(docsDir)
   routes.push(...docRoutes)
 
+  // Filter out excluded paths
+  const filteredRoutes = routes.filter(route => {
+    const urlPath = route.url.replace(SITE_URL, '')
+    return !EXCLUDED_PATHS.some(excluded => urlPath === excluded || urlPath.startsWith(excluded + '/'))
+  })
+
   // Sort by priority (highest first) then by URL
-  routes.sort((a, b) => {
+  filteredRoutes.sort((a, b) => {
     if (b.priority !== a.priority) {
       return b.priority - a.priority
     }
     return a.url.localeCompare(b.url)
   })
 
-  return routes
+  return filteredRoutes
 }


### PR DESCRIPTION
## Summary

Implements a comprehensive brand guidelines page at `/brand` that showcases Candid's brand identity through an editorial-style interface with interactive design system components. The page includes logo variations, interactive color swatches with copy-to-clipboard functionality, typography specimens, and voice & tone guidelines. Page is hidden from search engines via robots meta tags and excluded from the sitemap.

## Details

- **Logo Section**: Full logo display, anatomy explanation, variations (full/icon/wordmark), do's & don'ts guidelines with SVG downloads
- **Color Section**: Interactive swatches showing all brand colors with CSS variable references, clickable to copy hex values
- **Typography Section**: Type specimens for Fraunces, Inter, and JetBrains Mono with full character sets and usage guidance
- **Voice & Tone Section**: Harsh vs. Constructive modes with philosophy quote and writing guidelines

## Technical

- Server/client component split for proper Next.js metadata handling
- Dark mode fully supported via MutationObserver and CSS variables
- Responsive design at 768px and 1024px breakpoints
- Scroll-triggered animations with IntersectionObserver
- Error handling for clipboard API and file downloads

🧑‍💻 Generated with [Claude Code](https://claude.com/claude-code)