### PR TITLE
Docs and version updates for v1.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-04-19
+
+### Added
+
+- **Post-Merge Command** (`ship.postMergeCommand`): New config field to run a shell command after auto-merge is successfully enabled
+  - Fires after `gh pr merge --squash --auto` succeeds — useful for triggering deployments, notifications, or cleanup scripts
+  - Conditional execution: only runs when `autoMerge` is enabled and the auto-merge command succeeds
+  - Non-blocking: if the command fails, a warning is shown but the workflow is not aborted (the PR is already merging)
+  - Shown in ship plan display and summary output
+  - Documented in CONFIG.md, candid-ship docs, and example configs
+
 ## [1.10.0] - 2026-03-17
 
 ### Added

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,46 +76,14 @@ npm run bump <major|minor|patch>
 1. ✅ Validates git working directory is clean
 2. ✅ Reads current version from `.claude-plugin/plugin.json`
 3. ✅ Calculates new version
-4. ✅ Updates `.claude-plugin/plugin.json`
+4. ✅ Updates `.claude-plugin/plugin.json` (single source of truth)
 5. ✅ Updates `.claude-plugin/marketplace.json`
 6. ✅ Updates `CHANGELOG.md` (adds new version header with date)
 7. ✅ Creates git commit: `"Bump plugin version to X.Y.Z"`
 8. ✅ Creates git tag: `vX.Y.Z`
 9. ✅ Pushes to `origin/stable`
 
-### 2.2 Update Website Version Badge (CRITICAL - Often Missed!)
-
-**This step is NOT automated and has been missed in recent releases.**
-
-Update the version badge on the homepage:
-
-**File**: `docs/app/(marketing)/page.jsx`
-
-**Line 118**: Change the version number:
-
-```jsx
-// BEFORE
-<span className="version-dot"></span>
-v1.5.0 Now Available for Claude Code
-
-// AFTER (example for 1.6.0)
-<span className="version-dot"></span>
-v1.6.0 Now Available for Claude Code
-```
-
-**Why this matters**: The homepage is the first thing users see. An outdated version number creates confusion and makes the site look unmaintained.
-
-### 2.3 Commit Website Version Update
-
-After updating the homepage version:
-
-```bash
-git add docs/app/(marketing)/page.jsx
-git commit -m "Update homepage version badge to v1.6.0
-
-Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>"
-git push origin HEAD:stable
-```
+The homepage version badge (`docs/app/(marketing)/page.jsx`) reads directly from `plugin.json` at build time — no manual update needed.
 
 ## Phase 3: Post-Release Verification
 
@@ -193,7 +161,7 @@ git revert HEAD
 git push origin HEAD:stable
 ```
 
-**Then**: Manually revert any other changes (like the website version badge).
+**Then**: Manually revert any other changes (CHANGELOG content, etc.).
 
 ## Complete Release Checklist
 

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import { trackEvent, EVENTS } from '../components/trackEvent'
 import Pre from '../components/Pre'
 import SoftwareApplicationSchema from '../components/schema/SoftwareApplicationSchema'
+import pluginJson from '../../../.claude-plugin/plugin.json'
 
 const SCREENSHOTS = [
   {
@@ -120,7 +121,7 @@ export default function HomePage() {
           style={getHeroAnimationStyle(heroLoaded, 0)}
         >
           <span className="version-dot"></span>
-          v1.10.0 Now Available for Claude Code
+          v{pluginJson.version} Now Available for Claude Code
         </div>
         <h1
           style={getHeroAnimationStyle(heroLoaded, 100)}

--- a/docs/app/docs/core-features/candid-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-ship/page.mdx
@@ -162,7 +162,7 @@ If the command fails, a warning is shown but the workflow is **not** aborted —
 
 ## Output Examples
 
-### Success
+### Success (with post-merge command)
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -177,6 +177,20 @@ Merge:    Auto-merge enabled
 Post-merge: PASS
 ```
 
+### Success (without post-merge command)
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Ship Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Review:   PASS (3 iterations, 7 issues fixed)
+Build:    PASS
+Tests:    PASS
+PR:       https://github.com/org/repo/pull/42
+Merge:    Auto-merge enabled
+```
+
 ### With Skipped Steps
 
 ```
@@ -189,7 +203,6 @@ Build:    PASS
 Tests:    SKIPPED
 PR:       https://github.com/org/repo/pull/42
 Merge:    Manual merge required
-Post-merge: SKIPPED
 ```
 
 ### Build Failure

--- a/docs/app/docs/core-features/candid-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-ship/page.mdx
@@ -77,7 +77,8 @@ Add to `.candid/config.json`:
     "testCommand": "npm test",
     "targetBranch": "stable",
     "autoMerge": false,
-    "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware"
+    "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware",
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
   }
 }
 ```
@@ -89,6 +90,7 @@ Add to `.candid/config.json`:
 | `targetBranch` | string | first `mergeTargetBranches` or `"main"` | Branch to target for the PR. |
 | `autoMerge` | boolean | `false` | Auto-merge the PR after creation. |
 | `additionalPrompt` | string | — | Extra context passed to candid-loop/review during the review step. |
+| `postMergeCommand` | string | — | Shell command to run after auto-merge succeeds. Skipped if auto-merge is disabled or fails. |
 
 ## Additional Prompt
 
@@ -115,6 +117,26 @@ gh pr merge --squash --auto
 This means the PR will merge automatically once all branch protection checks pass. If your repository doesn't have auto-merge enabled, you'll see a warning but the PR is still created.
 
 > **Note:** Auto-merge requires the "Allow auto-merge" setting to be enabled in your GitHub repository settings under Settings → General → Pull Requests.
+
+## Post-Merge Command
+
+When `postMergeCommand` is configured, candid-ship runs the specified shell command after auto-merge is successfully enabled. This is useful for triggering deployments, sending notifications, or running cleanup scripts.
+
+```json
+{
+  "ship": {
+    "autoMerge": true,
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
+  }
+}
+```
+
+The command only runs when all three conditions are met:
+- `postMergeCommand` is configured
+- `autoMerge` is enabled
+- `gh pr merge --squash --auto` succeeded
+
+If the command fails, a warning is shown but the workflow is **not** aborted — the PR is already created and auto-merge is in progress.
 
 ## Examples
 
@@ -152,6 +174,7 @@ Build:    PASS
 Tests:    PASS
 PR:       https://github.com/org/repo/pull/42
 Merge:    Auto-merge enabled
+Post-merge: PASS
 ```
 
 ### With Skipped Steps
@@ -166,6 +189,7 @@ Build:    PASS
 Tests:    SKIPPED
 PR:       https://github.com/org/repo/pull/42
 Merge:    Manual merge required
+Post-merge: SKIPPED
 ```
 
 ### Build Failure
@@ -203,7 +227,8 @@ A typical shipping workflow with candid-ship configured:
     "testCommand": "npm test",
     "targetBranch": "stable",
     "autoMerge": true,
-    "additionalPrompt": "Ensure error handling covers all async operations"
+    "additionalPrompt": "Ensure error handling covers all async operations",
+    "postMergeCommand": "echo 'Shipped successfully!'"
   }
 }
 ```

--- a/examples/ship/config.json
+++ b/examples/ship/config.json
@@ -7,6 +7,7 @@
     "testCommand": "npm test",
     "targetBranch": "main",
     "autoMerge": false,
-    "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware"
+    "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware",
+    "postMergeCommand": "echo 'Ship complete!'"
   }
 }

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -9,7 +9,6 @@ type BumpType = 'major' | 'minor' | 'patch';
 const PLUGIN_JSON_PATH = '../.claude-plugin/plugin.json';
 const MARKETPLACE_JSON_PATH = '../.claude-plugin/marketplace.json';
 const CHANGELOG_PATH = '../CHANGELOG.md';
-const HOMEPAGE_PATH = '../docs/app/(marketing)/page.jsx';
 const TARGET_BRANCH = 'stable';
 
 /**
@@ -174,37 +173,12 @@ async function updateChangelog(newVersion: string): Promise<void> {
 }
 
 /**
- * Update version badge in homepage
- */
-async function updateHomepage(newVersion: string): Promise<void> {
-  try {
-    const content = await readFile(HOMEPAGE_PATH, 'utf-8');
-
-    // Match the version badge pattern: v1.2.3 Now Available for Claude Code
-    const versionBadgePattern = /v\d+\.\d+\.\d+ Now Available for Claude Code/;
-    const newVersionBadge = `v${newVersion} Now Available for Claude Code`;
-
-    if (!versionBadgePattern.test(content)) {
-      throw new Error(`Could not find version badge pattern in ${HOMEPAGE_PATH}`);
-    }
-
-    const updatedContent = content.replace(versionBadgePattern, newVersionBadge);
-
-    await writeFile(HOMEPAGE_PATH, updatedContent);
-    console.log(`✅ Updated ${HOMEPAGE_PATH}`);
-  } catch (error) {
-    console.error(`❌ Failed to update ${HOMEPAGE_PATH}`);
-    throw error;
-  }
-}
-
-/**
  * Create git commit and tag
  */
 function gitCommitAndTag(version: string): void {
   try {
     // Stage the updated files
-    exec(`git add ${PLUGIN_JSON_PATH} ${MARKETPLACE_JSON_PATH} ${CHANGELOG_PATH} ${HOMEPAGE_PATH}`);
+    exec(`git add ${PLUGIN_JSON_PATH} ${MARKETPLACE_JSON_PATH} ${CHANGELOG_PATH}`);
 
     // Create commit with co-author
     const commitMessage = `Bump plugin version to ${version}\n\nCo-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>`;
@@ -274,7 +248,6 @@ async function main(): Promise<void> {
   await updatePluginJson(newVersion);
   await updateMarketplaceJson(newVersion);
   await updateChangelog(newVersion);
-  await updateHomepage(newVersion);
   console.log('');
 
   // Git operations

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -27,7 +27,8 @@ Valid config file format:
     "testCommand": "npm test",
     "targetBranch": "stable",
     "autoMerge": false,
-    "additionalPrompt": "Focus on security"
+    "additionalPrompt": "Focus on security",
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
   }
 }
 ```
@@ -59,6 +60,7 @@ Valid config file format:
   - `ship.targetBranch` (optional): Branch name for PR target. Defaults to first entry in `mergeTargetBranches` or `"main"`. Must be a non-empty string.
   - `ship.autoMerge` (optional): Whether to auto-merge the PR after creation via `gh pr merge --squash --auto`. Defaults to `false`. Must be a boolean.
   - `ship.additionalPrompt` (optional): Extra prompt text passed to candid-loop/candid-review as additional review context. Must be a non-empty string.
+  - `ship.postMergeCommand` (optional): Shell command to run after auto-merge is successfully enabled. Only executes when `autoMerge` is `true` and `gh pr merge --squash --auto` succeeds. If the command fails, a warning is shown but the workflow is not aborted. Must be a non-empty string.
 
 ## Validation Rules
 
@@ -69,7 +71,7 @@ Valid config file format:
 5. **mergeTargetBranches field validation** - If present, must be an array of non-empty strings. Empty arrays or invalid values show warning and are ignored.
 6. **AutoCommit field validation** - If `autoCommit` field is present, must be a boolean (`true` or `false`). Invalid values show warning and are ignored.
 7. **DecisionRegister field validation** - If `decisionRegister` field is present, must be an object. If `decisionRegister.enabled` is present, must be a boolean. If `decisionRegister.path` is present, must be a non-empty string. If `decisionRegister.mode` is present, must be exactly `"lookup"` or `"load"` (case-sensitive). Invalid values show warning and are ignored (feature defaults to disabled).
-8. **Ship field validation** - If `ship` field is present, must be an object. If `ship.buildCommand` is present, must be a non-empty string. If `ship.testCommand` is present, must be a non-empty string. If `ship.targetBranch` is present, must be a non-empty string. If `ship.autoMerge` is present, must be a boolean. If `ship.additionalPrompt` is present, must be a non-empty string. Invalid values show warning and are ignored.
+8. **Ship field validation** - If `ship` field is present, must be an object. If `ship.buildCommand` is present, must be a non-empty string. If `ship.testCommand` is present, must be a non-empty string. If `ship.targetBranch` is present, must be a non-empty string. If `ship.autoMerge` is present, must be a boolean. If `ship.additionalPrompt` is present, must be a non-empty string. If `ship.postMergeCommand` is present, must be a non-empty string. Invalid values show warning and are ignored.
 9. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, `autoCommit`, `decisionRegister`, and `ship` are ignored for forward compatibility
 10. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
 
@@ -307,7 +309,8 @@ Using constructive tone (from interactive prompt)
     "testCommand": "npm test",
     "targetBranch": "stable",
     "autoMerge": true,
-    "additionalPrompt": "Ensure error handling covers all async operations"
+    "additionalPrompt": "Ensure error handling covers all async operations",
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
   }
 }
 ```

--- a/skills/candid-ship/SKILL.md
+++ b/skills/candid-ship/SKILL.md
@@ -80,6 +80,7 @@ If the `ship` field exists, extract:
 - `targetBranch` (string) — PR target branch
 - `autoMerge` (boolean) — auto-merge after PR creation
 - `additionalPrompt` (string) — extra context for candid-loop/review
+- `postMergeCommand` (string) — shell command to run after auto-merge succeeds
 
 Output when loading: `Using ship settings from project config`
 
@@ -112,6 +113,7 @@ testCommand = null (skip tests if not set)
 targetBranch = resolved per above
 autoMerge = false
 additionalPrompt = null
+postMergeCommand = null (skip if not set)
 ```
 
 #### Validate Current Branch != Target Branch
@@ -147,6 +149,7 @@ Steps:
   3. 🧪 Tests: [testCommand]                [or SKIP — not configured]
   4. 📋 Create pull request
   5. 🔀 Auto-merge: enabled                 [or disabled]
+  6. 🚀 Post-merge: [postMergeCommand]      [or SKIP — not configured]
 ```
 
 If `additionalPrompt` is set:
@@ -344,7 +347,40 @@ If auto-merge succeeds:
 Auto-merge enabled. PR will merge when checks pass.
 ```
 
-### Step 9: Display Summary
+### Step 9: Run Post-Merge Command (Conditional)
+
+**Skip if** `postMergeCommand` is not configured. Output: `Skipping post-merge command (not configured)`
+
+**Skip if** `autoMerge` is `false`. Output: `Skipping post-merge command (auto-merge disabled)`
+
+**Skip if** auto-merge failed in Step 8. Output: `Skipping post-merge command (auto-merge failed)`
+
+If all conditions are met (command configured, auto-merge enabled, auto-merge succeeded):
+
+Display:
+```
+Step 6/6: Running post-merge command...
+$ [postMergeCommand]
+```
+
+Execute the post-merge command:
+```bash
+[postMergeCommand]
+```
+
+**If command fails** (non-zero exit code):
+```
+⚠️  Post-merge command failed: [error output]
+PR is still merging at: [URL]
+```
+Do NOT abort — the PR was already created and auto-merge is enabled. Continue to summary.
+
+**If command succeeds:**
+```
+Post-merge command completed.
+```
+
+### Step 10: Display Summary
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -356,6 +392,7 @@ Build:    [PASS | SKIPPED]
 Tests:    [PASS | SKIPPED]
 PR:       [URL]
 Merge:    [Auto-merge enabled | Manual merge required | Auto-merge failed]
+Post-merge: [PASS | SKIPPED | FAILED | N/A]
 ```
 
 ## Configuration
@@ -372,7 +409,8 @@ Add to `.candid/config.json`:
     "testCommand": "npm test",
     "targetBranch": "stable",
     "autoMerge": false,
-    "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware"
+    "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware",
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
   }
 }
 ```
@@ -386,6 +424,7 @@ Add to `.candid/config.json`:
 | `ship.targetBranch` | string | first `mergeTargetBranches` or `"main"` | Branch to target for PR. |
 | `ship.autoMerge` | boolean | `false` | Auto-merge PR after creation via `gh pr merge --squash --auto`. |
 | `ship.additionalPrompt` | string | `null` | Extra context passed to candid-loop/review. |
+| `ship.postMergeCommand` | string | `null` | Shell command to run after auto-merge succeeds. Skipped if auto-merge is disabled or fails. |
 
 ### Examples
 
@@ -406,7 +445,8 @@ Add to `.candid/config.json`:
     "testCommand": "npm test",
     "targetBranch": "stable",
     "autoMerge": true,
-    "additionalPrompt": "Ensure error handling covers all async operations"
+    "additionalPrompt": "Ensure error handling covers all async operations",
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
   }
 }
 ```

--- a/skills/candid-ship/SKILL.md
+++ b/skills/candid-ship/SKILL.md
@@ -134,6 +134,8 @@ If no commits ahead: abort with `No commits ahead of [targetBranch]. Nothing to 
 
 ### Step 3: Display Plan
 
+Calculate `totalSteps = 5 + (postMergeCommand is set ? 1 : 0)`. Use this value as the step total in all step progress displays throughout the workflow.
+
 Show what will be executed:
 
 ```
@@ -149,7 +151,7 @@ Steps:
   3. 🧪 Tests: [testCommand]                [or SKIP — not configured]
   4. 📋 Create pull request
   5. 🔀 Auto-merge: enabled                 [or disabled]
-  6. 🚀 Post-merge: [postMergeCommand]      [or SKIP — not configured]
+  6. 🚀 Post-merge: [postMergeCommand]      [only shown if postMergeCommand is set]
 ```
 
 If `additionalPrompt` is set:
@@ -177,7 +179,7 @@ If "No, cancel": exit with `Ship cancelled.`
 
 Display:
 ```
-Step 1/5: Running code review...
+Step 1/[totalSteps]: Running code review...
 ```
 
 Invoke candid-loop via the Skill tool: `/candid-loop`
@@ -205,7 +207,7 @@ If skipped due to flag: Output: `Skipping build (--skip-build)`
 
 Display:
 ```
-Step 2/5: Running build...
+Step 2/[totalSteps]: Running build...
 $ [buildCommand]
 ```
 
@@ -235,7 +237,7 @@ If skipped due to flag: Output: `Skipping tests (--skip-tests)`
 
 Display:
 ```
-Step 3/5: Running tests...
+Step 3/[totalSteps]: Running tests...
 $ [testCommand]
 ```
 
@@ -260,7 +262,7 @@ Tests passed.
 
 Display:
 ```
-Step 4/5: Creating pull request...
+Step 4/[totalSteps]: Creating pull request...
 ```
 
 #### 7.1: Generate PR Title
@@ -327,7 +329,7 @@ If `autoMerge` is `true`:
 
 Display:
 ```
-Step 5/5: Enabling auto-merge...
+Step 5/[totalSteps]: Enabling auto-merge...
 ```
 
 ```bash
@@ -359,7 +361,7 @@ If all conditions are met (command configured, auto-merge enabled, auto-merge su
 
 Display:
 ```
-Step 6/6: Running post-merge command...
+Step 6/[totalSteps]: Running post-merge command...
 $ [postMergeCommand]
 ```
 


### PR DESCRIPTION
## Summary

- feat: add ship.postMergeCommand for post-merge script execution
- refactor: read version badge from plugin.json at build time (eliminates hard-coded version copy in page.jsx)
- fix: correct step counter display and output examples in candid-ship
- docs: add candid-ship documentation to site
- Bump plugin version to 1.11.0

## Verification

- Review: PASS
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*