### PR TITLE
Add issue tracker integration to candid-ship (closes #54)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-04-25
+
+### Added
+
+- **Issue Tracker Integration** (`ship.issueTracker`): New optional step in candid-ship that automatically transitions a tracked issue to a configured state after PR creation
+  - **Provider-agnostic schema** (`provider`, `enabled`, `teamPrefixes`, `state`, `prompt`) — built to extend to Asana, Jira, GitHub Issues, Shortcut, etc. Today only `provider: "linear"` is implemented; other values produce a friendly warning with a link to [open a request](https://github.com/ron-myers/candid/issues), and the step is skipped
+  - **Configurable prompt with intelligent default** (`ship.issueTracker.prompt`): User-editable template sent to the MCP server, written by `candid-init` into `.candid/config.json` so it's discoverable and easy to edit. Supports `{issueId}`, `{state}`, `{provider}` placeholders. The default prompt encodes four safety invariants: (1) single-issue scope, (2) single-field scope (only `state` changes), (3) idempotent no-op when already in target state, and (4) no fallback search on missing-issue errors. Default: `Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.` Custom prompts must preserve invariants 1 and 4
+  - **Branch-name parsing**: extracts the issue ID using a case-insensitive regex built from `teamPrefixes` (defaults: `DIS`, `ENG`, `DISC`) — easy to edit to match your tracker workspace's team keys
+  - **Opt-in & graceful**: disabled by default. Skips silently in every "can't run" scenario — config absent, `enabled: false`, no provider set, unsupported provider, MCP not installed, no matching team prefix in branch, or MCP error. The ship continues regardless. Branches without a tracked issue and repos without an MCP are unaffected
+  - **Linear MCP integration**: requires the official Linear MCP server (claude.ai/Linear) when `provider: "linear"`
+  - **candid-init flow**: Step 10.6f asks "Yes — Linear / Yes — other tracker (request support) / No, skip" — the "other tracker" option links to the issues page so users can request their tracker, and skips configuration cleanly
+  - **Comprehensive docs**: provider setup, MCP installation, branch naming conventions, custom prompt examples, skip-scenario table, and instructions for requesting other providers — see [/docs/core-features/candid-ship#issue-tracker-integration](https://candid.dev/docs/core-features/candid-ship#issue-tracker-integration)
+  - **Config reference updated**: `docs/reference/config-options` now documents the full `ship.*` schema including `issueTracker`, and `skills/candid-review/CONFIG.md` covers the validation rules
+
+### Changed
+
+- **candid-ship summary**: Now includes an `Issue:` row when `issueTracker.enabled` is `true`
+- **`docs/reference/config-options/page.mdx`**: Now documents the complete `ship` config (was previously absent)
+
 ## [1.12.0] - 2026-04-25
 
 ### Added

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -317,6 +317,12 @@ export default function HomePage() {
               <p>Track questions raised during reviews and their resolutions. Prior answers are reused automatically so the same question is never asked twice.</p>
             </div>
           </Link>
+          <Link href="/docs/core-features/candid-ship#issue-tracker-integration" className="card-link">
+            <div className="card">
+              <h3>Issue Tracker Integration</h3>
+              <p>Ship a branch and <code>/candid-ship</code> automatically moves the linked issue (Linear today, more soon) to <code>In Review</code>. Provider, state, and prompt are configurable.</p>
+            </div>
+          </Link>
         </div>
       </section>
 

--- a/docs/app/docs/core-features/candid-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-ship/page.mdx
@@ -138,6 +138,196 @@ The command only runs when all three conditions are met:
 
 If the command fails, a warning is shown but the workflow is **not** aborted — the PR is already created and auto-merge is in progress.
 
+## Issue Tracker Integration
+
+When `issueTracker.enabled` is `true`, candid-ship reads the current branch name, extracts an issue ID, and updates that issue's state in your tracker right after creating the PR. New in v1.13.0.
+
+> **Provider support:** Linear is the only supported provider today. The config is provider-agnostic and built to extend — see [requesting support](#requesting-support-for-other-trackers) below.
+
+### How it works
+
+1. After the PR is created, candid-ship reads the current branch name (`git branch --show-current`).
+2. It builds a case-insensitive regex from `issueTracker.teamPrefixes` — for example, `(DIS|ENG|DISC)-\d+`.
+3. If the branch name contains a match, candid-ship renders the prompt template (substituting `{issueId}`, `{state}`, `{provider}`) and calls the provider's MCP server to update **only that single issue** to `issueTracker.state` (default: `"In Review"`).
+4. The result appears in the ship summary as `Issue: Updated DIS-509 → In Review`.
+
+If no issue ID is found in the branch name, the step is skipped silently — branches without a tracked issue just ship normally. The same is true if the tracker isn't configured at all.
+
+### Configuration
+
+```json
+{
+  "ship": {
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG", "DISC"],
+      "state": "In Review",
+      "prompt": "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider` | string | `"linear"` | Issue tracker. Only `"linear"` is supported today. |
+| `enabled` | boolean | `false` | Opt-in flag. Requires the provider's MCP. |
+| `teamPrefixes` | string[] | `["DIS", "ENG", "DISC"]` | Team keys to match in branch names. **Edit to match your tracker workspace's prefixes.** |
+| `state` | string | `"In Review"` | Workflow state to transition the issue to. Must match a state name in your tracker exactly. |
+| `prompt` | string | (see default) | Customizable prompt template sent to the MCP. Supports `{issueId}`, `{state}`, `{provider}` placeholders. **Must restrict the action to a single issue.** |
+
+### Branch naming
+
+Use a branch name that includes the issue ID anywhere in the name. The match is case-insensitive:
+
+| Branch name | Matched issue |
+|-------------|---------------|
+| `ron-myers/dis-509-add-auth` | `DIS-509` |
+| `feature/ENG-1234-fix-login` | `ENG-1234` |
+| `disc-42` | `DISC-42` |
+| `main` | (no match — skipped) |
+| `feature/refactor-auth` | (no match — skipped) |
+
+A common convention:
+
+```
+[your-name]/[issue-id]-[short-description]
+```
+
+Linear's "Copy git branch name" feature on each issue produces a perfectly formatted branch name with the issue ID baked in.
+
+### Customizing the prompt
+
+The default prompt is written into `.candid/config.json` by `candid-init` so it's visible and easy to edit:
+
+```
+Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.
+```
+
+The default encodes four safety invariants so a verbose MCP can't accidentally fan out:
+
+1. **Single issue** — only `{issueId}` is touched, never any other issue.
+2. **Single field** — only the `state` field changes (assignees, labels, priority, title, description are untouched).
+3. **Idempotent** — already in `{state}`? Succeed without action.
+4. **No fallback search** — missing or inaccessible issue? Stop. Don't look for "similar" issues.
+
+You can customize this to add domain-specific instructions (e.g. add a comment, set an assignee, link to the PR), but **any custom prompt must preserve invariants 1 and 4** — single issue, no fallback search. Without those, a chatty MCP could fan out and modify unrelated issues.
+
+Example custom prompt:
+
+```json
+{
+  "ship": {
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "state": "Code Review",
+      "prompt": "Move {issueId} to \"{state}\" and add a comment 'PR ready for review.' Only modify this single issue."
+    }
+  }
+}
+```
+
+Available placeholders:
+
+| Placeholder | Substituted with | Example |
+|-------------|------------------|---------|
+| `{issueId}` | The matched issue ID (uppercase) | `DIS-509` |
+| `{state}` | Value of `issueTracker.state` | `In Review` |
+| `{provider}` | Value of `issueTracker.provider` | `linear` |
+
+### Setup: Linear MCP
+
+The Linear MCP server is required when `provider: "linear"`. If it's not installed, the issue-tracker step is skipped silently — the rest of the ship still works.
+
+**Step 1 — Install the Linear MCP.** From your Claude Code settings, add the official Linear MCP server (provided by claude.ai). When prompted, sign in with the Linear account that has access to the issues you want to update.
+
+**Step 2 — Verify the connection.** In a fresh Claude Code conversation, ask Claude to list your Linear teams. If Claude returns your team list, the MCP is wired up correctly.
+
+**Step 3 — Find your team prefixes.** Open Linear and look at any issue ID. The letters before the dash are your team key (e.g. `DIS-509` → team key `DIS`). Note every team key whose issues you ship from this repository.
+
+**Step 4 — Set `teamPrefixes` in your config.** Add an entry to `.candid/config.json`:
+
+```json
+{
+  "ship": {
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["YOUR", "TEAM", "KEYS"]
+    }
+  }
+}
+```
+
+**Step 5 — Confirm the state name.** Open an issue in Linear and check the workflow state names in the right sidebar. The `state` field must match exactly. Common values:
+
+- `"In Review"`
+- `"Code Review"`
+- `"In Progress"`
+- `"Ready for Review"`
+
+If the state name has different capitalization or wording, the update will fail with a `state not found` error — you'll see a warning, the PR is still created.
+
+### When the update is skipped
+
+candid-ship skips the issue-tracker update gracefully in every case below. **The ship continues regardless** — the issue tracker is purely additive.
+
+| Scenario | Output |
+|----------|--------|
+| `issueTracker` field absent from config | `No issue tracker configured — skipping` |
+| `enabled` is `false` | `Skipping issue tracker update (disabled)` |
+| `provider` is `"none"` or unset | `Skipping issue tracker update (no provider set)` |
+| `provider` is unsupported (e.g. `"asana"`) | Warning + link to [GitHub issues](https://github.com/ron-myers/candid/issues), step skipped |
+| Provider's MCP isn't installed | `Linear MCP not available — skipping issue update` |
+| Branch name has no team prefix match | `No issue ID found in branch name — skipping` |
+| MCP returns an error (issue not found, bad state name, etc.) | Warning shown, ship continues. PR is already created. |
+
+This means you can safely commit `issueTracker` config to a repo that other developers ship from — if they don't have the Linear MCP, their ships still work.
+
+### Example flow
+
+```
+Branch: ron-myers/dis-509-add-auth → stable
+
+Step 4/6: Creating pull request...
+PR created: https://github.com/org/repo/pull/42
+
+Step 5/6: Updating issue tracker (linear)...
+Updated DIS-509 → In Review
+
+Step 6/6: Enabling auto-merge...
+Auto-merge enabled. PR will merge when checks pass.
+```
+
+### Adding more team prefixes later
+
+Team prefixes are workspace-specific. The defaults (`DIS`, `ENG`, `DISC`) are starting examples — **edit them to match your workspace.** To add a new team:
+
+1. Open `.candid/config.json`.
+2. Add the new team key to `ship.issueTracker.teamPrefixes`.
+3. Save. The next `/candid-ship` will recognize branches with that prefix.
+
+No restart, no reinstall — the config is read fresh on every run.
+
+### Requesting support for other trackers
+
+Today Linear is the only supported provider. The config schema is built to extend — adding Asana, Jira, GitHub Issues, Shortcut, or any other tracker is a matter of mapping the provider's MCP into the same `provider` / `teamPrefixes` / `state` / `prompt` contract.
+
+If you'd like support for another tracker:
+
+→ **Open a request:** [github.com/ron-myers/candid/issues](https://github.com/ron-myers/candid/issues)
+
+Tell us:
+
+- Which tracker you use
+- How issue IDs are formatted (e.g. team-prefix conventions)
+- The state/status field name and target state
+- Any tracker-specific quirks (custom fields, multi-step transitions, etc.)
+
+Until your tracker is supported, `provider: "your-tracker"` produces a friendly warning during ship and the step is skipped — the rest of the ship works normally.
+
 ## Examples
 
 ```bash

--- a/docs/app/docs/reference/config-options/page.mdx
+++ b/docs/app/docs/reference/config-options/page.mdx
@@ -15,6 +15,21 @@ Complete reference for Candid configuration.
     "enabled": boolean,
     "path": "string",
     "mode": "lookup" | "load"
+  },
+  "ship": {
+    "buildCommand": "string",
+    "testCommand": "string",
+    "targetBranch": "string",
+    "autoMerge": boolean,
+    "additionalPrompt": "string",
+    "postMergeCommand": "string",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": boolean,
+      "teamPrefixes": ["string"],
+      "state": "string",
+      "prompt": "string"
+    }
   }
 }
 ```
@@ -82,6 +97,99 @@ Example:
 ```
 
 See [Decision Register](/docs/core-features/decision-register) for full documentation.
+
+### ship
+
+Configuration for the [`/candid-ship`](/docs/core-features/candid-ship) shipping workflow. All sub-fields are optional; if absent, candid-ship uses defaults or skips the corresponding step.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `buildCommand` | string | — | Shell command for build verification before creating the PR. Skipped if not set. |
+| `testCommand` | string | — | Shell command for running tests before creating the PR. Skipped if not set. |
+| `targetBranch` | string | first `mergeTargetBranches` or `"main"` | Branch to target for the PR. |
+| `autoMerge` | boolean | `false` | Auto-merge the PR after creation via `gh pr merge --squash --auto`. |
+| `additionalPrompt` | string | — | Extra context passed to candid-loop/review during the review step. |
+| `postMergeCommand` | string | — | Shell command to run after auto-merge succeeds. Skipped if auto-merge is disabled or fails. |
+| `issueTracker` | object | — | Issue tracker auto-update config (see below). Opt-in. |
+
+Example (minimal):
+
+```json
+{
+  "ship": {
+    "targetBranch": "main"
+  }
+}
+```
+
+Example (full pipeline):
+
+```json
+{
+  "ship": {
+    "buildCommand": "npm run build",
+    "testCommand": "npm test",
+    "targetBranch": "stable",
+    "autoMerge": true,
+    "additionalPrompt": "Ensure error handling covers all async operations",
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
+  }
+}
+```
+
+See [Candid Ship](/docs/core-features/candid-ship) for full documentation.
+
+### ship.issueTracker
+
+Optional auto-update of an external issue tracker after the PR is created. Currently `provider: "linear"` is the only supported provider; this field can be safely left unset, in which case the issue-tracker step is skipped silently and the rest of the ship runs unchanged.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider` | string | `"linear"` | Issue tracker name. Only `"linear"` is supported today. Other values produce a warning with a link to [request support](https://github.com/ron-myers/candid/issues) and the step is skipped. |
+| `enabled` | boolean | `false` | Whether to attempt the issue update. Opt-in. |
+| `teamPrefixes` | string[] | `["DIS", "ENG", "DISC"]` | Team key prefixes to match in branch names. **Edit this list to match your tracker workspace's team keys.** |
+| `state` | string | `"In Review"` | Workflow state to transition the issue to. Must match a state name in your tracker exactly (case-sensitive). |
+| `prompt` | string | (see default) | Customizable prompt template sent to the tracker's MCP. Supports `{issueId}`, `{state}`, `{provider}` placeholders. **Must restrict the action to a single issue.** |
+
+**Default prompt:**
+
+```
+Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.
+```
+
+This default encodes four safety invariants so a verbose MCP can't accidentally fan out:
+
+1. **Single issue** — only `{issueId}` is touched.
+2. **Single field** — only the `state` field changes (assignees, labels, priority, etc. are untouched).
+3. **Idempotent** — already in `{state}`? Succeed without action.
+4. **No fallback search** — missing or inaccessible? Stop. Don't look for "similar" issues.
+
+`candid-init` writes this default into `.candid/config.json` so it's discoverable and easy to edit. Custom prompts must preserve invariants 1 and 4.
+
+Example:
+
+```json
+{
+  "ship": {
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG"],
+      "state": "In Review"
+    }
+  }
+}
+```
+
+**Behavior when not configured or disabled:**
+
+- `issueTracker` field absent → step skipped silently
+- `enabled: false` → step skipped silently
+- branch name has no matching team prefix → step skipped silently (branches without an issue ID just ship normally)
+- provider's MCP is not installed → warning shown, step skipped, ship continues
+- provider is unsupported (anything other than `"linear"`) → warning with link to issue tracker, step skipped, ship continues
+
+See [Candid Ship — Issue Tracker Integration](/docs/core-features/candid-ship#issue-tracker-integration) for full setup and usage.
 
 ## Config Precedence
 

--- a/examples/ship/config.json
+++ b/examples/ship/config.json
@@ -8,6 +8,13 @@
     "targetBranch": "main",
     "autoMerge": false,
     "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware",
-    "postMergeCommand": "echo 'Ship complete!'"
+    "postMergeCommand": "echo 'Ship complete!'",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG", "DISC"],
+      "state": "In Review",
+      "prompt": "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
+    }
   }
 }

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -1070,6 +1070,75 @@ Use AskUserQuestion:
 If "Yes" → follow-up: "Enter additional review prompt:" with free-text response.
 If "No" → omit `additionalPrompt` field.
 
+#### 10.6f: Issue Tracker Integration
+
+Use AskUserQuestion:
+
+**Question:** "Do you use an issue tracker (Linear, Asana, Jira, etc.) and want candid-ship to auto-update issues when you ship?"
+
+**Options:**
+1. "Yes — Linear (supported)"
+2. "Yes — other tracker (request support)"
+3. "No, skip"
+
+**If "No, skip"** → omit `issueTracker` field. Proceed.
+
+**If "Yes — other tracker (request support)":**
+
+Display:
+```
+Issue tracker integration currently supports Linear only. To request support for your tracker (Asana, Jira, GitHub Issues, Shortcut, etc.):
+
+  → Open an issue: https://github.com/ron-myers/candid/issues
+
+Tell us which tracker you use and how you'd like the workflow to behave (state name, when to trigger, etc.) and we'll prioritize accordingly.
+
+Skipping issue tracker config for now.
+```
+
+Omit the `issueTracker` field. Proceed.
+
+**If "Yes — Linear (supported)":**
+
+Display:
+```
+Linear integration requires the official Linear MCP server (claude.ai/Linear). If it isn't installed, the issue-tracker step is skipped at ship time — the rest of the ship still runs.
+```
+
+**Follow-up 1:** "Linear team prefixes (comma-separated, e.g. DIS,ENG,DISC):" — free-text response. Split on comma, trim each entry, uppercase. If the user leaves blank, default to `["DIS", "ENG", "DISC"]`.
+
+**Follow-up 2:** "Linear state name to set when PR is created:" — free-text response. If blank, default to `"In Review"`. The user should match the exact state name from their Linear workspace (e.g. `"In Review"`, `"Code Review"`, `"In Progress"`).
+
+**Follow-up 3:** Use AskUserQuestion: "Use the default Linear MCP prompt, or customize it?"
+
+Show the default below the question so the user can see what they're agreeing to:
+
+```
+Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.
+```
+
+Options:
+1. "Use the default (recommended) — written into your config so you can edit it later"
+2. "Customize now"
+
+**If "Use the default":** write the default prompt verbatim into the `prompt` field of the generated config. The user can edit `.candid/config.json` later. **Do not omit the field** — having the prompt visible in the config is a feature, not noise.
+
+**If "Customize now":** Free-text follow-up: "Enter your custom prompt. Use `{issueId}`, `{state}`, and `{provider}` as placeholders. **Required:** the prompt must restrict the action to a single issue and stop on missing-issue errors (don't search for a fallback)." Show the default below as a reference baseline. Use the user's response as the `prompt` value.
+
+In either case, write the resulting `prompt` field into the config:
+
+```json
+"issueTracker": {
+  "provider": "linear",
+  "enabled": true,
+  "teamPrefixes": ["..."],
+  "state": "...",
+  "prompt": "..."
+}
+```
+
+The skill's runtime default is identical to the value written here — the explicit-in-config approach simply makes the prompt visible to the user without changing behavior.
+
 ### 10.7: Preview and Confirm
 
 Assemble the config object from all detected and prompted values. Only include fields that were explicitly set — omit fields the user skipped (they default correctly when absent).

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -28,7 +28,14 @@ Valid config file format:
     "targetBranch": "stable",
     "autoMerge": false,
     "additionalPrompt": "Focus on security",
-    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG", "DISC"],
+      "state": "In Review",
+      "prompt": "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
+    }
   }
 }
 ```
@@ -61,6 +68,12 @@ Valid config file format:
   - `ship.autoMerge` (optional): Whether to auto-merge the PR after creation via `gh pr merge --squash --auto`. Defaults to `false`. Must be a boolean.
   - `ship.additionalPrompt` (optional): Extra prompt text passed to candid-loop/candid-review as additional review context. Must be a non-empty string.
   - `ship.postMergeCommand` (optional): Shell command to run after auto-merge is successfully enabled. Only executes when `autoMerge` is `true` and `gh pr merge --squash --auto` succeeds. If the command fails, a warning is shown but the workflow is not aborted. Must be a non-empty string.
+  - `ship.issueTracker` (optional): Configuration for auto-updating an issue tracker after PR creation. Opt-in. If absent, the issue-tracker step is skipped silently — the rest of the ship runs unchanged. Currently `provider: "linear"` is the only supported provider; other values produce a warning with a link to request support. Sub-fields:
+    - `ship.issueTracker.provider` (optional): Issue tracker name. Currently only `"linear"` is supported. Defaults to `"linear"`. Future values may include `"asana"`, `"jira"`, `"github"`, etc. — set `"none"` (or omit `issueTracker` entirely) to disable.
+    - `ship.issueTracker.enabled` (optional): Whether to attempt the issue update. Defaults to `false`. Must be a boolean.
+    - `ship.issueTracker.teamPrefixes` (optional): Array of team key prefixes to match in branch names (e.g. for Linear, the letters before the dash in any issue ID). Defaults to `["DIS", "ENG", "DISC"]` — **edit this to match your tracker workspace's team keys.** Must be an array of non-empty strings.
+    - `ship.issueTracker.state` (optional): The workflow state to transition the issue to. Defaults to `"In Review"`. Must match a state name in your tracker workspace exactly (case-sensitive). Must be a non-empty string.
+    - `ship.issueTracker.prompt` (optional): Customizable prompt template sent to the tracker's MCP server. Supports `{issueId}`, `{state}`, and `{provider}` placeholders. The rendered prompt **must restrict the action to a single issue** — multiple-issue updates are explicitly disallowed. Defaults to: `Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.` This default also restricts the change to the `state` field (no assignee/label/title changes), is idempotent (no-op if already in `{state}`), and stops on a missing-issue error rather than searching for a fallback. candid-init writes this default into `.candid/config.json` so it's discoverable and easy to edit. Must be a non-empty string.
 
 ## Validation Rules
 
@@ -71,7 +84,7 @@ Valid config file format:
 5. **mergeTargetBranches field validation** - If present, must be an array of non-empty strings. Empty arrays or invalid values show warning and are ignored.
 6. **AutoCommit field validation** - If `autoCommit` field is present, must be a boolean (`true` or `false`). Invalid values show warning and are ignored.
 7. **DecisionRegister field validation** - If `decisionRegister` field is present, must be an object. If `decisionRegister.enabled` is present, must be a boolean. If `decisionRegister.path` is present, must be a non-empty string. If `decisionRegister.mode` is present, must be exactly `"lookup"` or `"load"` (case-sensitive). Invalid values show warning and are ignored (feature defaults to disabled).
-8. **Ship field validation** - If `ship` field is present, must be an object. If `ship.buildCommand` is present, must be a non-empty string. If `ship.testCommand` is present, must be a non-empty string. If `ship.targetBranch` is present, must be a non-empty string. If `ship.autoMerge` is present, must be a boolean. If `ship.additionalPrompt` is present, must be a non-empty string. If `ship.postMergeCommand` is present, must be a non-empty string. Invalid values show warning and are ignored.
+8. **Ship field validation** - If `ship` field is present, must be an object. If `ship.buildCommand` is present, must be a non-empty string. If `ship.testCommand` is present, must be a non-empty string. If `ship.targetBranch` is present, must be a non-empty string. If `ship.autoMerge` is present, must be a boolean. If `ship.additionalPrompt` is present, must be a non-empty string. If `ship.postMergeCommand` is present, must be a non-empty string. If `ship.issueTracker` is present, must be an object. If `ship.issueTracker.provider` is present, must be a non-empty string. If `ship.issueTracker.enabled` is present, must be a boolean. If `ship.issueTracker.teamPrefixes` is present, must be an array of non-empty strings. If `ship.issueTracker.state` is present, must be a non-empty string. If `ship.issueTracker.prompt` is present, must be a non-empty string. Invalid values show warning and are ignored — the ship continues without the issue tracker step.
 9. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, `autoCommit`, `decisionRegister`, and `ship` are ignored for forward compatibility
 10. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
 
@@ -291,6 +304,39 @@ Using constructive tone (from interactive prompt)
 }
 ```
 
+**With Linear issue tracker:**
+```json
+{
+  "version": 1,
+  "tone": "constructive",
+  "ship": {
+    "buildCommand": "npm run build",
+    "targetBranch": "main",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG"],
+      "state": "In Review"
+    }
+  }
+}
+```
+
+**With custom issue tracker prompt:**
+```json
+{
+  "ship": {
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS"],
+      "state": "Code Review",
+      "prompt": "Move {issueId} to \"{state}\" and add a comment that the PR is ready. Only modify this single issue."
+    }
+  }
+}
+```
+
 **Full config with all features:**
 ```json
 {
@@ -310,7 +356,13 @@ Using constructive tone (from interactive prompt)
     "targetBranch": "stable",
     "autoMerge": true,
     "additionalPrompt": "Ensure error handling covers all async operations",
-    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG", "DISC"],
+      "state": "In Review"
+    }
   }
 }
 ```

--- a/skills/candid-ship/SKILL.md
+++ b/skills/candid-ship/SKILL.md
@@ -81,6 +81,7 @@ If the `ship` field exists, extract:
 - `autoMerge` (boolean) — auto-merge after PR creation
 - `additionalPrompt` (string) — extra context for candid-loop/review
 - `postMergeCommand` (string) — shell command to run after auto-merge succeeds
+- `issueTracker` (object) — issue tracker auto-update config with `provider`, `enabled`, `teamPrefixes`, `state`, `prompt` sub-fields
 
 Output when loading: `Using ship settings from project config`
 
@@ -114,6 +115,11 @@ targetBranch = resolved per above
 autoMerge = false
 additionalPrompt = null
 postMergeCommand = null (skip if not set)
+issueTracker.provider = "linear" (only "linear" is currently supported)
+issueTracker.enabled = false
+issueTracker.teamPrefixes = ["DIS", "ENG", "DISC"]
+issueTracker.state = "In Review"
+issueTracker.prompt = "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
 ```
 
 #### Validate Current Branch != Target Branch
@@ -134,7 +140,7 @@ If no commits ahead: abort with `No commits ahead of [targetBranch]. Nothing to 
 
 ### Step 3: Display Plan
 
-Calculate `totalSteps = 5 + (postMergeCommand is set ? 1 : 0)`. Use this value as the step total in all step progress displays throughout the workflow.
+Calculate `totalSteps = 4 + (issueTracker.enabled ? 1 : 0) + 1 + (postMergeCommand is set ? 1 : 0)`. Use this value as the step total in all step progress displays throughout the workflow. Renumber the visible step list (below) to skip rows for any disabled optional steps.
 
 Show what will be executed:
 
@@ -150,8 +156,9 @@ Steps:
   2. 🔨 Build: [buildCommand]               [or SKIP — not configured]
   3. 🧪 Tests: [testCommand]                [or SKIP — not configured]
   4. 📋 Create pull request
-  5. 🔀 Auto-merge: enabled                 [or disabled]
-  6. 🚀 Post-merge: [postMergeCommand]      [only shown if postMergeCommand is set]
+  5. 🎯 Update issue tracker ([provider]): state="[state]"  [only shown if issueTracker.enabled]
+  6. 🔀 Auto-merge: enabled                 [or disabled]
+  7. 🚀 Post-merge: [postMergeCommand]      [only shown if postMergeCommand is set]
 ```
 
 If `additionalPrompt` is set:
@@ -321,7 +328,115 @@ Capture the PR URL from stdout. If creation fails, abort with error message.
 
 Output: `PR created: [URL]`
 
-### Step 8: Auto-Merge (Optional)
+### Step 8: Update Issue Tracker (Optional)
+
+This step transitions the linked issue in the configured tracker (Linear today, more providers planned) to the configured state. The step is fully optional and skipped silently in every case where it can't or shouldn't run — the ship continues regardless.
+
+**Skip if** `issueTracker` is missing from config. Output: `No issue tracker configured — skipping`. Continue to Step 9.
+
+**Skip if** `issueTracker.enabled` is `false`. Output: `Skipping issue tracker update (disabled)`. Continue to Step 9.
+
+**Skip if** `issueTracker.provider` is `"none"`. Output: `Skipping issue tracker update (provider set to "none")`. Continue to Step 9.
+
+**Skip if** `issueTracker.provider` is anything other than `"linear"`:
+```
+⚠️  Issue tracker provider "[provider]" is not yet supported.
+Request support at: https://github.com/ron-myers/candid/issues
+```
+Continue to Step 9.
+
+**Skip if** `issueTracker.provider` is `"linear"` but the Linear MCP tool (`mcp__claude_ai_Linear__save_issue`) is unavailable. Output: `Linear MCP not available — skipping issue update`. Continue to Step 9.
+
+If enabled, the provider is supported, and the corresponding MCP is available, proceed.
+
+Display:
+```
+Step [N]/[totalSteps]: Updating issue tracker ([provider])...
+```
+(where `N` is the count of active steps so far + 1 — typically 5 if review, build, and tests all ran; lower otherwise)
+
+#### 8.1: Extract Issue Identifier
+
+Build a case-insensitive regex from `issueTracker.teamPrefixes`:
+
+```
+pattern = (PREFIX1|PREFIX2|...)-\d+
+```
+
+For example, with `teamPrefixes = ["DIS", "ENG", "DISC"]`:
+
+```
+pattern = (DIS|ENG|DISC)-\d+/i
+```
+
+Match the pattern against `currentBranch`. Examples:
+- `ron-myers/dis-509-add-auth` → matches `dis-509` → normalize to `DIS-509`
+- `feature/ENG-1234-fix-login` → matches `ENG-1234`
+- `feature/refactor-auth` → no match
+
+If no match, output `No issue ID found in branch name — skipping` and continue to Step 9. **This is not an error** — branches without a tracked issue ship normally.
+
+If matched, normalize the captured ID to uppercase (e.g. `dis-509` → `DIS-509`).
+
+**Note for editors:** The default `teamPrefixes` list (`DIS`, `ENG`, `DISC`) reflects one Linear workspace's team keys. **Edit this list in `.candid/config.json`** to match your workspace's team prefixes — every Linear team has its own key (the letters before the dash in any issue ID).
+
+#### 8.2: Render the Prompt
+
+Take `issueTracker.prompt` and substitute placeholders:
+
+- `{issueId}` → the matched issue ID (e.g. `DIS-509`)
+- `{state}` → `issueTracker.state` (e.g. `In Review`)
+- `{provider}` → `issueTracker.provider` (e.g. `linear`)
+
+Default prompt:
+```
+Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.
+```
+
+The default codifies four invariants that protect the user from accidental fan-out:
+1. **Single issue** — only `{issueId}` is touched, never any other issue.
+2. **Single field** — only the `state` field changes; assignees, labels, priority, title, description are untouched.
+3. **Idempotent** — already in `{state}`? Succeed without action.
+4. **No fallback search** — if the issue is missing or inaccessible, stop. Don't look for "similar" issues.
+
+The user can customize the prompt (e.g. add a comment, set an assignee), but **any custom prompt must preserve invariants 1 and 4** — single issue, no search fallback. Without those, a chatty MCP could fan out and modify unrelated issues.
+
+#### 8.3: Pre-Call Invariant Check
+
+Before calling the MCP, scan the rendered prompt for the single-issue restriction. If the user has customized `issueTracker.prompt` and stripped this protection, abort the issue-tracker step rather than risk fan-out.
+
+Treat the prompt as preserving the single-issue invariant if it contains any of these substrings (case-insensitive): `"only this one issue"`, `"only this single issue"`, `"only one issue"`, `"this issue only"`. If none match:
+
+```
+⚠️  Issue tracker prompt is missing the single-issue restriction.
+Refusing to call the MCP. Restore the invariant in `ship.issueTracker.prompt` (see candid-ship docs).
+```
+Continue to Step 9 without calling the MCP. The PR is already created.
+
+This check is defense-in-depth at the prompt layer. The structured `id` argument to the next step's MCP call already enforces single-issue scope from the API side.
+
+#### 8.4: Update Issue State (Linear)
+
+Call the Linear MCP using the rendered prompt as the instruction context, with the structured `id` and `state` arguments:
+
+```
+mcp__claude_ai_Linear__save_issue
+  id: "[matched issue ID]"
+  state: "[issueTracker.state]"
+```
+
+The structured arguments are the source of truth for what gets updated. The rendered prompt is the natural-language instruction wrapping this call — it shapes Claude's intent when invoking the tool but the `id` field is what the API enforces.
+
+**On success:** Output: `Updated [issueId] → [state]` (e.g. `Updated DIS-509 → In Review`)
+
+**On error** (issue not found, permission denied, state name not recognized, etc.):
+```
+⚠️  Issue tracker update failed: [error message]
+PR is still open at: [URL]
+```
+Do NOT abort — the PR already exists and shouldn't be wasted. Continue to Step 9.
+
+### Step 9: Auto-Merge (Optional)
 
 **Skip if** `autoMerge` is `false`. Output: `Auto-merge: disabled (manual merge required)`
 
@@ -329,8 +444,9 @@ If `autoMerge` is `true`:
 
 Display:
 ```
-Step 5/[totalSteps]: Enabling auto-merge...
+Step [N]/[totalSteps]: Enabling auto-merge...
 ```
+(where `N` is the count of active steps so far + 1)
 
 ```bash
 gh pr merge [PR_URL] --squash --auto
@@ -349,7 +465,7 @@ If auto-merge succeeds:
 Auto-merge enabled. PR will merge when checks pass.
 ```
 
-### Step 9: Run Post-Merge Command (Conditional)
+### Step 10: Run Post-Merge Command (Conditional)
 
 **Skip if** `postMergeCommand` is not configured. Output: `Skipping post-merge command (not configured)`
 
@@ -361,9 +477,10 @@ If all conditions are met (command configured, auto-merge enabled, auto-merge su
 
 Display:
 ```
-Step 6/[totalSteps]: Running post-merge command...
+Step [N]/[totalSteps]: Running post-merge command...
 $ [postMergeCommand]
 ```
+(where `N` is the active step number — `totalSteps` itself, since post-merge is always the last step when present)
 
 Execute the post-merge command:
 ```bash
@@ -382,7 +499,7 @@ Do NOT abort — the PR was already created and auto-merge is enabled. Continue 
 Post-merge command completed.
 ```
 
-### Step 10: Display Summary
+### Step 11: Display Summary
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -393,6 +510,7 @@ Review:   [PASS (N iterations, M issues fixed) | SKIPPED]
 Build:    [PASS | SKIPPED]
 Tests:    [PASS | SKIPPED]
 PR:       [URL]
+Issue:    [Updated DIS-509 → In Review | Skipped — no match | Skipped — provider unsupported | Failed: <error>]   [only shown if issueTracker.enabled]
 Merge:    [Auto-merge enabled | Manual merge required | Auto-merge failed]
 Post-merge: [PASS | SKIPPED | FAILED | N/A]
 ```
@@ -412,12 +530,21 @@ Add to `.candid/config.json`:
     "targetBranch": "stable",
     "autoMerge": false,
     "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware",
-    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG", "DISC"],
+      "state": "In Review",
+      "prompt": "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
+    }
   }
 }
 ```
 
 ### Field Descriptions
+
+> **Note:** `issueTracker` is an optional, opt-in integration. When omitted, the issue-tracker step is skipped silently — the rest of the ship runs unchanged. Currently `provider: "linear"` is the only supported provider; it requires the Linear MCP server installed and authenticated. To request support for another tracker (Asana, Jira, GitHub Issues, etc.), open an issue at https://github.com/ron-myers/candid/issues.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -427,6 +554,16 @@ Add to `.candid/config.json`:
 | `ship.autoMerge` | boolean | `false` | Auto-merge PR after creation via `gh pr merge --squash --auto`. |
 | `ship.additionalPrompt` | string | `null` | Extra context passed to candid-loop/review. |
 | `ship.postMergeCommand` | string | `null` | Shell command to run after auto-merge succeeds. Skipped if auto-merge is disabled or fails. |
+| `ship.issueTracker.provider` | string | `"linear"` | Issue tracker to integrate with. Currently only `"linear"` is supported. Other values produce a warning with a link to request support. |
+| `ship.issueTracker.enabled` | boolean | `false` | Enable automatic issue state update after PR creation. Opt-in. |
+| `ship.issueTracker.teamPrefixes` | string[] | `["DIS", "ENG", "DISC"]` | Team keys to match in branch names (e.g. Linear team keys). **Edit this list to match your tracker workspace's team prefixes.** |
+| `ship.issueTracker.state` | string | `"In Review"` | The workflow state to transition the issue to. Must match a state name in your tracker workspace. |
+| `ship.issueTracker.prompt` | string | see default below | Customizable prompt template sent to the MCP. Supports `{issueId}`, `{state}`, `{provider}` placeholders. **Must restrict the action to one issue.** |
+
+**Default prompt:**
+```
+Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.
+```
 
 ### Examples
 


### PR DESCRIPTION
## Summary

Adds a provider-agnostic `ship.issueTracker` config to candid-ship that auto-transitions a tracked issue to a configured state after PR creation. Linear is the only supported provider today; the schema is built to extend to Asana, Jira, and others.

The default prompt encodes four safety invariants — single-issue scope, single-field scope (only `state` changes), idempotent no-op when already in target state, and no fallback search on missing-issue errors. `candid-init` writes the prompt into `.candid/config.json` so it's visible and easy to edit. The skill runs a pre-call invariant check that refuses the MCP call if a custom prompt has lost the single-issue restriction.

The step is opt-in and skips silently in every "can't run" case (no config, disabled, no provider, unsupported provider, MCP missing, no matching team prefix in branch, MCP error). Branches without a tracked issue and repos without the Linear MCP ship normally — the issue tracker is purely additive.

## Changes

- `skills/candid-ship/SKILL.md` — new optional Step 8 with provider routing, prompt rendering, and pre-call invariant check
- `skills/candid-init/SKILL.md` — Step 10.6f three-way prompt: Linear / other tracker (request support → links to GitHub issues) / skip
- `skills/candid-review/CONFIG.md` — full `issueTracker` schema, validation rules, and examples
- `docs/app/docs/reference/config-options/page.mdx` — complete `ship.*` schema added (was previously absent)
- `docs/app/docs/core-features/candid-ship/page.mdx` — new "Issue Tracker Integration" section with setup, custom-prompt examples, and skip-scenario table
- `docs/app/(marketing)/page.jsx` — homepage feature card linking to the new docs section
- `examples/ship/config.json` — adds the `issueTracker` block with the default prompt rendered visibly
- `CHANGELOG.md` — `1.13.0` entry
- `.claude-plugin/plugin.json` — version bumped to `1.13.0`

## Quality gates

- Candid review (constructive): ✅ — 3 fixes applied (drop unreachable skip path, replace unimplementable response check with pre-call invariant, align step-numbering convention)
- Security review: ✅ — no findings
- Docs build: ✅ — 39 pages indexed, all routes prerendered including the two new sections
- Pre-PR verification: ✅ — all 19 tracked tasks complete

## Test plan

- [ ] On a branch like `dis-509-foo` with `ship.issueTracker.enabled: true` and Linear MCP installed: `/candid-ship` should show "Updated DIS-509 → In Review" in the summary
- [ ] On a branch with no team prefix match: `/candid-ship` should skip silently with "No issue ID found in branch name — skipping"
- [ ] With `provider: "asana"`: `/candid-ship` should warn with the GitHub issues link and skip
- [ ] Without the Linear MCP installed: `/candid-ship` should skip silently with "Linear MCP not available"
- [ ] `/candid-init` 10.6f → "Yes — Linear" should write the default prompt into `.candid/config.json` (visible/editable)
- [ ] `/candid-init` 10.6f → "Yes — other tracker" should display the request-support message and omit the field

Closes #54