### PR TITLE
Add candid-fast-ship for low-risk shipping (v1.14.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-04-25
+
+### Added
+
+- **Candid Fast Ship** (`/candid-fast-ship`): A new minimal shipping command for low-risk changes. Unlike `/candid-ship` (which runs everything by default and lets you skip steps), `/candid-fast-ship` runs **nothing by default** and only executes the steps you explicitly enable in a new `fastShip` config block. PR creation is the only mandatory step
+  - **New `fastShip` config block** (sibling to `ship` in `.candid/config.json`): boolean toggles for `review`, `build`, `tests`, `issueTracker`, `autoMerge`, and `postMergeCommand` — all default to `false`. Optional `targetBranch` override
+  - **Inherits configuration from `ship`**: command values (`buildCommand`, `testCommand`, `postMergeCommand`), tracker config (`issueTracker.provider`, `state`, `prompt`, `teamPrefixes`), and target branch all come from the existing `ship` block — `fastShip` only controls which steps run, not how
+  - **Use cases**: hotfixes, docs updates, dependency bumps, config changes, or any class of changes where the full review cycle would be overkill
+  - **CLI flags**: `--auto-merge` / `--no-auto-merge` (override config), `--dry-run` (preview plan). No `--skip-*` flags — there's nothing to skip when steps are off by default
+  - **Graceful skipping**: enabling a step in `fastShip` without the corresponding `ship` configuration shows a clear `SKIPPED — not configured in ship` message rather than failing
+  - **candid-init flow**: new Step 10.7 prompts the user to configure `fastShip` after the main ship config is set, with preset options (None / Build only / Build + auto-merge / Custom)
+  - **Comprehensive docs**: dedicated `/docs/core-features/candid-fast-ship` page covering quick start, config block, relationship to `ship`, use cases (4 real examples), skip-behavior table, and a comparison table between `candid-ship` and `candid-fast-ship`
+  - **Config reference updated**: `docs/reference/config-options` now documents the full `fastShip` schema, and `skills/candid-review/CONFIG.md` covers the validation rules
+
 ## [1.13.0] - 2026-04-25
 
 ### Added

--- a/commands/candid-fast-ship.md
+++ b/commands/candid-fast-ship.md
@@ -1,0 +1,43 @@
+---
+command: candid-fast-ship
+description: Fast ship for low-risk changes — runs only the steps enabled in fastShip config
+skill: candid-fast-ship
+args:
+  - name: auto-merge
+    description: Enable auto-merge after PR creation (overrides fastShip config)
+    required: false
+  - name: no-auto-merge
+    description: Disable auto-merge even if fastShip config enables it
+    required: false
+  - name: dry-run
+    description: Show what would be done without executing
+    required: false
+---
+
+Fast ship your current branch — only the steps you've enabled in `fastShip` config will run. PR creation always runs. Everything else is off by default.
+
+Usage:
+```
+/candid-fast-ship                   # Ship with fastShip config defaults
+/candid-fast-ship --auto-merge      # Force auto-merge after PR creation
+/candid-fast-ship --no-auto-merge   # Skip auto-merge even if configured
+/candid-fast-ship --dry-run         # Show plan without executing
+```
+
+Configure which steps run in `.candid/config.json`:
+```json
+{
+  "fastShip": {
+    "review": false,
+    "build": false,
+    "tests": false,
+    "issueTracker": false,
+    "autoMerge": false,
+    "postMergeCommand": false
+  }
+}
+```
+
+Command values (buildCommand, testCommand, etc.) are inherited from the `ship` block.
+
+For a full ship with all steps, use `/candid-ship` instead.

--- a/docs/app/docs/core-features/_meta.js
+++ b/docs/app/docs/core-features/_meta.js
@@ -9,5 +9,6 @@ export default {
   'decision-register': 'Decision Register',
   'context-optimization': 'Context Optimization',
   'candid-ship': 'Candid Ship',
+  'candid-fast-ship': 'Candid Fast Ship',
   'slash-commands': 'Slash Commands',
 }

--- a/docs/app/docs/core-features/candid-fast-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-fast-ship/page.mdx
@@ -1,0 +1,225 @@
+export const metadata = {
+  title: 'Candid Fast Ship - Minimal PR Shipping for Low-Risk Changes',
+  description: 'Use candid-fast-ship to ship low-risk changes with only the steps you explicitly enable. Nothing runs by default except PR creation.',
+}
+
+# Candid Fast Ship
+
+Ship low-risk changes with a minimal, opt-in workflow.
+
+## Quick Start
+
+```
+/candid-fast-ship
+```
+
+`candid-fast-ship` is the opposite of `candid-ship`: instead of running everything by default and letting you skip steps, it runs **nothing by default** and only executes the steps you explicitly enable in your `fastShip` config. The only step that always runs is PR creation.
+
+This makes it ideal for changes where a full review cycle would be overkill — docs updates, config changes, dependency bumps, or hotfixes you've already verified locally.
+
+## How It Works
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Fast Ship Plan
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Branch: feature/update-readme → stable
+
+Steps:
+  1. 🔍 Review code (candid-loop)           SKIPPED — not enabled
+  2. 🔨 Build: npm run build                ENABLED
+  3. 🧪 Tests: npm test                     SKIPPED — not enabled
+  4. 📋 Create pull request
+  5. 🎯 Update issue tracker (linear)       SKIPPED — not enabled
+  6. 🔀 Auto-merge                          ENABLED
+```
+
+Before executing, the plan shows exactly which steps are enabled and which are skipped. Use `--dry-run` to preview without executing.
+
+## Configuration
+
+### CLI Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--auto-merge` | Enable auto-merge after PR creation | from config |
+| `--no-auto-merge` | Disable auto-merge even if config enables it | from config |
+| `--dry-run` | Show plan without executing | `false` |
+
+### fastShip Config Block
+
+Add to `.candid/config.json` alongside your `ship` block:
+
+```json
+{
+  "fastShip": {
+    "review": false,
+    "build": false,
+    "tests": false,
+    "issueTracker": false,
+    "autoMerge": false,
+    "postMergeCommand": false
+  }
+}
+```
+
+All fields default to `false`. Set any to `true` to enable that step.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `review` | boolean | `false` | Run `candid-loop` code review before creating the PR. |
+| `build` | boolean | `false` | Run `ship.buildCommand`. Skipped if `ship.buildCommand` is not set. |
+| `tests` | boolean | `false` | Run `ship.testCommand`. Skipped if `ship.testCommand` is not set. |
+| `issueTracker` | boolean | `false` | Update issue tracker after PR creation. Uses `ship.issueTracker` for provider/state/prompt config. |
+| `autoMerge` | boolean | `false` | Auto-merge the PR after creation via `gh pr merge --squash --auto`. |
+| `postMergeCommand` | boolean | `false` | Run `ship.postMergeCommand` after auto-merge succeeds. |
+| `targetBranch` | string | from `ship` or `mergeTargetBranches` | PR target branch override. |
+
+### Relationship to the `ship` Block
+
+`fastShip` is purely a set of on/off toggles. The actual commands and configuration for each step come from the existing `ship` block:
+
+| `fastShip` toggle | Where the config comes from |
+|-------------------|-----------------------------|
+| `build: true` | `ship.buildCommand` |
+| `tests: true` | `ship.testCommand` |
+| `issueTracker: true` | `ship.issueTracker` (provider, state, teamPrefixes, prompt) |
+| `postMergeCommand: true` | `ship.postMergeCommand` |
+
+This means you configure your commands once in `ship` and use them from both `/candid-ship` and `/candid-fast-ship`.
+
+## Use Cases
+
+### Docs and config changes — just create a PR
+
+```json
+{
+  "fastShip": {}
+}
+```
+
+Nothing runs. PR is created immediately, no confirmation loop.
+
+### Build check + auto-merge, skip review and tests
+
+```json
+{
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
+  }
+}
+```
+
+Useful for dependency bumps where CI handles testing but you want to confirm the build locally first.
+
+### Issue tracker update only (docs shipped, no code change)
+
+```json
+{
+  "fastShip": {
+    "issueTracker": true,
+    "autoMerge": true
+  }
+}
+```
+
+Creates the PR, moves the Linear issue to "In Review", and enables auto-merge — without touching review or tests.
+
+### Everything except review
+
+```json
+{
+  "fastShip": {
+    "build": true,
+    "tests": true,
+    "issueTracker": true,
+    "autoMerge": true,
+    "postMergeCommand": true
+  }
+}
+```
+
+Full pipeline minus the code review loop. Useful when you've already done review via a different mechanism.
+
+## When a Step Is Skipped
+
+If you enable a step but the required configuration isn't in your `ship` block, the step is skipped silently with a message:
+
+| Situation | Output |
+|-----------|--------|
+| `build: true` but no `ship.buildCommand` | `Skipping build (buildCommand not configured in ship)` |
+| `tests: true` but no `ship.testCommand` | `Skipping tests (testCommand not configured in ship)` |
+| `issueTracker: true` but no `ship.issueTracker` | `Skipping issue tracker (issueTracker not configured in ship)` |
+| `postMergeCommand: true` but `autoMerge` not enabled | `Skipping post-merge command (auto-merge not enabled)` |
+
+## Output Example
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Fast Ship Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Review:   SKIPPED
+Build:    PASS
+Tests:    SKIPPED
+PR:       https://github.com/org/repo/pull/42
+Issue:    Updated DIS-509 → In Review
+Merge:    Auto-merge enabled
+```
+
+## Choosing Between candid-ship and candid-fast-ship
+
+| | `/candid-ship` | `/candid-fast-ship` |
+|---|---|---|
+| Default behavior | Runs all configured steps | Runs nothing (PR only) |
+| Skipping steps | Use `--skip-*` flags | Don't enable them in config |
+| Best for | Feature work, any change needing review | Hotfixes, docs, config, low-risk changes |
+| Code review | Always runs (unless skipped) | Only if `review: true` |
+
+If you want to ship with just a subset of steps for a one-off run, use `/candid-ship --skip-review --skip-tests` (flags are per-run). If you have a class of changes that consistently need fewer checks, use `/candid-fast-ship` with those steps enabled in config.
+
+## Examples
+
+```bash
+# Fast ship with fastShip config defaults
+/candid-fast-ship
+
+# Override auto-merge for this run
+/candid-fast-ship --auto-merge
+/candid-fast-ship --no-auto-merge
+
+# Preview the plan without executing
+/candid-fast-ship --dry-run
+```
+
+## Full Config Example
+
+```json
+{
+  "version": 1,
+  "tone": "constructive",
+  "mergeTargetBranches": ["stable"],
+  "ship": {
+    "buildCommand": "npm run build",
+    "testCommand": "npm test",
+    "targetBranch": "stable",
+    "autoMerge": false,
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG"],
+      "state": "In Review"
+    }
+  },
+  "fastShip": {
+    "build": true,
+    "issueTracker": true,
+    "autoMerge": true
+  }
+}
+```
+
+Then `/candid-fast-ship` runs build, creates the PR, updates the Linear issue, and enables auto-merge — no review, no tests.

--- a/docs/app/docs/core-features/candid-fast-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-fast-ship/page.mdx
@@ -99,7 +99,7 @@ This means you configure your commands once in `ship` and use them from both `/c
 }
 ```
 
-Nothing runs. PR is created immediately, no confirmation loop.
+Nothing runs except PR creation. The plan still confirms before executing.
 
 ### Build check + auto-merge, skip review and tests
 

--- a/docs/app/docs/core-features/slash-commands/page.mdx
+++ b/docs/app/docs/core-features/slash-commands/page.mdx
@@ -126,6 +126,32 @@ Ship your branch — review, build, test, create PR, and optionally auto-merge.
 /candid-ship --skip-review --skip-build --skip-tests
 ```
 
+## /candid-fast-ship
+
+Ship low-risk changes — only the steps you enable in `fastShip` config will run.
+
+```
+/candid-fast-ship
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--auto-merge` | Enable auto-merge after PR creation |
+| `--no-auto-merge` | Disable auto-merge even if config enables it |
+| `--dry-run` | Show plan without executing |
+
+### Examples
+
+```
+/candid-fast-ship
+/candid-fast-ship --auto-merge
+/candid-fast-ship --dry-run
+```
+
+Configure which steps run in `.candid/config.json` under the `fastShip` key. See [Candid Fast Ship](/docs/core-features/candid-fast-ship) for full documentation.
+
 ## /candid-validate-standards
 
 Check your Technical.md for issues.

--- a/docs/app/docs/reference/config-options/page.mdx
+++ b/docs/app/docs/reference/config-options/page.mdx
@@ -30,6 +30,15 @@ Complete reference for Candid configuration.
       "state": "string",
       "prompt": "string"
     }
+  },
+  "fastShip": {
+    "review": boolean,
+    "build": boolean,
+    "tests": boolean,
+    "issueTracker": boolean,
+    "autoMerge": boolean,
+    "postMergeCommand": boolean,
+    "targetBranch": "string"
   }
 }
 ```
@@ -190,6 +199,37 @@ Example:
 - provider is unsupported (anything other than `"linear"`) → warning with link to issue tracker, step skipped, ship continues
 
 See [Candid Ship — Issue Tracker Integration](/docs/core-features/candid-ship#issue-tracker-integration) for full setup and usage.
+
+### fastShip
+
+Configuration for the [`/candid-fast-ship`](/docs/core-features/candid-fast-ship) minimal shipping workflow. All steps are opt-in — nothing runs by default except PR creation. Command values are inherited from the `ship` block.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `review` | boolean | `false` | Run candid-loop code review. |
+| `build` | boolean | `false` | Run `ship.buildCommand`. Skipped if not configured in `ship`. |
+| `tests` | boolean | `false` | Run `ship.testCommand`. Skipped if not configured in `ship`. |
+| `issueTracker` | boolean | `false` | Update issue tracker after PR creation. Uses `ship.issueTracker` config. |
+| `autoMerge` | boolean | `false` | Auto-merge the PR after creation. |
+| `postMergeCommand` | boolean | `false` | Run `ship.postMergeCommand` after auto-merge succeeds. |
+| `targetBranch` | string | from `ship.targetBranch` or `mergeTargetBranches` | PR target branch override. |
+
+Example (build check + auto-merge, no review):
+
+```json
+{
+  "ship": {
+    "buildCommand": "npm run build",
+    "targetBranch": "stable"
+  },
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
+  }
+}
+```
+
+See [Candid Fast Ship](/docs/core-features/candid-fast-ship) for full documentation.
 
 ## Config Precedence
 

--- a/skills/candid-fast-ship/SKILL.md
+++ b/skills/candid-fast-ship/SKILL.md
@@ -1,0 +1,532 @@
+---
+name: candid-fast-ship
+description: Fast ship for low-risk changes — runs only the steps you explicitly enable in fastShip config
+---
+
+# Candid Fast Ship
+
+A minimal shipping path for low-risk changes. Unlike `candid-ship`, which runs all steps by default and lets you opt out, `candid-fast-ship` runs **nothing by default** and only executes the steps you explicitly enable in the `fastShip` configuration block.
+
+Step configuration (commands, target branch, issue tracker details) is inherited from the existing `ship` block. `fastShip` is purely a set of on/off toggles that sit on top of it.
+
+## Workflow
+
+Execute these steps in order:
+
+### Step 1: Pre-Flight Checks
+
+Verify the environment is ready for shipping.
+
+#### 1.1: Check gh CLI
+
+```bash
+gh auth status 2>&1
+```
+
+If command fails or `gh` not found:
+```
+Pre-flight failed: GitHub CLI (gh) is not installed or not authenticated.
+Install: https://cli.github.com/
+Authenticate: gh auth login
+```
+Abort.
+
+#### 1.2: Check Git Repository
+
+```bash
+git rev-parse --is-inside-work-tree 2>&1
+```
+
+If not inside a git repo: abort with `Pre-flight failed: Not inside a git repository.`
+
+#### 1.3: Check Current Branch
+
+```bash
+git branch --show-current
+```
+
+Store as `currentBranch`. If empty (detached HEAD): abort with `Pre-flight failed: Detached HEAD state. Check out a branch first.`
+
+### Step 2: Load Configuration
+
+Load `fastShip` toggles from config and `ship` field for command values.
+
+**Precedence (highest to lowest):**
+1. CLI flags
+2. Project config (`.candid/config.json` → `fastShip` field)
+3. User config (`~/.candid/config.json` → `fastShip` field)
+4. Defaults (all steps disabled)
+
+#### Parse CLI Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--auto-merge` | Enable auto-merge (overrides fastShip config) | from config |
+| `--no-auto-merge` | Disable auto-merge (overrides fastShip config) | from config |
+| `--dry-run` | Show plan without executing | `false` |
+
+If both `--auto-merge` and `--no-auto-merge` are provided, `--no-auto-merge` wins.
+
+#### Check Project Config — fastShip Field
+
+```bash
+jq -r '.fastShip // null' .candid/config.json 2>/dev/null
+```
+
+If the `fastShip` field exists, extract these boolean toggles (all default to `false` if absent):
+- `review` (boolean) — run candid-loop code review
+- `build` (boolean) — run build command
+- `tests` (boolean) — run test command
+- `issueTracker` (boolean) — update issue tracker
+- `autoMerge` (boolean) — enable auto-merge
+- `postMergeCommand` (boolean) — run post-merge shell command
+- `targetBranch` (string) — PR target branch override
+
+Output when loading: `Using fastShip settings from project config`
+
+#### Check User Config — fastShip Field
+
+Same procedure for `~/.candid/config.json` if project config doesn't have a `fastShip` field.
+
+Output when loading: `Using fastShip settings from user config`
+
+#### Load ship Field for Command Values
+
+```bash
+jq -r '.ship // null' .candid/config.json 2>/dev/null
+```
+
+Load from project config → user config → defaults. Extract:
+- `buildCommand` — used when `fastShip.build` is enabled
+- `testCommand` — used when `fastShip.tests` is enabled
+- `targetBranch` — fallback if `fastShip.targetBranch` not set
+- `additionalPrompt` — passed to candid-loop if `fastShip.review` is enabled
+- `postMergeCommand` — used when `fastShip.postMergeCommand` is enabled
+- `issueTracker` — full issueTracker config object, used when `fastShip.issueTracker` is enabled
+
+#### Resolve targetBranch
+
+Priority: `fastShip.targetBranch` → `ship.targetBranch` → `mergeTargetBranches[0]` → `"main"`
+
+Verify the target branch exists:
+```bash
+git rev-parse --verify [targetBranch] 2>/dev/null || git rev-parse --verify origin/[targetBranch] 2>/dev/null
+```
+
+If target branch doesn't exist: abort with `Target branch "[targetBranch]" does not exist locally or on remote.`
+
+#### Validate Current Branch != Target Branch
+
+If `currentBranch == targetBranch`:
+```
+Cannot ship: you are on the target branch ([targetBranch]). Check out a feature branch first.
+```
+Abort.
+
+#### Check Commits Ahead
+
+```bash
+git log --oneline [targetBranch]..HEAD 2>/dev/null | head -20
+```
+
+If no commits ahead: abort with `No commits ahead of [targetBranch]. Nothing to ship.`
+
+### Step 3: Display Plan
+
+Determine which steps are enabled and configured. A step is **ENABLED** only when its toggle is `true` AND (for build/tests/postMerge) the corresponding command is set in `ship`, or (for issueTracker) `ship.issueTracker` is present with a supported provider.
+
+Calculate `totalSteps` as the count of steps that will actually execute (PR creation always counts as 1; add 1 for each enabled+configured optional step).
+
+Renumber displayed steps to skip any that are fully skipped.
+
+Show what will be executed:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Fast Ship Plan
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Branch: [currentBranch] → [targetBranch]
+
+Steps:
+  1. 🔍 Review code (candid-loop)           [ENABLED | SKIPPED — not enabled]
+  2. 🔨 Build: [buildCommand]               [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  3. 🧪 Tests: [testCommand]                [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  4. 📋 Create pull request
+  5. 🎯 Update issue tracker ([provider])   [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  6. 🔀 Auto-merge                          [ENABLED | SKIPPED — not enabled]
+  7. 🚀 Post-merge: [postMergeCommand]      [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+```
+
+If all optional steps are disabled:
+```
+  (All optional steps disabled — only PR creation will run)
+```
+
+**If `--dry-run`:**
+Output: `Dry run complete. No changes made.`
+Exit.
+
+**If not dry-run:** Use AskUserQuestion:
+
+**Question:** "Proceed with this fast ship plan?"
+
+**Options:**
+1. "Yes, ship it"
+2. "No, cancel"
+
+If "No, cancel": exit with `Fast ship cancelled.`
+
+### Step 4: Run Review (Optional)
+
+**Skip if** `fastShip.review` is `false`. Output: `Skipping review (not enabled in fastShip config)`
+
+Display:
+```
+Step [N]/[totalSteps]: Running code review...
+```
+
+Invoke candid-loop via the Skill tool: `/candid-loop`
+
+If `additionalPrompt` is set (from `ship.additionalPrompt`), include it:
+> "IMPORTANT: During this review, also consider the following additional context: [additionalPrompt]"
+
+After candid-loop completes, check its summary output:
+
+- **If PASS**: continue. Output: `Review passed.`
+- **If INCOMPLETE** (max iterations reached with remaining issues): Use AskUserQuestion:
+  - **Question:** "Review completed with remaining issues. Continue shipping?"
+  - **Options:**
+    1. "Yes, continue anyway"
+    2. "No, abort"
+  - If "No, abort": exit with `Fast ship aborted: unresolved review issues.`
+- **If CANCELLED**: abort with `Fast ship aborted: review was cancelled.`
+
+### Step 5: Run Build (Optional)
+
+**Skip if** `fastShip.build` is `false`. Output: `Skipping build (not enabled in fastShip config)`
+
+**Skip if** `fastShip.build` is `true` but `ship.buildCommand` is not set. Output: `Skipping build (buildCommand not configured in ship)`
+
+Display:
+```
+Step [N]/[totalSteps]: Running build...
+$ [buildCommand]
+```
+
+Execute the build command:
+```bash
+[buildCommand]
+```
+
+**If build fails** (non-zero exit code):
+```
+Build failed. Fast ship aborted.
+```
+Show the build output so the user can diagnose.
+Abort.
+
+**If build succeeds:**
+```
+Build passed.
+```
+
+### Step 6: Run Tests (Optional)
+
+**Skip if** `fastShip.tests` is `false`. Output: `Skipping tests (not enabled in fastShip config)`
+
+**Skip if** `fastShip.tests` is `true` but `ship.testCommand` is not set. Output: `Skipping tests (testCommand not configured in ship)`
+
+Display:
+```
+Step [N]/[totalSteps]: Running tests...
+$ [testCommand]
+```
+
+Execute the test command:
+```bash
+[testCommand]
+```
+
+**If tests fail** (non-zero exit code):
+```
+Tests failed. Fast ship aborted.
+```
+Show the test output so the user can diagnose.
+Abort.
+
+**If tests succeed:**
+```
+Tests passed.
+```
+
+### Step 7: Create Pull Request
+
+Display:
+```
+Step [N]/[totalSteps]: Creating pull request...
+```
+
+#### 7.1: Generate PR Title
+
+```bash
+git log [targetBranch]..HEAD --oneline
+```
+
+- **Single commit:** Use that commit message as the title
+- **Multiple commits:** Clean the branch name into a title:
+  - Remove prefix (e.g., `feature/`, `fix/`, `ron-myers/`)
+  - Replace hyphens/underscores with spaces
+  - Capitalize first letter
+  - Example: `feature/add-auth-middleware` → `Add auth middleware`
+
+Truncate title to 70 characters if needed.
+
+#### 7.2: Generate PR Body
+
+```bash
+git log [targetBranch]..HEAD --pretty=format:"- %s"
+```
+
+Assemble the body:
+
+```markdown
+## Summary
+[commit list from git log]
+
+## Verification
+- Review: [PASS — N iterations, M issues fixed | SKIPPED]
+- Build: [PASS | SKIPPED]
+- Tests: [PASS | SKIPPED]
+
+---
+*Shipped with [candid-fast-ship](https://github.com/ron-myers/candid)*
+```
+
+#### 7.3: Push Branch
+
+```bash
+git push -u origin [currentBranch]
+```
+
+If push fails, abort with error message.
+
+#### 7.4: Create PR
+
+```bash
+gh pr create --base [targetBranch] --title "[title]" --body "[body]"
+```
+
+Capture the PR URL from stdout. If creation fails, abort with error message.
+
+Output: `PR created: [URL]`
+
+### Step 8: Update Issue Tracker (Optional)
+
+**Skip if** `fastShip.issueTracker` is `false`. Output: `Skipping issue tracker (not enabled in fastShip config)`
+
+**Skip if** `fastShip.issueTracker` is `true` but `ship.issueTracker` is not present in config. Output: `Skipping issue tracker (issueTracker not configured in ship)`
+
+**Skip if** `ship.issueTracker.provider` is `"none"`. Output: `Skipping issue tracker update (provider set to "none")`
+
+**Skip if** `ship.issueTracker.provider` is anything other than `"linear"`:
+```
+⚠️  Issue tracker provider "[provider]" is not yet supported.
+Request support at: https://github.com/ron-myers/candid/issues
+```
+Continue to Step 9.
+
+**Skip if** `ship.issueTracker.provider` is `"linear"` but the Linear MCP tool (`mcp__claude_ai_Linear__save_issue`) is unavailable. Output: `Linear MCP not available — skipping issue update`
+
+Note: `fastShip.issueTracker: true` acts as the enable toggle — `ship.issueTracker.enabled` is ignored in fast ship mode.
+
+If enabled and configured, proceed using the same logic as candid-ship Step 8 (extract issue ID from branch name, render prompt, pre-call invariant check, call MCP).
+
+Display:
+```
+Step [N]/[totalSteps]: Updating issue tracker ([provider])...
+```
+
+Use `ship.issueTracker.teamPrefixes`, `ship.issueTracker.state`, and `ship.issueTracker.prompt` for the update.
+
+**On success:** Output: `Updated [issueId] → [state]`
+
+**On error:**
+```
+⚠️  Issue tracker update failed: [error message]
+PR is still open at: [URL]
+```
+Do NOT abort.
+
+### Step 9: Auto-Merge (Optional)
+
+**Skip if** `fastShip.autoMerge` is `false`. Output: `Auto-merge: disabled (manual merge required)`
+
+If `fastShip.autoMerge` is `true`:
+
+Display:
+```
+Step [N]/[totalSteps]: Enabling auto-merge...
+```
+
+```bash
+gh pr merge [PR_URL] --squash --auto
+```
+
+If auto-merge fails:
+```
+⚠️  Auto-merge failed: [error message]
+The repository may not have auto-merge enabled in Settings → General → Pull Requests.
+PR is still open at: [URL]
+```
+Do NOT abort.
+
+If auto-merge succeeds:
+```
+Auto-merge enabled. PR will merge when checks pass.
+```
+
+### Step 10: Run Post-Merge Command (Optional)
+
+**Skip if** `fastShip.postMergeCommand` is `false`. Output: `Skipping post-merge command (not enabled in fastShip config)`
+
+**Skip if** `fastShip.postMergeCommand` is `true` but `ship.postMergeCommand` is not set. Output: `Skipping post-merge command (postMergeCommand not configured in ship)`
+
+**Skip if** `fastShip.autoMerge` is `false`. Output: `Skipping post-merge command (auto-merge not enabled)`
+
+**Skip if** auto-merge failed in Step 9. Output: `Skipping post-merge command (auto-merge failed)`
+
+If all conditions are met:
+
+Display:
+```
+Step [N]/[totalSteps]: Running post-merge command...
+$ [postMergeCommand]
+```
+
+Execute:
+```bash
+[postMergeCommand]
+```
+
+**If command fails:**
+```
+⚠️  Post-merge command failed: [error output]
+PR is still merging at: [URL]
+```
+Do NOT abort.
+
+**If command succeeds:**
+```
+Post-merge command completed.
+```
+
+### Step 11: Display Summary
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Fast Ship Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Review:   [PASS (N iterations, M issues fixed) | SKIPPED]
+Build:    [PASS | SKIPPED]
+Tests:    [PASS | SKIPPED]
+PR:       [URL]
+Issue:    [Updated DIS-509 → In Review | Skipped | Failed: <error>]
+Merge:    [Auto-merge enabled | Manual merge required | Auto-merge failed]
+Post-merge: [PASS | SKIPPED | FAILED | N/A]
+```
+
+## Configuration
+
+### fastShip Config Block
+
+Add to `.candid/config.json` alongside the `ship` field:
+
+```json
+{
+  "fastShip": {
+    "review": false,
+    "build": false,
+    "tests": false,
+    "issueTracker": false,
+    "autoMerge": false,
+    "postMergeCommand": false,
+    "targetBranch": "stable"
+  }
+}
+```
+
+All fields are optional. Boolean fields default to `false`. `targetBranch` defaults to `ship.targetBranch` → `mergeTargetBranches[0]` → `"main"`.
+
+Command values, target branch, and issue tracker configuration are inherited from the `ship` block — `fastShip` only controls which steps run.
+
+### Field Descriptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `fastShip.review` | boolean | `false` | Run candid-loop code review before creating PR. |
+| `fastShip.build` | boolean | `false` | Run `ship.buildCommand` before creating PR. Skipped if `ship.buildCommand` is not set. |
+| `fastShip.tests` | boolean | `false` | Run `ship.testCommand` before creating PR. Skipped if `ship.testCommand` is not set. |
+| `fastShip.issueTracker` | boolean | `false` | Update issue tracker after PR creation. Uses `ship.issueTracker` for provider/state/prompt config. Skipped if `ship.issueTracker` is not configured. |
+| `fastShip.autoMerge` | boolean | `false` | Auto-merge PR after creation via `gh pr merge --squash --auto`. |
+| `fastShip.postMergeCommand` | boolean | `false` | Run `ship.postMergeCommand` after auto-merge succeeds. Skipped if `ship.postMergeCommand` is not set or auto-merge is not enabled. |
+| `fastShip.targetBranch` | string | `ship.targetBranch` or first `mergeTargetBranches` or `"main"` | PR target branch. |
+
+### Examples
+
+**Minimal — just create a PR:**
+```json
+{
+  "fastShip": {}
+}
+```
+
+**Build check + PR only:**
+```json
+{
+  "fastShip": {
+    "build": true
+  }
+}
+```
+
+**Build + auto-merge (no review, no tests):**
+```json
+{
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
+  }
+}
+```
+
+**Docs change — just PR and issue tracker update:**
+```json
+{
+  "fastShip": {
+    "issueTracker": true,
+    "autoMerge": true
+  }
+}
+```
+
+## CLI Examples
+
+```bash
+# Fast ship with fastShip config defaults
+/candid-fast-ship
+
+# Override auto-merge flag
+/candid-fast-ship --auto-merge
+/candid-fast-ship --no-auto-merge
+
+# Preview plan without executing
+/candid-fast-ship --dry-run
+```
+
+## Remember
+
+`candid-fast-ship` is **opt-in by default** — nothing runs unless you explicitly enable it in `fastShip` config. Use it for low-risk changes where the full `candid-ship` review cycle would be overkill: hotfixes, docs updates, config changes, dependency bumps.
+
+For anything that needs review, use `/candid-ship` or enable `fastShip.review: true`.

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -1139,7 +1139,46 @@ In either case, write the resulting `prompt` field into the config:
 
 The skill's runtime default is identical to the value written here — the explicit-in-config approach simply makes the prompt visible to the user without changing behavior.
 
-### 10.7: Preview and Confirm
+### 10.7: Fast Ship Configuration
+
+Use AskUserQuestion:
+
+**Question:** "Configure `candid-fast-ship`? It's a minimal ship path that runs only the steps you enable — nothing runs by default except PR creation. (Command values are inherited from the `ship` block you just configured.)"
+
+**Options:**
+1. "Yes, configure fast ship"
+2. "No, skip"
+
+If "No, skip" → omit `fastShip` field. Proceed to Step 10.8.
+
+If "Yes, configure fast ship":
+
+Use AskUserQuestion:
+
+**Question:** "Which steps should `candid-fast-ship` enable by default?"
+
+**Options:**
+1. "None — PR creation only (safest default, decide per-run)"
+2. "Build only"
+3. "Build + auto-merge"
+4. "Custom — let me choose"
+
+If "Custom — let me choose": Ask the user to confirm each of the following with Yes/No:
+- Enable review (candid-loop)?
+- Enable build? (only shown if `ship.buildCommand` was configured)
+- Enable tests? (only shown if `ship.testCommand` was configured)
+- Enable issue tracker update? (only shown if `ship.issueTracker` was configured)
+- Enable auto-merge?
+- Enable post-merge command? (only shown if `ship.postMergeCommand` was configured)
+
+Build the `fastShip` object from the selections. Set only fields that the user explicitly enabled to `true`; omit fields that are `false` (they default to `false` when absent). Always omit `targetBranch` from the generated config (it falls back to `ship.targetBranch` automatically).
+
+For the preset options:
+- "None" → `"fastShip": {}`
+- "Build only" → `"fastShip": { "build": true }` (omit if `ship.buildCommand` not configured; use `{}` instead with a note)
+- "Build + auto-merge" → `"fastShip": { "build": true, "autoMerge": true }` (same caveat for build)
+
+### 10.8: Preview and Confirm
 
 Assemble the config object from all detected and prompted values. Only include fields that were explicitly set — omit fields the user skipped (they default correctly when absent).
 
@@ -1162,9 +1201,15 @@ Show the assembled config as valid JSON. Example with all fields enabled:
     "testCommand": "npm test",
     "targetBranch": "main",
     "autoMerge": false
+  },
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
   }
 }
 ```
+
+Include the `fastShip` field in the preview only if the user configured it in Step 10.7. Omit it entirely if the user skipped fast ship configuration.
 
 Only include fields the user selected — omit any they skipped.
 
@@ -1249,6 +1294,8 @@ A fresh init with `--optimize` therefore yields mostly Technical.md findings, wi
 
 ⚙️  Configuration
    Location: .candid/config.json
+   Ship: [configured | not configured]
+   Fast Ship: [configured ([N] steps enabled) | not configured]
 
 📝 Next Steps
    1. Review architecture rules - ensure they match your intent

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -1235,7 +1235,7 @@ mkdir -p .candid
 
 Use the Write tool to create:
 - `.candid/Technical.md` (or the path passed via `--output`) — the synthesized content from Step 9
-- `.candid/config.json` — the assembled config from Step 10.7
+- `.candid/config.json` — the assembled config from Step 10.8
 
 ### 11.2: Optionally Run Optimize Stage
 

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -36,6 +36,15 @@ Valid config file format:
       "state": "In Review",
       "prompt": "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
     }
+  },
+  "fastShip": {
+    "review": false,
+    "build": false,
+    "tests": false,
+    "issueTracker": false,
+    "autoMerge": false,
+    "postMergeCommand": false,
+    "targetBranch": "stable"
   }
 }
 ```
@@ -74,6 +83,14 @@ Valid config file format:
     - `ship.issueTracker.teamPrefixes` (optional): Array of team key prefixes to match in branch names (e.g. for Linear, the letters before the dash in any issue ID). Defaults to `["DIS", "ENG", "DISC"]` — **edit this to match your tracker workspace's team keys.** Must be an array of non-empty strings.
     - `ship.issueTracker.state` (optional): The workflow state to transition the issue to. Defaults to `"In Review"`. Must match a state name in your tracker workspace exactly (case-sensitive). Must be a non-empty string.
     - `ship.issueTracker.prompt` (optional): Customizable prompt template sent to the tracker's MCP server. Supports `{issueId}`, `{state}`, and `{provider}` placeholders. The rendered prompt **must restrict the action to a single issue** — multiple-issue updates are explicitly disallowed. Defaults to: `Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.` This default also restricts the change to the `state` field (no assignee/label/title changes), is idempotent (no-op if already in `{state}`), and stops on a missing-issue error rather than searching for a fallback. candid-init writes this default into `.candid/config.json` so it's discoverable and easy to edit. Must be a non-empty string.
+- `fastShip` (optional): Configuration for the `candid-fast-ship` minimal shipping workflow. Unlike `ship` (which runs all steps by default), `fastShip` is **opt-in**: every step is disabled by default and must be explicitly enabled. Command values and issue tracker configuration are inherited from the `ship` block. If not present, `candid-fast-ship` runs with all steps disabled (PR creation only).
+  - `fastShip.review` (optional): Run candid-loop code review. Defaults to `false`. Must be a boolean.
+  - `fastShip.build` (optional): Run `ship.buildCommand`. Skipped silently if `ship.buildCommand` is not set. Defaults to `false`. Must be a boolean.
+  - `fastShip.tests` (optional): Run `ship.testCommand`. Skipped silently if `ship.testCommand` is not set. Defaults to `false`. Must be a boolean.
+  - `fastShip.issueTracker` (optional): Update issue tracker after PR creation. Uses `ship.issueTracker` for provider, state, and prompt configuration. `ship.issueTracker.enabled` is ignored — this toggle takes precedence. Skipped silently if `ship.issueTracker` is not configured. Defaults to `false`. Must be a boolean.
+  - `fastShip.autoMerge` (optional): Auto-merge PR via `gh pr merge --squash --auto`. Defaults to `false`. Must be a boolean.
+  - `fastShip.postMergeCommand` (optional): Run `ship.postMergeCommand` after auto-merge succeeds. Only executes when `fastShip.autoMerge` is `true` and auto-merge succeeds. Skipped silently if `ship.postMergeCommand` is not set. Defaults to `false`. Must be a boolean.
+  - `fastShip.targetBranch` (optional): PR target branch. Defaults to `ship.targetBranch` → first `mergeTargetBranches` entry → `"main"`. Must be a non-empty string.
 
 ## Validation Rules
 
@@ -85,7 +102,8 @@ Valid config file format:
 6. **AutoCommit field validation** - If `autoCommit` field is present, must be a boolean (`true` or `false`). Invalid values show warning and are ignored.
 7. **DecisionRegister field validation** - If `decisionRegister` field is present, must be an object. If `decisionRegister.enabled` is present, must be a boolean. If `decisionRegister.path` is present, must be a non-empty string. If `decisionRegister.mode` is present, must be exactly `"lookup"` or `"load"` (case-sensitive). Invalid values show warning and are ignored (feature defaults to disabled).
 8. **Ship field validation** - If `ship` field is present, must be an object. If `ship.buildCommand` is present, must be a non-empty string. If `ship.testCommand` is present, must be a non-empty string. If `ship.targetBranch` is present, must be a non-empty string. If `ship.autoMerge` is present, must be a boolean. If `ship.additionalPrompt` is present, must be a non-empty string. If `ship.postMergeCommand` is present, must be a non-empty string. If `ship.issueTracker` is present, must be an object. If `ship.issueTracker.provider` is present, must be a non-empty string. If `ship.issueTracker.enabled` is present, must be a boolean. If `ship.issueTracker.teamPrefixes` is present, must be an array of non-empty strings. If `ship.issueTracker.state` is present, must be a non-empty string. If `ship.issueTracker.prompt` is present, must be a non-empty string. Invalid values show warning and are ignored — the ship continues without the issue tracker step.
-9. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, `autoCommit`, `decisionRegister`, and `ship` are ignored for forward compatibility
+9. **FastShip field validation** - If `fastShip` field is present, must be an object. Boolean fields (`review`, `build`, `tests`, `issueTracker`, `autoMerge`, `postMergeCommand`) must be booleans if present. `targetBranch` must be a non-empty string if present. Invalid values show warning and are ignored — `fastShip` defaults to all steps disabled.
+10. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, `autoCommit`, `decisionRegister`, `ship`, and `fastShip` are ignored for forward compatibility
 10. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
 
 ## Config Validation Procedure
@@ -363,6 +381,36 @@ Using constructive tone (from interactive prompt)
       "teamPrefixes": ["DIS", "ENG", "DISC"],
       "state": "In Review"
     }
+  },
+  "fastShip": {
+    "build": true,
+    "issueTracker": true,
+    "autoMerge": true
+  }
+}
+```
+
+**With fast ship only (minimal PR creation):**
+```json
+{
+  "ship": {
+    "buildCommand": "npm run build",
+    "targetBranch": "main"
+  },
+  "fastShip": {}
+}
+```
+
+**Fast ship with build and auto-merge:**
+```json
+{
+  "ship": {
+    "buildCommand": "npm run build",
+    "targetBranch": "stable"
+  },
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
   }
 }
 ```

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -42,7 +42,7 @@ Valid config file format:
     "build": false,
     "tests": false,
     "issueTracker": false,
-    "autoMerge": false,
+    "autoMerge": true,
     "postMergeCommand": false,
     "targetBranch": "stable"
   }


### PR DESCRIPTION
## Summary

- Add `/candid-fast-ship` — a minimal shipping path for low-risk changes that runs **nothing by default** and only executes the steps explicitly enabled in a new `fastShip` config block (PR creation is the only mandatory step)
- Add `fastShip` config block (sibling to `ship`) with boolean toggles for `review`, `build`, `tests`, `issueTracker`, `autoMerge`, `postMergeCommand` plus optional `targetBranch`. Command values and tracker config are inherited from the existing `ship` block
- Integrate into candid-init flow (new Step 10.7), CONFIG.md schema/validation, and full documentation (dedicated docs page, slash-commands entry, config-options reference)
- Bump plugin version 1.13.0 → 1.14.0 with CHANGELOG entry

## Verification

- Review: PASS (2 iterations, 2 issues fixed)
- Build: SKIPPED (not configured)
- Tests: SKIPPED (not configured)
- Docs site: builds successfully (40 pages indexed)

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*