### PR TITLE
Add Decision Register feature (v1.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
         "source": "url",
         "url": "https://github.com/ron-myers/candid.git"
       },
-      "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, and seamless todo integration.",
-      "version": "1.6.1",
+      "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
+      "version": "1.7.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
-  "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, and seamless todo integration.",
-  "version": "1.6.1",
+  "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
+  "version": "1.7.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-02-21
+
 ### Added
+
+- **Decision Register** (`decisionRegister` config): Track questions and decisions during code reviews
+  - **Active knowledge base**: Before asking a question, checks the register for prior answers and reuses them automatically — the same question is never asked twice
+  - **Two consultation modes**: `"lookup"` (per-question check, default) or `"load"` (full register in context)
+  - **Automatic question capture**: Issues marked "Clarification Needed ?" are recorded in the register
+  - **User-initiated questions**: Choose "I have a question about this" during individual fix review
+  - **Resolution tracking**: Via answers, re-review detection, or explicit decline
+  - **Four statuses**: `open`, `answered`, `superseded`, `declined`
+  - **Deduplication**: Avoids duplicate entries for the same logical question
+  - **Configurable path**: Default `.candid/register/review-decision-register.md`, customizable via `decisionRegister.path`
+  - **Loop mode support**: Prior decisions auto-applied in auto mode; interactive in review-each/interactive modes
+  - **Git-friendly**: Register designed to be committed (unlike ephemeral `last-review.json`)
+  - **Documentation**: New core feature page, config reference update, homepage feature card
 
 ### Changed
 
-### Fixed
+- **Fix Confidence Levels**: Added "Clarification Needed ?" level for issues requiring author input
+- **Phase 8b (Individual Fix Review)**: New "I have a question about this" option when register is enabled
+- **candid-loop auto mode**: Prior decisions from register applied automatically across iterations
+- **candid-loop summary**: Shows decision register statistics when enabled
+- **candid-init**: Offers option to enable decision register during project initialization
 
 ## [1.6.1] - 2026-01-27
 

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -120,7 +120,7 @@ export default function HomePage() {
           style={getHeroAnimationStyle(heroLoaded, 0)}
         >
           <span className="version-dot"></span>
-          v1.6.1 Now Available for Claude Code
+          v1.7.0 Now Available for Claude Code
         </div>
         <h1
           style={getHeroAnimationStyle(heroLoaded, 100)}
@@ -308,6 +308,12 @@ export default function HomePage() {
             <div className="card">
               <h3>Config Hierarchy</h3>
               <p>CLI flags override project config (<code>.candid/config.json</code>), which overrides user config (<code>~/.candid/config.json</code>).</p>
+            </div>
+          </Link>
+          <Link href="/docs/core-features/decision-register" className="card-link">
+            <div className="card">
+              <h3>Decision Register</h3>
+              <p>Track questions raised during reviews and their resolutions. Prior answers are reused automatically so the same question is never asked twice.</p>
             </div>
           </Link>
         </div>

--- a/docs/app/docs/core-features/_meta.js
+++ b/docs/app/docs/core-features/_meta.js
@@ -6,5 +6,6 @@ export default {
   'auto-commit': 'Auto-Commit',
   're-review': 'Re-Review',
   'candid-loop': 'Candid Loop',
+  'decision-register': 'Decision Register',
   'slash-commands': 'Slash Commands',
 }

--- a/docs/app/docs/core-features/decision-register/page.mdx
+++ b/docs/app/docs/core-features/decision-register/page.mdx
@@ -1,0 +1,166 @@
+# Decision Register
+
+Track questions and decisions from code reviews. Build a searchable history of architectural decisions.
+
+## Usage
+
+Enable the decision register in your config:
+
+```json
+{
+  "decisionRegister": {
+    "enabled": true
+  }
+}
+```
+
+When enabled, Candid checks for prior answers before asking questions — and records new questions and resolutions for future sessions.
+
+## How It Works
+
+### Questions Are Raised
+
+During a review, questions appear in two ways:
+
+1. **Reviewer flags uncertainty** — When Candid can't determine the correct fix from code alone, it marks the issue as "Clarification Needed ?" and records it in the register.
+2. **You ask a question** — During individual fix review, choose "I have a question about this" to record your own question.
+
+### Prior Answers Are Reused
+
+Before raising a Clarification Needed question, Candid checks the register for a matching resolved answer. If a prior decision exists:
+
+- The question is **not re-asked**
+- The prior decision is applied automatically
+- The review shows a "Previously Decided" note referencing the original answer
+
+This prevents the same questions from being asked across review sessions and loop iterations.
+
+### Questions Are Resolved
+
+New questions (not in the register) get resolved when:
+
+- You answer during the same review session ("Here's my answer")
+- A subsequent review detects the issue was fixed (via `--re-review`)
+- You mark them as declined or not applicable
+
+## Consultation Modes
+
+### Lookup Mode (Default)
+
+```json
+{
+  "decisionRegister": {
+    "enabled": true,
+    "mode": "lookup"
+  }
+}
+```
+
+Before each Clarification Needed question, checks the register for a matching resolved answer. Efficient for large registers — only relevant entries are consulted.
+
+### Load Mode
+
+```json
+{
+  "decisionRegister": {
+    "enabled": true,
+    "mode": "load"
+  }
+}
+```
+
+Loads the entire register into context at the start of the review. The reviewer has full awareness of all prior decisions throughout. Better for small-to-medium registers where broad context helps inform the review.
+
+## Register Format
+
+The register is a markdown file at `.candid/register/review-decision-register.md`:
+
+```markdown
+# Decision Register
+
+Tracks questions raised during Candid code reviews and their resolutions.
+
+Last updated: 2026-02-21T14:30:00Z
+
+## Open Questions
+
+| # | File/Component | Question | Asked By | Asked At | Status |
+|---|----------------|----------|----------|----------|--------|
+| 3 | src/auth.ts:42 | Is the admin bypass intentional? | Reviewer | 2026-02-21 | open |
+
+## Resolved Questions
+
+| # | File/Component | Question | Asked By | Asked At | Resolution | Resolved By | Status | Resolved At |
+|---|----------------|----------|----------|----------|------------|-------------|--------|-------------|
+| 1 | src/api/users.ts:15 | Should we rate-limit? | Reviewer | 2026-02-20 | Added 100 req/min | Author | answered | 2026-02-21 |
+| 2 | src/db/queries.ts:88 | Is the N+1 acceptable? | Reviewer | 2026-02-20 | Superseded by pagination | Author | superseded | 2026-02-21 |
+```
+
+## Configuration
+
+### Enable with Defaults
+
+```json
+{
+  "decisionRegister": {
+    "enabled": true
+  }
+}
+```
+
+### Custom Path and Mode
+
+```json
+{
+  "decisionRegister": {
+    "enabled": true,
+    "path": "docs/decisions",
+    "mode": "load"
+  }
+}
+```
+
+### Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Whether to track questions during reviews |
+| `path` | string | `".candid/register"` | Directory for the register file |
+| `mode` | string | `"lookup"` | `"lookup"` (per-question check) or `"load"` (full context) |
+
+## Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `open` | Question awaiting answer |
+| `answered` | Question resolved with an answer |
+| `superseded` | Question made irrelevant by other changes |
+| `declined` | Question explicitly declined / not applicable |
+
+## Git Integration
+
+The register file should be committed to your repository. Unlike `.candid/last-review.json` (which is ephemeral review state), the decision register captures architectural decisions that benefit your whole team.
+
+If your `.gitignore` excludes the `.candid/` directory, add an exception for the register:
+
+```
+# .gitignore
+.candid/*
+!.candid/register/
+```
+
+## Loop Mode
+
+In `candid-loop`, the register works across iterations:
+
+- **Auto mode**: Prior decisions from the register are applied automatically. New Clarification Needed issues (no prior answer) are skipped and recorded as open — they don't block loop completion.
+- **Review-each / Interactive**: You can answer questions during each iteration. Answers are recorded and reused in subsequent iterations.
+- Questions from iteration 1 are available to inform iteration 2+.
+
+## Deduplication
+
+Candid avoids duplicate entries for the same logical question. If a question about the same file and topic already exists as `open`, a new duplicate is not created. If a matching question was previously resolved and the same question resurfaces, a new entry is allowed.
+
+## During Init
+
+When running `/candid-init`, you'll be asked whether to enable the decision register. This adds the config to your `.candid/config.json`.

--- a/docs/app/docs/core-features/page.mdx
+++ b/docs/app/docs/core-features/page.mdx
@@ -16,6 +16,7 @@ Everything Candid can do for your code reviews.
 - [Auto-Commit](/docs/core-features/auto-commit) — Automatically commit applied fixes
 - [Re-Review](/docs/core-features/re-review) — Track progress on fixing issues
 - [Candid Loop](/docs/core-features/candid-loop) — Run reviews in a loop until clean
+- [Decision Register](/docs/core-features/decision-register) — Track questions and decisions from reviews
 
 ## Commands
 

--- a/docs/app/docs/reference/config-options/page.mdx
+++ b/docs/app/docs/reference/config-options/page.mdx
@@ -10,7 +10,12 @@ Complete reference for Candid configuration.
   "focus": "security" | "performance" | "architecture" | "edge-case",
   "mergeTargetBranches": ["branch1", "branch2"],
   "exclude": ["pattern1", "pattern2"],
-  "commit": boolean
+  "commit": boolean,
+  "decisionRegister": {
+    "enabled": boolean,
+    "path": "string",
+    "mode": "lookup" | "load"
+  }
 }
 ```
 
@@ -53,6 +58,30 @@ Example: `["*.generated.ts", "vendor/*"]`
 Whether to auto-commit applied fixes.
 
 Default: `false`
+
+### decisionRegister
+
+Configuration for tracking questions and decisions during reviews.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Whether to track questions during reviews |
+| `path` | string | `".candid/register"` | Directory for the register file |
+| `mode` | string | `"lookup"` | How the register is consulted: `"lookup"` (per-question check) or `"load"` (full register in context) |
+
+Example:
+
+```json
+{
+  "decisionRegister": {
+    "enabled": true,
+    "path": ".candid/register",
+    "mode": "lookup"
+  }
+}
+```
+
+See [Decision Register](/docs/core-features/decision-register) for full documentation.
 
 ## Config Precedence
 

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -870,6 +870,20 @@ For quick mode: Generate ~50 lines (essential rules only)
 
 Same as before - auto-detect settings from codebase analysis.
 
+#### Decision Register Option
+
+During the interactive confirmation flow for config.json, include the decision register as a configurable option:
+
+Use AskUserQuestion:
+
+**Question:** "Enable the decision register to track questions and decisions during reviews?"
+
+**Options:**
+1. "Yes, enable decision register" → Add `"decisionRegister": { "enabled": true }` to the generated config
+2. "No, skip" → Omit the `decisionRegister` field from the generated config (disabled by default)
+
+If the user enables it, the default path (`.candid/register`) and default mode (`"lookup"`) are used. The user can customize these later in the config file.
+
 ---
 
 ## Step 11: Write Files and Show Summary

--- a/skills/candid-loop/SKILL.md
+++ b/skills/candid-loop/SKILL.md
@@ -81,6 +81,9 @@ Set up tracking variables:
 iteration = 0
 totalFixesApplied = 0
 allFixedIssues = []
+registerQuestionsRaised = 0
+registerQuestionsResolved = 0
+registerPriorDecisionsApplied = 0
 ```
 
 Display mode banner:
@@ -134,6 +137,12 @@ Invoke the candid-review skill to analyze current code:
 - Wait for review to complete and save state to `.candid/last-review.json`
 
 **Note:** candid-review will present its own fix selection prompt. In auto mode, we need to handle this by selecting "Apply all fixes". In interactive mode, we defer to the user's choices within candid-review.
+
+**Decision Register:** If the decision register is enabled in config, each candid-review iteration reads and updates the register file independently. This means:
+- Questions raised in iteration 1 are recorded in the register
+- In iteration 2+, candid-review checks the register before raising the same question again
+- If a question was answered in a previous iteration, the answer is reused automatically
+- In auto mode, Clarification Needed issues with prior answers from the register are applied without prompting
 
 #### Step 3.2: Read Review Results
 
@@ -240,6 +249,23 @@ Track fixes:
 totalFixesApplied += appliedCount
 allFixedIssues.push(...appliedIssues)
 ```
+
+**Decision Register in auto mode:**
+
+If the decision register is enabled, candid-review handles register consultation during its Step 6 (before raising Clarification Needed questions). In auto mode:
+- Prior decisions from the register are applied automatically by candid-review — log: `Applied prior decision (#N) for [file]`
+- New Clarification Needed issues (no prior answer) are NOT auto-applied — they require human input and are recorded as `open` in the register
+- These are treated as "skipped" in the loop — they do not count as remaining issues that block loop completion
+- Output: `Applied [N] prior decisions, skipped [M] new questions requiring clarification`
+
+Track register activity:
+```
+registerPriorDecisionsApplied += priorDecisionsCount
+registerQuestionsRaised += newQuestionsCount
+registerQuestionsResolved += resolvedCount
+```
+
+Where `resolvedCount` comes from candid-review's Step 10.5 output — it includes questions answered by the user during Phase 8b and auto-resolutions from re-review. Read the register file after each iteration to count newly resolved entries compared to the previous read.
 
 Continue to next iteration.
 
@@ -371,6 +397,23 @@ Summary:
 Skipped issues:
   [icon] [title] in [file]:[line]
   ...
+```
+
+**Decision Register section (add to all summary variants when register is enabled):**
+
+If `decisionRegister.enabled == true` in config, append this section to whichever summary is displayed:
+
+```
+Decision Register:
+- Prior decisions applied: [N]
+- New questions raised: [M]
+- Questions resolved: [P]
+- Open questions: [Q]
+```
+
+If open questions remain:
+```
+Open questions can be reviewed at: [registerPath]/review-decision-register.md
 ```
 
 ## Configuration

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -14,9 +14,14 @@ Valid config file format:
   "version": 1,
   "tone": "harsh" | "constructive",
   "exclude": ["*.generated.ts", "vendor/*"],
-  "focus": "security" | "performance" | "architecture",
+  "focus": "security" | "performance" | "architecture" | "edge-case",
   "mergeTargetBranches": ["main", "develop", "master"],
-  "autoCommit": true | false
+  "autoCommit": true | false,
+  "decisionRegister": {
+    "enabled": true | false,
+    "path": ".candid/register",
+    "mode": "lookup" | "load"
+  }
 }
 ```
 
@@ -35,6 +40,12 @@ Valid config file format:
   - `["trunk"]` - Trunk-based development
   - `["origin/main", "main"]` - CI environments
 - `autoCommit` (optional): Default auto-commit behavior. If `true`, automatically creates git commits after applying fixes (equivalent to always using `--auto-commit` flag). If `false` or omitted, commits only when `--auto-commit` flag is provided. Defaults to `false`.
+- `decisionRegister` (optional): Configuration for the decision register feature. Tracks questions and decisions raised during reviews. If not present, defaults to disabled.
+  - `decisionRegister.enabled` (optional): Whether to track questions and decisions during reviews. When enabled, the reviewer checks the register for prior answers before asking new questions, and records new questions/answers for future sessions. Defaults to `false`.
+  - `decisionRegister.path` (optional): Directory path where the register file is stored. The file will be named `review-decision-register.md` inside this directory. Defaults to `".candid/register"`.
+  - `decisionRegister.mode` (optional): How the register is consulted during reviews. Must be exactly `"lookup"` or `"load"`. Defaults to `"lookup"`.
+    - `"lookup"` — Before raising each Clarification Needed question, check the register for a matching resolved answer. If found, reuse the prior answer instead of re-asking. Efficient for large registers.
+    - `"load"` — Load the entire register into context at the start of the review. The reviewer has full awareness of all prior decisions throughout. Better for small-to-medium registers where broad context helps.
 
 ## Validation Rules
 
@@ -44,8 +55,9 @@ Valid config file format:
 4. **Focus field validation** - If `focus` field is present, must be exactly `"security"`, `"performance"`, `"architecture"`, or `"edge-case"` (case-sensitive). Invalid values show warning and are ignored.
 5. **mergeTargetBranches field validation** - If present, must be an array of non-empty strings. Empty arrays or invalid values show warning and are ignored.
 6. **AutoCommit field validation** - If `autoCommit` field is present, must be a boolean (`true` or `false`). Invalid values show warning and are ignored.
-7. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, and `autoCommit` are ignored for forward compatibility
-8. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
+7. **DecisionRegister field validation** - If `decisionRegister` field is present, must be an object. If `decisionRegister.enabled` is present, must be a boolean. If `decisionRegister.path` is present, must be a non-empty string. If `decisionRegister.mode` is present, must be exactly `"lookup"` or `"load"` (case-sensitive). Invalid values show warning and are ignored (feature defaults to disabled).
+8. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, `autoCommit`, and `decisionRegister` are ignored for forward compatibility
+9. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
 
 ## Config Validation Procedure
 
@@ -208,6 +220,44 @@ Using constructive tone (from interactive prompt)
   "exclude": ["*.generated.ts", "vendor/*"],
   "focus": "performance",
   "autoCommit": true
+}
+```
+
+**With decision register (default lookup mode):**
+```json
+{
+  "tone": "constructive",
+  "decisionRegister": {
+    "enabled": true
+  }
+}
+```
+
+**With decision register (load mode, custom path):**
+```json
+{
+  "tone": "harsh",
+  "decisionRegister": {
+    "enabled": true,
+    "path": "docs/decisions",
+    "mode": "load"
+  }
+}
+```
+
+**Full config with decision register:**
+```json
+{
+  "version": 1,
+  "tone": "harsh",
+  "exclude": ["*.generated.ts", "vendor/*"],
+  "focus": "performance",
+  "autoCommit": true,
+  "decisionRegister": {
+    "enabled": true,
+    "path": ".candid/register",
+    "mode": "lookup"
+  }
 }
 ```
 

--- a/skills/candid-review/SKILL.md
+++ b/skills/candid-review/SKILL.md
@@ -24,6 +24,59 @@ Check for Technical.md (project-specific standards):
 
 When Technical.md exists, you will flag violations as 📜 Standards Violation.
 
+### Step 1.5: Load Decision Register Config
+
+Check if the decision register feature is enabled. The decision register tracks questions and decisions from reviews, and — when a question has been answered before — automatically reuses the prior answer instead of re-asking.
+
+**Precedence (highest to lowest):**
+1. Project config (`.candid/config.json` → `decisionRegister`)
+2. User config (`~/.candid/config.json` → `decisionRegister`)
+3. Default (disabled)
+
+#### Check Project Config
+
+Read `.candid/config.json`:
+1. Check file existence → if missing, continue to user config
+2. Extract field: `jq -r '.decisionRegister // null'`
+3. Validate:
+   - If null → continue to user config
+   - If not object → warn "⚠️  Invalid config: decisionRegister must be an object. Ignoring." and continue
+   - Extract `enabled` (must be boolean, default `false`)
+   - Extract `path` (must be non-empty string, default `".candid/register"`)
+   - Extract `mode` (must be `"lookup"` or `"load"`, default `"lookup"`)
+4. Success: Store `registerEnabled`, `registerPath`, and `registerMode`
+
+#### Check User Config
+
+Same procedure for `~/.candid/config.json`.
+
+#### Apply Defaults
+
+If no config found:
+```
+registerEnabled = false
+registerPath = ".candid/register"
+registerMode = "lookup"
+```
+
+#### Load Existing Register (if enabled)
+
+If `registerEnabled == true`:
+
+1. Construct register file path: `${registerPath}/review-decision-register.md`
+2. Read file if it exists
+3. Parse existing entries into `existingRegisterEntries` array by reading the markdown tables:
+   - Parse Open Questions table rows into entries with status `open`
+   - Parse Resolved Questions table rows into entries with their stored status
+   - Each entry has: `id` (the `#` column), `file`, `question`, `askedBy`, `askedAt`, `resolution`, `resolvedBy`, `status`, `resolvedAt`
+4. Track `nextEntryId` = highest existing `#` + 1 (or 1 if no entries)
+
+If file does not exist, initialize `existingRegisterEntries = []` and `nextEntryId = 1`.
+
+**Output based on mode:**
+- If mode == `"load"`: `Decision register loaded ([N] entries, [M] resolved) — using loaded context`
+- If mode == `"lookup"`: `Decision register enabled (lookup mode, path: [registerPath])`
+
 ### Step 2: Detect Changes
 
 Get the code to review:
@@ -362,6 +415,39 @@ Analyze every change with the chosen tone. Categorize issues by severity:
 | 4 | Code Smell | 📋 | Maintainability: complexity, duplication, unclear code |
 | 5 | Edge Case | 🤔 | Unhandled scenarios: null, empty, concurrent, timeout |
 | 6 | Architectural | 💭 | Design concerns: coupling, SRP violations, patterns |
+| 7 | Clarification Needed | ? | Question for the author — cannot determine correct action from code alone |
+
+### Clarification Needed ? (Decision Register)
+
+When `registerEnabled == true` (from Step 1.5), you may mark issues as **Clarification Needed ?** when the correct fix depends on information you cannot determine from the code, tests, or Technical.md alone.
+
+**Use this when:**
+- Business intent is ambiguous (e.g., "Is this permission check intentionally absent?")
+- Design tradeoffs need author input (e.g., "Was performance or readability prioritized here?")
+- Code appears to contradict Technical.md but might be an intentional exception
+- A configuration value seems arbitrary and may have a business reason
+
+**Do NOT use this for:**
+- Issues where the fix is clear from the code
+- Style preferences or subjective opinions
+- Issues covered by existing focus mode checklists
+- When `registerEnabled == false` — never use this confidence level if the register is disabled
+
+**Register consultation before raising a question:**
+
+Before marking an issue as Clarification Needed, check `existingRegisterEntries` for an existing resolved answer:
+
+1. Search for entries matching the same file/component AND a similar question topic
+2. Match by: file path (exact or same file) + normalized question text (case-insensitive, ignore punctuation)
+
+**When a matching resolved answer is found:**
+- Do NOT mark the issue as Clarification Needed
+- Instead, apply the previous decision and present it as a "Previously Decided" item in the review output (see the "Previously Decided example" after Step 7)
+- This prevents the same question from being asked across review sessions
+
+**When NO matching answer is found:**
+- Mark as Clarification Needed ? as normal
+- The question will be recorded in the register at Step 10.5
 
 ### What to Look For
 
@@ -547,6 +633,21 @@ Include confidence in every issue. Users can use this to decide whether to apply
 > const email = user.email;
 > ```
 
+*Clarification Needed example (when register is enabled and no prior answer found):*
+> ### ? Rate limiting absent on public endpoint
+> **File:** src/api/public.ts:23
+> **Confidence:** Clarification Needed ?
+> **Question:** This endpoint has no rate limiting. Was this intentional (e.g., health check) or should rate limiting be added?
+> **Impact:** If this should be rate-limited, it could be vulnerable to abuse. If intentional, please confirm so we can document the decision.
+
+*Previously Decided example (when register has a matching resolved answer):*
+> ### ✓ Previously decided: Rate limiting on public endpoint
+> **File:** src/api/public.ts:23
+> **Prior Decision (#4):** "Yes, add rate limiting at 100 req/min" — answered by Author on 2026-02-20
+> **Action:** Applied consistent with prior decision.
+
+**Note:** Previously Decided items are informational — they show the user that a prior decision was reused. They are NOT included in the fix selection prompt (Step 8) since they have already been resolved.
+
 ### Step 8: Fix Selection (MANDATORY)
 
 **⚠️ CRITICAL: This step is MANDATORY. If ANY issues were identified in Steps 6-7, you MUST present the fix selection prompt. Never skip this step when issues exist.**
@@ -584,6 +685,8 @@ Loop through each issue identified in Steps 6-7. For each issue:
    - Show icon, title, file location, and brief problem summary
 
 2. **Call AskUserQuestion:**
+
+   **For standard issues (Safe ✓ / Verify ⚡ / Careful ⚠️):**
    - **Question:** "Apply this fix?"
    - **Context to display before options:**
      ```
@@ -594,10 +697,30 @@ Loop through each issue identified in Steps 6-7. For each issue:
    - **Options:**
      - "Yes, apply this fix"
      - "No, skip this fix"
+     - "I have a question about this" (only if `registerEnabled == true`)
+
+   **For Clarification Needed ? issues (only when register is enabled):**
+   - **Question:** "This issue needs your input:"
+   - **Context to display before options:**
+     ```
+     ? [Title]
+     File: [path/to/file.ts:line]
+     Question: [The question from the issue]
+     ```
+   - **Options:**
+     - "Here's my answer" — Use a follow-up AskUserQuestion to get the answer text. Record the answer in the register entry as `answered` with the user's response.
+     - "Skip for now" — Leave the register entry as `open`. Continue to next issue.
+     - "No longer relevant / Superseded" — Mark the register entry as `superseded` (the question was made irrelevant by other changes). Continue to next issue.
+     - "Not applicable / Decline" — Mark the register entry as `declined`. Continue to next issue.
 
 3. **Track selection:**
    - If "Yes" → Add this issue to selectedFixes array
    - If "No" → Continue to next issue without adding
+   - If "I have a question about this" → Use a follow-up AskUserQuestion: "What is your question about this issue?" Record the user's question as a new register entry (`status: open`, `Asked By: Author`, file/component from the issue). Continue to next issue without adding to selectedFixes.
+   - If "Here's my answer" → Mark the Clarification Needed entry as `answered`. If the answer implies a fix should be applied, add to selectedFixes. If the answer is informational only, continue without adding.
+   - If "Skip for now" → Continue to next issue
+   - If "No longer relevant / Superseded" → Mark as `superseded`, continue to next issue
+   - If "Not applicable / Decline" → Mark as `declined`, continue to next issue
 
 Repeat for all issues. After completing the loop, proceed to Phase 8c.
 
@@ -776,6 +899,86 @@ Run /candid-review --re-review to compare against this review later.
 
 **Note:** The `.candid/last-review.json` should typically be added to `.gitignore` as it's user-specific state.
 
+### Step 10.5: Update Decision Register
+
+**Pre-condition:** Only execute this step if `registerEnabled == true` (loaded in Step 1.5).
+
+If `registerEnabled == false`, skip this step entirely and proceed to Output Structure.
+
+#### 1. Collect new entries from this review
+
+Gather all register entries accumulated during Steps 6-8:
+- Issues marked with **Clarification Needed ?** confidence → new entries with `status: open`, `Asked By: Reviewer`
+- User questions from Phase 8b "I have a question about this" → new entries with `status: open`, `Asked By: Author`
+- Resolved entries from Phase 8b "Here's my answer" → update entry to `status: answered` with user's response
+- Superseded entries from Phase 8b "No longer relevant / Superseded" → update entry to `status: superseded`
+- Declined entries from Phase 8b "Not applicable / Decline" → update entry to `status: declined`
+
+#### 2. Check for auto-resolutions
+
+If `--re-review` mode was used and previous review state exists:
+- For each `open` entry in `existingRegisterEntries` where the corresponding issue is now in the ✅ Fixed category of the re-review comparison → mark as `answered` with resolution: "Issue resolved in code (detected by re-review)", `Resolved By: Author`
+
+#### 3. Deduplicate
+
+Before adding new entries, check against `existingRegisterEntries`:
+- Compare by file path (exact match) + normalized question text (case-insensitive, strip trailing punctuation)
+- If a matching entry exists with status `open` → do NOT add duplicate. Note in output: "Matches existing question #[N]"
+- If a matching entry exists with status `answered`/`superseded`/`declined` → allow new entry (the question has resurfaced)
+
+#### 4. Create register directory if needed
+
+```bash
+mkdir -p [registerPath]
+```
+
+#### 5. Generate register markdown
+
+Write the complete register file with this structure:
+
+```markdown
+# Decision Register
+
+Tracks questions raised during Candid code reviews and their resolutions.
+
+Last updated: [ISO timestamp]
+
+## Open Questions
+
+| # | File/Component | Question | Asked By | Asked At | Status |
+|---|----------------|----------|----------|----------|--------|
+[rows for entries with status open, sorted by # ascending]
+
+## Resolved Questions
+
+| # | File/Component | Question | Asked By | Asked At | Resolution | Resolved By | Status | Resolved At |
+|---|----------------|----------|----------|----------|------------|-------------|--------|-------------|
+[rows for entries with status answered/superseded/declined, sorted by # ascending]
+```
+
+If no open questions exist, show: `_No open questions._` after the Open Questions table header.
+If no resolved questions exist, show: `_No resolved questions yet._` after the Resolved Questions table header.
+
+**Scalability:** If the Resolved Questions section exceeds 100 entries, keep only the most recent 100. Add a note: `_Showing most recent 100 resolved questions. [N] older entries removed._`
+
+#### 6. Write file
+
+Write to `${registerPath}/review-decision-register.md` using the Write tool.
+
+#### 7. Output
+
+```
+Decision register updated: [N] open, [M] resolved ([P] new this review)
+Register saved to [registerPath]/review-decision-register.md
+```
+
+If new entries were added or entries were resolved this review:
+```
+Consider committing [registerPath]/review-decision-register.md to preserve decision history.
+```
+
+**Note:** Unlike `.candid/last-review.json`, the decision register should be committed to the repository — it captures architectural decisions and rationale that benefit the whole team.
+
 ## Output Structure
 
 Present your review in this order:
@@ -787,9 +990,12 @@ Present your review in this order:
 5. **📋 Code Smells** - Consider fixing (if any)
 6. **🤔 Missing Edge Cases** - Scenarios to handle (if any)
 7. **💭 Architectural Concerns** - Design issues (if any)
-8. **✅ What's Good** - Acknowledge good practices (keep brief)
-9. **Fix Selection** - Multi-select prompt for which fixes to apply (remind user to scroll up for context)
-10. **Commit Summary** - If --auto-commit was used and successful, confirmation message
+8. **? Clarification Needed** - Questions for the author (if any, only when register enabled)
+9. **✓ Previously Decided** - Prior decisions reused from register (if any, only when register enabled)
+10. **✅ What's Good** - Acknowledge good practices (keep brief)
+11. **Fix Selection** - Multi-select prompt for which fixes to apply (remind user to scroll up for context)
+12. **Commit Summary** - If --auto-commit was used and successful, confirmation message
+13. **Decision Register Summary** - If register enabled, show update summary (new questions, resolved, open count)
 
 ### Re-Review Output Structure
 


### PR DESCRIPTION
## Summary

Introduces the Decision Register feature — an active knowledge base for tracking questions and decisions from code reviews. Before asking any question, Candid checks the register for prior answers and reuses them automatically, preventing the same questions from being asked across review sessions and loop iterations.

## Key Features

- **Active knowledge base**: Checks register for prior answers before raising Clarification Needed questions
- **Two consultation modes**: `"lookup"` (per-question check, efficient for large registers) and `"load"` (full context, better for smaller registers)
- **Automatic question capture**: Issues marked "Clarification Needed ?" are recorded in the register
- **User-initiated questions**: New "I have a question about this" option during individual fix review
- **Resolution tracking**: Four statuses (open, answered, superseded, declined)
- **Deduplication**: Prevents duplicate entries for the same logical question
- **Loop mode integration**: Prior decisions auto-applied in auto mode; interactive in review-each/interactive modes
- **Git-friendly**: Designed to be committed (unlike ephemeral `.candid/last-review.json`)

## Changes

- Added `decisionRegister` config field with schema validation and examples
- Added Step 1.5 to load and parse register configuration
- Added Step 10.5 to update register with new entries
- Enhanced Phase 8b with new interaction options and Clarification Needed handling
- Integrated into candid-loop for cross-iteration decision reuse
- Created comprehensive feature documentation page
- Updated homepage feature cards and navigation
- Version bump: 1.6.1 → 1.7.0

## Code Review Improvements

Incorporated feedback from code review:
- Cleaned up empty Unreleased subsections in CHANGELOG
- Added "edge-case" to focus field schema
- Updated plugin descriptions to mention decision register
- Simplified candid-init skip option wording
- Added .gitignore guidance for register directory

## Testing

All 6 implementation tasks completed and verified. Code review iteration 1 found 5 issues, all fixed. Iteration 2 verification found no remaining issues.