### PR TITLE
candid-init: add --optimize / --auto-optimize flags

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-04-25
+
+### Added
+
+- **Integrated optimization stage in `/candid-init`**: Two new opt-in flags run the `/candid-optimize` audit immediately after Technical.md and config.json are generated, so users get a tightened file in one command (closes #19)
+  - `--optimize` — runs the full candid-optimize audit (Technical.md + excludes + register + config) in interactive mode after generation; user chooses to apply all, review each, or skip
+  - `--auto-optimize` — runs the audit and applies all recommendations without prompting
+  - Default behavior unchanged: when neither flag is passed, candid-init writes the raw generated files and prints a `Tip: run /candid-optimize…` hint
+  - Implementation delegates to the existing candid-optimize skill — no analysis logic is duplicated, so verbose/duplicate/low-signal heuristics stay in one place
+  - Useful for thorough mode where 5 parallel generation sub-agents can produce cross-section duplicates and verbose rules without joint awareness
+
 ## [1.11.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Define project-specific standards that Candid enforces during reviews. Violation
 /candid-init minimal            # Minimal starter
 /candid-init --effort quick     # Fast analysis (~30 sec)
 /candid-init --effort thorough  # Deep analysis (~3-5 min, default)
+/candid-init --optimize         # Run /candid-optimize after generation
 ```
 
 **Or copy a template:**

--- a/commands/candid-init.md
+++ b/commands/candid-init.md
@@ -12,6 +12,12 @@ args:
   - name: effort
     description: Analysis depth (quick, medium, thorough). Default is thorough.
     required: false
+  - name: optimize
+    description: Run /candid-optimize after generation with interactive apply
+    required: false
+  - name: auto-optimize
+    description: Run /candid-optimize after generation and apply all recommendations without prompting
+    required: false
 ---
 
 Generate a project-specific Technical.md file by analyzing your codebase.
@@ -26,4 +32,6 @@ Usage:
 /candid-init --effort medium    # Balanced analysis (~1-2 min)
 /candid-init --effort thorough  # Deep analysis (~3-5 min, default)
 /candid-init --output .claude/Technical.md  # Custom output path
+/candid-init --optimize         # Run /candid-optimize after generation (interactive)
+/candid-init --auto-optimize    # Run /candid-optimize and apply all recommendations
 ```

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -23,3 +23,6 @@ next-env.d.ts
 # Generated at build time from root CHANGELOG.md
 app/docs/resources/changelog/page.mdx
 
+# Generated at build time from root .claude-plugin/plugin.json
+data/plugin.json
+

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import { trackEvent, EVENTS } from '../components/trackEvent'
 import Pre from '../components/Pre'
 import SoftwareApplicationSchema from '../components/schema/SoftwareApplicationSchema'
-import pluginJson from '../../../.claude-plugin/plugin.json'
+import pluginJson from '../../data/plugin.json'
 
 const SCREENSHOTS = [
   {

--- a/docs/app/docs/core-features/slash-commands/page.mdx
+++ b/docs/app/docs/core-features/slash-commands/page.mdx
@@ -77,6 +77,8 @@ Generate a Technical.md file by analyzing your codebase.
 | `--template <name>` | Use a specific template (minimal, react, node, python) |
 | `--effort <level>` | Analysis depth: quick (~30s), medium (~1-2min), thorough (~5-10min, default) |
 | `--output <path>` | Custom output path (default: .candid/Technical.md) |
+| `--optimize` | Run `/candid-optimize` after generation with interactive apply |
+| `--auto-optimize` | Run `/candid-optimize` after generation and apply all recommendations without prompting |
 
 ### Effort Levels
 
@@ -91,6 +93,8 @@ Generate a Technical.md file by analyzing your codebase.
 /candid-init --template react
 /candid-init --effort quick
 /candid-init --effort thorough
+/candid-init --optimize         # Audit and tighten the generated context
+/candid-init --auto-optimize    # Same, but apply all recommendations automatically
 ```
 
 ## /candid-ship

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,8 +5,10 @@
   "private": true,
   "scripts": {
     "copy-changelog": "node scripts/copy-changelog.js",
-    "dev": "npm run copy-changelog && next dev",
-    "build": "npm run copy-changelog && next build",
+    "copy-plugin-json": "node scripts/copy-plugin-json.js",
+    "prebuild-data": "npm run copy-changelog && npm run copy-plugin-json",
+    "dev": "npm run prebuild-data && next dev",
+    "build": "npm run prebuild-data && next build",
     "postbuild": "node scripts/generate-search-index.js",
     "start": "next start",
     "lint": "next lint"

--- a/docs/scripts/copy-plugin-json.js
+++ b/docs/scripts/copy-plugin-json.js
@@ -1,0 +1,13 @@
+const fs = require('fs')
+const path = require('path')
+
+const source = path.join(__dirname, '..', '..', '.claude-plugin', 'plugin.json')
+const dest = path.join(__dirname, '..', 'data', 'plugin.json')
+
+const content = fs.readFileSync(source, 'utf-8')
+
+fs.mkdirSync(path.dirname(dest), { recursive: true })
+
+fs.writeFileSync(dest, content)
+
+console.log('Copied .claude-plugin/plugin.json to docs/data/plugin.json')

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -1109,7 +1109,57 @@ Use AskUserQuestion:
 
 ---
 
-## Step 11: Write Files and Show Summary
+## Step 11: Write Files, Optimize, and Show Summary
+
+### 11.1: Write Files to Disk
+
+Ensure the `.candid/` directory exists, then write both files:
+
+```bash
+mkdir -p .candid
+```
+
+Use the Write tool to create:
+- `.candid/Technical.md` (or the path passed via `--output`) — the synthesized content from Step 9
+- `.candid/config.json` — the assembled config from Step 10.7
+
+### 11.2: Optionally Run Optimize Stage
+
+**Skip this substep entirely unless `--optimize` or `--auto-optimize` was passed.**
+
+Why this exists: the 5 generation sub-agents in Step 9 each write a section independently and have no awareness of each other's output. The result frequently contains cross-section duplicates, verbose rules with redundant qualifiers, and low-signal generic rules. Running `/candid-optimize` immediately after generation tightens the file before the user opens it.
+
+**If `--optimize` is set (interactive):**
+
+Print:
+```
+Running optimization audit on generated context…
+```
+
+Invoke the `candid-optimize` skill with no extra flags. It will display the token budget (Step 2), analyze Technical.md / excludes / register / config (Steps 3–6), and run its own interactive apply phase (Step 7) including the before/after token report.
+
+When `candid-optimize` returns, continue to Step 11.3.
+
+**If `--auto-optimize` is set (non-interactive):**
+
+Print:
+```
+Running optimization audit and applying all recommendations…
+```
+
+Invoke the `candid-optimize` skill with the `--apply-all` flag. All recommendations are applied without prompting; the before/after report still prints.
+
+When `candid-optimize` returns, continue to Step 11.3.
+
+**Edge cases (delegated to candid-optimize):**
+
+- Decision register absent — Step 5 of candid-optimize skips silently (a fresh init has no register).
+- Config newly written by Step 10 — Step 6 of candid-optimize typically emits the "well-tuned" message.
+- Technical.md already optimal — Step 3 of candid-optimize emits the "efficient" message.
+
+A fresh init with `--optimize` therefore yields mostly Technical.md findings, with the broader audit serving as a no-cost confirmation.
+
+### 11.3: Show Summary
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -1136,6 +1186,13 @@ Use AskUserQuestion:
    2. Address identified gaps if desired
    3. Run /candid-validate-standards to check rule quality
    4. Run /candid-review to test enforcement
+```
+
+**If Step 11.2 ran (either `--optimize` or `--auto-optimize`):** replace step 3 of "Next Steps" with `Run /candid-validate-standards to check rule quality (optimization already applied)` so the user knows the audit pass already happened.
+
+**If Step 11.2 was skipped:** append a final hint line below the Next Steps block:
+```
+💡 Tip: run /candid-optimize to audit and tighten the generated context.
 ```
 
 ---


### PR DESCRIPTION
Closes #19.

## Summary
Adds an opt-in optimization stage to `/candid-init` that delegates to the existing `/candid-optimize` skill, so users get a tightened Technical.md in one command.

- `--optimize` — runs the full candid-optimize audit (Technical.md + excludes + register + config) interactively after generation
- `--auto-optimize` — same audit, applies all recommendations without prompting
- Default behavior unchanged: without a flag, candid-init writes the raw generated files and prints a `Tip: run /candid-optimize…` hint
- No analysis logic duplicated — verbose/duplicate/low-signal heuristics stay in candid-optimize

## Why
In thorough mode candid-init launches 5 generation sub-agents in parallel; each writes one section without awareness of the others, so the synthesized Technical.md frequently has cross-section duplicates, verbose qualifiers, and low-signal generic rules. Running the optimize pass immediately after generation tightens the file before the user opens it.

## Changes
- `commands/candid-init.md` — new `--optimize` / `--auto-optimize` args + Usage examples
- `skills/candid-init/SKILL.md` — Step 11 split into 11.1 Write Files / 11.2 Optionally Run Optimize Stage / 11.3 Show Summary; conditional summary footer
- `CHANGELOG.md` — 1.12.0 entry
- `.claude-plugin/plugin.json` — bumped 1.11.0 → 1.12.0
- `docs/app/docs/core-features/slash-commands/page.mdx`, `README.md` — flag tables and examples updated

### Bonus: docs build fix
The marketing page imported `../../../.claude-plugin/plugin.json` directly, which Turbopack (Next 16) rejects as a cross-project import. Mirrored the existing `copy-changelog.js` pattern with `copy-plugin-json.js` that copies the file into `docs/data/plugin.json` at build time. `docs/data/plugin.json` is gitignored.

## Quality gates
- pre-pr-verification: ✅ (3/3 implementation tasks complete)
- candid-review (constructive): ✅ (one finding — docs/README missing the new flags — fixed in this PR)
- security review: ✅ (no findings; documentation-only diff)
- docs site build: ✅ (was broken on stable; fixed in this PR)

## Test plan
- [ ] `/candid-init --effort thorough` (no flag) — Step 11.2 skipped, summary shows the tip
- [ ] `/candid-init --effort thorough --optimize` — interactive optimize prompt after generation
- [ ] `/candid-init --effort thorough --auto-optimize` — non-interactive, before/after token report appears
- [ ] After `--auto-optimize`, `/candid-optimize --section technical-md --dry-run` reports no remaining verbose/duplicate findings
- [ ] `npm run build` in `docs/` completes without the `Module not found` error