### PR TITLE
Optimize candid-ship workflow + add installCommand (v1.15.0)

### DIFF
--- a/.candid/Technical.md
+++ b/.candid/Technical.md
@@ -75,8 +75,9 @@ that Claude executes as a structured workflow:
 **Skill Files (`skills/*/SKILL.md`):**
 - Must respect 3-level config precedence: CLI args → `.candid/config.json` → `~/.candid/config.json` → defaults
 - Must check for `.candid/Technical.md` before enforcing standards; gracefully proceed without it
-- Must not depend on other skills directly — coordinate through shared config only
-- Reference: `skills/candid-review/SKILL.md` Step 1 and Step 2.5
+- Must not depend on other skills' workflow logic directly — coordinate through shared config or shared specs
+- Cross-skill shared specifications live alongside their primary skill (e.g. `candid-review/CONFIG.md`, `candid-ship/WORKFLOW.md`). When extracting common steps from a skill workflow, prefer this pattern over duplication.
+- Reference: `skills/candid-review/SKILL.md` Step 1 and Step 2.5; `skills/candid-ship/WORKFLOW.md`
 
 **Documentation Website (`docs/`):**
 - Server Components (layouts, static pages): must NOT use `'use client'`, must NOT use React hooks directly

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-04-25
+
+### Added
+
+- **Install step** (`ship.installCommand` / `fastShip.install`): New optional step that runs a dependency-install command before build and tests. Addresses the common failure mode where build/test logs are really stale-dependency errors. Common values: `pnpm install`, `npm ci`, `poetry install`, `bundle install`. Opt-in — leave `installCommand` unset to skip the step entirely
+  - **`ship.installCommand`** — runs by default in `/candid-ship` when set, skipped silently when unset
+  - **`fastShip.install`** — explicit toggle for `/candid-fast-ship`; requires `ship.installCommand` to be configured
+  - **`--skip-install`** flag on `/candid-ship` for one-off skips when deps are known to be current
+  - **PR body** now includes an `Install: PASS | SKIPPED` row in the Verification block
+  - **Summary output** includes an `Install:` row when `installCommand` is configured
+
+### Changed
+
+- **Shared shipping workflow** extracted to `skills/candid-ship/WORKFLOW.md`. Both `candid-ship` and `candid-fast-ship` now reference this single document for the mechanics of pre-flight, install, build, tests, PR creation, issue tracker, auto-merge, post-merge, and summary. Each skill owns only the **skip semantics** unique to its mode (`--skip-*` flags vs `fastShip.*` toggles). Removes ~80% duplication between the two skill files and substantially reduces tokens loaded per shipping invocation
+- **`candid-ship` SKILL.md** trimmed from 631 → ~180 lines. Field-descriptions table now references `skills/candid-review/CONFIG.md` rather than restating it
+- **`candid-fast-ship` SKILL.md** trimmed from 532 → ~180 lines. Same dedup pattern
+- **Single `git log` call** during PR creation now serves both title generation and body generation (previously three separate calls on the same range)
+- **`git rev-list --count`** replaces `git log | head -20` for the commits-ahead pre-flight check
+
 ## [1.14.0] - 2026-04-25
 
 ### Added

--- a/commands/candid-fast-ship.md
+++ b/commands/candid-fast-ship.md
@@ -29,6 +29,7 @@ Configure which steps run in `.candid/config.json`:
 {
   "fastShip": {
     "review": false,
+    "install": false,
     "build": false,
     "tests": false,
     "issueTracker": false,

--- a/commands/candid-ship.md
+++ b/commands/candid-ship.md
@@ -12,6 +12,9 @@ args:
   - name: skip-review
     description: Skip the candid-loop review step
     required: false
+  - name: skip-install
+    description: Skip the dependency install step
+    required: false
   - name: skip-build
     description: Skip the build verification step
     required: false
@@ -30,7 +33,8 @@ Usage:
 /candid-ship                        # Full workflow with config defaults
 /candid-ship --auto-merge           # Force auto-merge after PR creation
 /candid-ship --no-auto-merge        # Skip auto-merge even if configured
-/candid-ship --skip-review          # Skip candid-loop, go straight to build/test/PR
+/candid-ship --skip-review          # Skip candid-loop, go straight to install/build/test/PR
+/candid-ship --skip-install         # Skip dependency install
 /candid-ship --skip-build           # Skip build verification
 /candid-ship --skip-tests           # Skip test execution
 /candid-ship --dry-run              # Show plan without executing
@@ -39,7 +43,9 @@ Usage:
 The workflow:
 1. Pre-flight checks (gh CLI, git repo, branch validation)
 2. Run candid-loop to review and fix code issues
-3. Execute configured build command
-4. Execute configured test command
-5. Create pull request via gh CLI
-6. Optionally auto-merge via gh pr merge --squash --auto
+3. Install dependencies (when ship.installCommand is configured)
+4. Execute configured build command
+5. Execute configured test command
+6. Create pull request via gh CLI
+7. Optionally update issue tracker (Linear) via MCP
+8. Optionally auto-merge via gh pr merge --squash --auto

--- a/docs/app/docs/core-features/candid-fast-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-fast-ship/page.mdx
@@ -28,11 +28,12 @@ Branch: feature/update-readme → stable
 
 Steps:
   1. 🔍 Review code (candid-loop)           SKIPPED — not enabled
-  2. 🔨 Build: npm run build                ENABLED
-  3. 🧪 Tests: npm test                     SKIPPED — not enabled
-  4. 📋 Create pull request
-  5. 🎯 Update issue tracker (linear)       SKIPPED — not enabled
-  6. 🔀 Auto-merge                          ENABLED
+  2. 🛠️  Install: pnpm install              ENABLED
+  3. 🔨 Build: npm run build                ENABLED
+  4. 🧪 Tests: npm test                     SKIPPED — not enabled
+  5. 📋 Create pull request
+  6. 🎯 Update issue tracker (linear)       SKIPPED — not enabled
+  7. 🔀 Auto-merge                          ENABLED
 ```
 
 Before executing, the plan shows exactly which steps are enabled and which are skipped. Use `--dry-run` to preview without executing.
@@ -55,6 +56,7 @@ Add to `.candid/config.json` alongside your `ship` block:
 {
   "fastShip": {
     "review": false,
+    "install": false,
     "build": false,
     "tests": false,
     "issueTracker": false,
@@ -69,6 +71,7 @@ All fields default to `false`. Set any to `true` to enable that step.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `review` | boolean | `false` | Run `candid-loop` code review before creating the PR. |
+| `install` | boolean | `false` | Run `ship.installCommand`. Skipped if `ship.installCommand` is not set. |
 | `build` | boolean | `false` | Run `ship.buildCommand`. Skipped if `ship.buildCommand` is not set. |
 | `tests` | boolean | `false` | Run `ship.testCommand`. Skipped if `ship.testCommand` is not set. |
 | `issueTracker` | boolean | `false` | Update issue tracker after PR creation. Uses `ship.issueTracker` for provider/state/prompt config. |
@@ -82,6 +85,7 @@ All fields default to `false`. Set any to `true` to enable that step.
 
 | `fastShip` toggle | Where the config comes from |
 |-------------------|-----------------------------|
+| `install: true` | `ship.installCommand` |
 | `build: true` | `ship.buildCommand` |
 | `tests: true` | `ship.testCommand` |
 | `issueTracker: true` | `ship.issueTracker` (provider, state, teamPrefixes, prompt) |
@@ -106,13 +110,14 @@ Nothing runs except PR creation. The plan still confirms before executing.
 ```json
 {
   "fastShip": {
+    "install": true,
     "build": true,
     "autoMerge": true
   }
 }
 ```
 
-Useful for dependency bumps where CI handles testing but you want to confirm the build locally first.
+Useful for dependency bumps where CI handles testing but you want to confirm the build locally first. Enabling `install` makes the build run against fresh dependencies — the most common cause of "works on my machine" failures in PRs.
 
 ### Issue tracker update only (docs shipped, no code change)
 
@@ -132,6 +137,7 @@ Creates the PR, moves the Linear issue to "In Review", and enables auto-merge �
 ```json
 {
   "fastShip": {
+    "install": true,
     "build": true,
     "tests": true,
     "issueTracker": true,
@@ -149,6 +155,7 @@ If you enable a step but the required configuration isn't in your `ship` block, 
 
 | Situation | Output |
 |-----------|--------|
+| `install: true` but no `ship.installCommand` | `Skipping install (installCommand not configured in ship)` |
 | `build: true` but no `ship.buildCommand` | `Skipping build (buildCommand not configured in ship)` |
 | `tests: true` but no `ship.testCommand` | `Skipping tests (testCommand not configured in ship)` |
 | `issueTracker: true` but no `ship.issueTracker` | `Skipping issue tracker (issueTracker not configured in ship)` |
@@ -202,8 +209,9 @@ If you want to ship with just a subset of steps for a one-off run, use `/candid-
   "tone": "constructive",
   "mergeTargetBranches": ["stable"],
   "ship": {
-    "buildCommand": "npm run build",
-    "testCommand": "npm test",
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
     "targetBranch": "stable",
     "autoMerge": false,
     "postMergeCommand": "curl -X POST https://deploy.example.com/trigger",
@@ -215,6 +223,7 @@ If you want to ship with just a subset of steps for a one-off run, use `/candid-
     }
   },
   "fastShip": {
+    "install": true,
     "build": true,
     "issueTracker": true,
     "autoMerge": true

--- a/docs/app/docs/core-features/candid-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-ship/page.mdx
@@ -16,12 +16,13 @@ Ship your branch with one command — review, build, test, PR, and merge.
 Candid Ship orchestrates the full shipping workflow:
 
 1. Run `candid-loop` to review and fix code issues
-2. Execute your build command
-3. Run your tests
-4. Create a pull request
-5. Optionally auto-merge
+2. Install dependencies (when `installCommand` is set)
+3. Execute your build command
+4. Run your tests
+5. Create a pull request
+6. Optionally auto-merge
 
-Any failure aborts immediately with a clear message.
+Any failure before PR creation aborts immediately with a clear message.
 
 ## How It Works
 
@@ -34,10 +35,11 @@ Branch: feature/add-auth → stable
 
 Steps:
   1. 🔍 Review code (candid-loop)
-  2. 🔨 Build: npm run build
-  3. 🧪 Tests: npm test
-  4. 📋 Create pull request
-  5. 🔀 Auto-merge: disabled
+  2. 🛠️  Install: pnpm install
+  3. 🔨 Build: npm run build
+  4. 🧪 Tests: npm test
+  5. 📋 Create pull request
+  6. 🔀 Auto-merge: disabled
 ```
 
 Before executing, the plan is shown for confirmation. Use `--dry-run` to preview without executing.
@@ -62,6 +64,7 @@ If any check fails, you get a clear error message before any work begins.
 | `--auto-merge` | Enable auto-merge after PR creation | from config |
 | `--no-auto-merge` | Disable auto-merge even if config enables it | from config |
 | `--skip-review` | Skip the candid-loop review step | `false` |
+| `--skip-install` | Skip dependency install | `false` |
 | `--skip-build` | Skip build verification | `false` |
 | `--skip-tests` | Skip test execution | `false` |
 | `--dry-run` | Show plan without executing | `false` |
@@ -73,6 +76,7 @@ Add to `.candid/config.json`:
 ```json
 {
   "ship": {
+    "installCommand": "pnpm install",
     "buildCommand": "npm run build",
     "testCommand": "npm test",
     "targetBranch": "stable",
@@ -85,12 +89,43 @@ Add to `.candid/config.json`:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `installCommand` | string | — | Shell command to install dependencies. Runs before build/tests. Skipped if not set. Common values: `pnpm install`, `npm ci`, `poetry install`. |
 | `buildCommand` | string | — | Shell command for build verification. Skipped if not set. |
 | `testCommand` | string | — | Shell command for running tests. Skipped if not set. |
 | `targetBranch` | string | first `mergeTargetBranches` or `"main"` | Branch to target for the PR. |
 | `autoMerge` | boolean | `false` | Auto-merge the PR after creation. |
 | `additionalPrompt` | string | — | Extra context passed to candid-loop/review during the review step. |
 | `postMergeCommand` | string | — | Shell command to run after auto-merge succeeds. Skipped if auto-merge is disabled or fails. |
+
+## Install Step
+
+When `installCommand` is set, candid-ship runs it before the build and test steps. This avoids the common failure mode where build/test errors are really stale-dependency errors.
+
+```json
+{
+  "ship": {
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test"
+  }
+}
+```
+
+The install step is **opt-in** — leave `installCommand` unset to skip it entirely. If your build/test commands already handle their own install (e.g. `buildCommand: "pnpm install && pnpm build"`), you can keep that pattern; the dedicated `installCommand` field just makes the install phase visible and independently skippable via `--skip-install`.
+
+Common values:
+
+| Stack | Install command |
+|-------|-----------------|
+| pnpm | `pnpm install` |
+| npm (CI-friendly) | `npm ci` |
+| npm | `npm install` |
+| yarn | `yarn install --frozen-lockfile` |
+| poetry | `poetry install` |
+| bundler | `bundle install` |
+| go | `go mod download` |
+
+If install fails, the ship aborts before review/build/tests run — giving you a clear, focused error.
 
 ## Additional Prompt
 
@@ -337,14 +372,17 @@ Until your tracker is supported, `provider: "your-tracker"` produces a friendly 
 # Force auto-merge
 /candid-ship --auto-merge
 
-# Quick ship — skip review, just build/test/PR
+# Quick ship — skip review, just install/build/test/PR
 /candid-ship --skip-review
+
+# Skip install (deps already up to date)
+/candid-ship --skip-install
 
 # Preview the plan without executing
 /candid-ship --dry-run
 
 # Skip everything except PR creation
-/candid-ship --skip-review --skip-build --skip-tests
+/candid-ship --skip-review --skip-install --skip-build --skip-tests
 
 # Override auto-merge for this run
 /candid-ship --no-auto-merge
@@ -352,7 +390,7 @@ Until your tracker is supported, `provider: "your-tracker"` produces a friendly 
 
 ## Output Examples
 
-### Success (with post-merge command)
+### Success (with install and post-merge command)
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -360,6 +398,7 @@ Candid Ship Complete
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Review:   PASS (3 iterations, 7 issues fixed)
+Install:  PASS
 Build:    PASS
 Tests:    PASS
 PR:       https://github.com/org/repo/pull/42
@@ -367,7 +406,7 @@ Merge:    Auto-merge enabled
 Post-merge: PASS
 ```
 
-### Success (without post-merge command)
+### Success (without install or post-merge command)
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -398,7 +437,7 @@ Merge:    Manual merge required
 ### Build Failure
 
 ```
-Step 2/5: Running build...
+Step 3/6: Running build...
 $ npm run build
 
 [build output with errors]
@@ -426,8 +465,9 @@ A typical shipping workflow with candid-ship configured:
   "mergeTargetBranches": ["stable"],
   "autoCommit": true,
   "ship": {
-    "buildCommand": "npm run build",
-    "testCommand": "npm test",
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
     "targetBranch": "stable",
     "autoMerge": true,
     "additionalPrompt": "Ensure error handling covers all async operations",

--- a/docs/app/docs/reference/config-options/page.mdx
+++ b/docs/app/docs/reference/config-options/page.mdx
@@ -17,6 +17,7 @@ Complete reference for Candid configuration.
     "mode": "lookup" | "load"
   },
   "ship": {
+    "installCommand": "string",
     "buildCommand": "string",
     "testCommand": "string",
     "targetBranch": "string",
@@ -33,6 +34,7 @@ Complete reference for Candid configuration.
   },
   "fastShip": {
     "review": boolean,
+    "install": boolean,
     "build": boolean,
     "tests": boolean,
     "issueTracker": boolean,
@@ -113,6 +115,7 @@ Configuration for the [`/candid-ship`](/docs/core-features/candid-ship) shipping
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
+| `installCommand` | string | — | Shell command to install dependencies before build (e.g. `pnpm install`, `npm ci`). Runs before `buildCommand` and `testCommand`. Skipped if not set. |
 | `buildCommand` | string | — | Shell command for build verification before creating the PR. Skipped if not set. |
 | `testCommand` | string | — | Shell command for running tests before creating the PR. Skipped if not set. |
 | `targetBranch` | string | first `mergeTargetBranches` or `"main"` | Branch to target for the PR. |
@@ -136,8 +139,9 @@ Example (full pipeline):
 ```json
 {
   "ship": {
-    "buildCommand": "npm run build",
-    "testCommand": "npm test",
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
     "targetBranch": "stable",
     "autoMerge": true,
     "additionalPrompt": "Ensure error handling covers all async operations",
@@ -207,6 +211,7 @@ Configuration for the [`/candid-fast-ship`](/docs/core-features/candid-fast-ship
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `review` | boolean | `false` | Run candid-loop code review. |
+| `install` | boolean | `false` | Run `ship.installCommand`. Skipped if not configured in `ship`. |
 | `build` | boolean | `false` | Run `ship.buildCommand`. Skipped if not configured in `ship`. |
 | `tests` | boolean | `false` | Run `ship.testCommand`. Skipped if not configured in `ship`. |
 | `issueTracker` | boolean | `false` | Update issue tracker after PR creation. Uses `ship.issueTracker` config. |
@@ -214,15 +219,17 @@ Configuration for the [`/candid-fast-ship`](/docs/core-features/candid-fast-ship
 | `postMergeCommand` | boolean | `false` | Run `ship.postMergeCommand` after auto-merge succeeds. |
 | `targetBranch` | string | from `ship.targetBranch` or `mergeTargetBranches` | PR target branch override. |
 
-Example (build check + auto-merge, no review):
+Example (install + build check + auto-merge, no review):
 
 ```json
 {
   "ship": {
-    "buildCommand": "npm run build",
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
     "targetBranch": "stable"
   },
   "fastShip": {
+    "install": true,
     "build": true,
     "autoMerge": true
   }

--- a/examples/ship/config.json
+++ b/examples/ship/config.json
@@ -3,6 +3,7 @@
   "tone": "constructive",
   "mergeTargetBranches": ["main"],
   "ship": {
+    "installCommand": "pnpm install",
     "buildCommand": "npm run build",
     "testCommand": "npm test",
     "targetBranch": "main",

--- a/skills/candid-fast-ship/SKILL.md
+++ b/skills/candid-fast-ship/SKILL.md
@@ -62,15 +62,15 @@ Candid Fast Ship Plan
 
 Branch: [currentBranch] → [targetBranch]
 
-Steps:
-  1. 🔍 Review code (candid-loop)           [ENABLED | SKIPPED — not enabled]
-  2. 🛠️  Install: [installCommand]          [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  3. 🔨 Build: [buildCommand]               [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  4. 🧪 Tests: [testCommand]                [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  5. 📋 Create pull request
-  6. 🎯 Update issue tracker ([provider])   [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  7. 🔀 Auto-merge                          [ENABLED | SKIPPED — not enabled]
-  8. 🚀 Post-merge: [postMergeCommand]      [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+Steps (numbers assigned dynamically — only enabled+configured steps get a number):
+  [N]. 🔍 Review code (candid-loop)           [ENABLED | SKIPPED — not enabled]
+  [N]. 🛠️  Install: [installCommand]          [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  [N]. 🔨 Build: [buildCommand]               [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  [N]. 🧪 Tests: [testCommand]                [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  [N]. 📋 Create pull request
+  [N]. 🎯 Update issue tracker ([provider])   [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  [N]. 🔀 Auto-merge                          [ENABLED | SKIPPED — not enabled]
+  [N]. 🚀 Post-merge: [postMergeCommand]      [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
 ```
 
 If all optional steps are disabled, append `(All optional steps disabled — only PR creation will run)`.

--- a/skills/candid-fast-ship/SKILL.md
+++ b/skills/candid-fast-ship/SKILL.md
@@ -5,141 +5,55 @@ description: Fast ship for low-risk changes — runs only the steps you explicit
 
 # Candid Fast Ship
 
-A minimal shipping path for low-risk changes. Unlike `candid-ship`, which runs all steps by default and lets you opt out, `candid-fast-ship` runs **nothing by default** and only executes the steps you explicitly enable in the `fastShip` configuration block.
+A minimal shipping path for low-risk changes. Unlike `candid-ship`, which runs all steps by default and lets you opt out, `candid-fast-ship` runs **nothing by default** — only steps explicitly enabled in the `fastShip` config block. PR creation always runs.
 
 Step configuration (commands, target branch, issue tracker details) is inherited from the existing `ship` block. `fastShip` is purely a set of on/off toggles that sit on top of it.
 
 ## Workflow
 
-Execute these steps in order:
+Execute these steps in order. The mechanics for each step are defined in `skills/candid-ship/WORKFLOW.md`. This file specifies the **toggle semantics** unique to `candid-fast-ship`.
 
 ### Step 1: Pre-Flight Checks
 
-Verify the environment is ready for shipping.
-
-#### 1.1: Check gh CLI
-
-```bash
-gh auth status 2>&1
-```
-
-If command fails or `gh` not found:
-```
-Pre-flight failed: GitHub CLI (gh) is not installed or not authenticated.
-Install: https://cli.github.com/
-Authenticate: gh auth login
-```
-Abort.
-
-#### 1.2: Check Git Repository
-
-```bash
-git rev-parse --is-inside-work-tree 2>&1
-```
-
-If not inside a git repo: abort with `Pre-flight failed: Not inside a git repository.`
-
-#### 1.3: Check Current Branch
-
-```bash
-git branch --show-current
-```
-
-Store as `currentBranch`. If empty (detached HEAD): abort with `Pre-flight failed: Detached HEAD state. Check out a branch first.`
+Run the pre-flight checks from WORKFLOW.md → "Pre-Flight Checks".
 
 ### Step 2: Load Configuration
 
-Load `fastShip` toggles from config and `ship` field for command values.
+Read config per WORKFLOW.md → "Load Configuration", with two top-level fields:
+- `fastShip.*` — the boolean toggles (see CLI Flags table below for the schema)
+- `ship.*` — command values, target branch, issue tracker config (inherited)
 
-**Precedence (highest to lowest):**
-1. CLI flags
-2. Project config (`.candid/config.json` → `fastShip` field)
-3. User config (`~/.candid/config.json` → `fastShip` field)
-4. Defaults (all steps disabled)
+When loading from project config, output: `Using fastShip settings from project config`. From user config: `Using fastShip settings from user config`.
 
 #### Parse CLI Flags
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--auto-merge` | Enable auto-merge (overrides fastShip config) | from config |
-| `--no-auto-merge` | Disable auto-merge (overrides fastShip config) | from config |
+| `--auto-merge` | Enable auto-merge (overrides `fastShip.autoMerge`) | from config |
+| `--no-auto-merge` | Disable auto-merge (overrides `fastShip.autoMerge`) | from config |
 | `--dry-run` | Show plan without executing | `false` |
 
 If both `--auto-merge` and `--no-auto-merge` are provided, `--no-auto-merge` wins.
 
-#### Check Project Config — fastShip Field
-
-```bash
-jq -r '.fastShip // null' .candid/config.json 2>/dev/null
-```
-
-If the `fastShip` field exists, extract these boolean toggles (all default to `false` if absent):
-- `review` (boolean) — run candid-loop code review
-- `build` (boolean) — run build command
-- `tests` (boolean) — run test command
-- `issueTracker` (boolean) — update issue tracker
-- `autoMerge` (boolean) — enable auto-merge
-- `postMergeCommand` (boolean) — run post-merge shell command
-- `targetBranch` (string) — PR target branch override
-
-Output when loading: `Using fastShip settings from project config`
-
-#### Check User Config — fastShip Field
-
-Same procedure for `~/.candid/config.json` if project config doesn't have a `fastShip` field.
-
-Output when loading: `Using fastShip settings from user config`
-
-#### Load ship Field for Command Values
-
-```bash
-jq -r '.ship // null' .candid/config.json 2>/dev/null
-```
-
-Load from project config → user config → defaults. Extract:
-- `buildCommand` — used when `fastShip.build` is enabled
-- `testCommand` — used when `fastShip.tests` is enabled
-- `targetBranch` — fallback if `fastShip.targetBranch` not set
-- `additionalPrompt` — passed to candid-loop if `fastShip.review` is enabled
-- `postMergeCommand` — used when `fastShip.postMergeCommand` is enabled
-- `issueTracker` — full issueTracker config object, used when `fastShip.issueTracker` is enabled
-
 #### Resolve targetBranch
 
-Priority: `fastShip.targetBranch` → `ship.targetBranch` → `mergeTargetBranches[0]` → `"main"`
-
-Verify the target branch exists:
-```bash
-git rev-parse --verify [targetBranch] 2>/dev/null || git rev-parse --verify origin/[targetBranch] 2>/dev/null
-```
-
-If target branch doesn't exist: abort with `Target branch "[targetBranch]" does not exist locally or on remote.`
-
-#### Validate Current Branch != Target Branch
-
-If `currentBranch == targetBranch`:
-```
-Cannot ship: you are on the target branch ([targetBranch]). Check out a feature branch first.
-```
-Abort.
-
-#### Check Commits Ahead
-
-```bash
-git log --oneline [targetBranch]..HEAD 2>/dev/null | head -20
-```
-
-If no commits ahead: abort with `No commits ahead of [targetBranch]. Nothing to ship.`
+Priority: `fastShip.targetBranch` → `ship.targetBranch` → first `mergeTargetBranches` entry → `"main"`. Then run target-branch verification and branch-state validation per WORKFLOW.md → "Resolve targetBranch" / "Validate Branch State".
 
 ### Step 3: Display Plan
 
-Determine which steps are enabled and configured. A step is **ENABLED** only when its toggle is `true` AND (for build/tests/postMerge) the corresponding command is set in `ship`, or (for issueTracker) `ship.issueTracker` is present with a supported provider.
+A step is **enabled** only when its `fastShip` toggle is `true` AND the underlying `ship` config is present:
 
-Calculate `totalSteps` as the count of steps that will actually execute (PR creation always counts as 1; add 1 for each enabled+configured optional step).
+| Toggle | Required `ship` config |
+|--------|------------------------|
+| `fastShip.review` | (none — always runnable when enabled) |
+| `fastShip.install` | `ship.installCommand` |
+| `fastShip.build` | `ship.buildCommand` |
+| `fastShip.tests` | `ship.testCommand` |
+| `fastShip.issueTracker` | `ship.issueTracker` with supported provider |
+| `fastShip.autoMerge` | (none) |
+| `fastShip.postMergeCommand` | `ship.postMergeCommand` AND `fastShip.autoMerge: true` |
 
-Renumber displayed steps to skip any that are fully skipped.
-
-Show what will be executed:
+Calculate `totalSteps` = 1 (PR creation) + count of enabled steps. Renumber displayed step rows so disabled steps don't take a number.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -150,292 +64,60 @@ Branch: [currentBranch] → [targetBranch]
 
 Steps:
   1. 🔍 Review code (candid-loop)           [ENABLED | SKIPPED — not enabled]
-  2. 🔨 Build: [buildCommand]               [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  3. 🧪 Tests: [testCommand]                [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  4. 📋 Create pull request
-  5. 🎯 Update issue tracker ([provider])   [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  6. 🔀 Auto-merge                          [ENABLED | SKIPPED — not enabled]
-  7. 🚀 Post-merge: [postMergeCommand]      [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  2. 🛠️  Install: [installCommand]          [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  3. 🔨 Build: [buildCommand]               [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  4. 🧪 Tests: [testCommand]                [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  5. 📋 Create pull request
+  6. 🎯 Update issue tracker ([provider])   [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
+  7. 🔀 Auto-merge                          [ENABLED | SKIPPED — not enabled]
+  8. 🚀 Post-merge: [postMergeCommand]      [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
 ```
 
-If all optional steps are disabled:
-```
-  (All optional steps disabled — only PR creation will run)
-```
+If all optional steps are disabled, append `(All optional steps disabled — only PR creation will run)`.
 
-**If `--dry-run`:**
-Output: `Dry run complete. No changes made.`
-Exit.
+**If `--dry-run`:** Output `Dry run complete. No changes made.` and exit.
 
-**If not dry-run:** Use AskUserQuestion:
+**Otherwise:** Use AskUserQuestion: "Proceed with this fast ship plan?" with options "Yes, ship it" / "No, cancel". On "No, cancel": exit with `Fast ship cancelled.`
 
-**Question:** "Proceed with this fast ship plan?"
+### Step 4: Run Review
 
-**Options:**
-1. "Yes, ship it"
-2. "No, cancel"
+**Skip if** `fastShip.review` is `false` → `Skipping review (not enabled in fastShip config)`. Otherwise execute WORKFLOW.md → "Run Review (candid-loop)". Use `ship.additionalPrompt` if set.
 
-If "No, cancel": exit with `Fast ship cancelled.`
+### Step 5: Install Dependencies
 
-### Step 4: Run Review (Optional)
+**Skip if** `fastShip.install` is `false` → `Skipping install (not enabled in fastShip config)`. Skip if `fastShip.install` is `true` but `ship.installCommand` is not set → `Skipping install (installCommand not configured in ship)`. Otherwise execute WORKFLOW.md → "Install Dependencies".
 
-**Skip if** `fastShip.review` is `false`. Output: `Skipping review (not enabled in fastShip config)`
+### Step 6: Run Build
 
-Display:
-```
-Step [N]/[totalSteps]: Running code review...
-```
+**Skip if** `fastShip.build` is `false` → `Skipping build (not enabled in fastShip config)`. Skip if `fastShip.build` is `true` but `ship.buildCommand` is not set → `Skipping build (buildCommand not configured in ship)`. Otherwise execute WORKFLOW.md → "Run Build".
 
-Invoke candid-loop via the Skill tool: `/candid-loop`
+### Step 7: Run Tests
 
-If `additionalPrompt` is set (from `ship.additionalPrompt`), include it:
-> "IMPORTANT: During this review, also consider the following additional context: [additionalPrompt]"
+**Skip if** `fastShip.tests` is `false` → `Skipping tests (not enabled in fastShip config)`. Skip if `fastShip.tests` is `true` but `ship.testCommand` is not set → `Skipping tests (testCommand not configured in ship)`. Otherwise execute WORKFLOW.md → "Run Tests".
 
-After candid-loop completes, check its summary output:
+### Step 8: Create Pull Request
 
-- **If PASS**: continue. Output: `Review passed.`
-- **If INCOMPLETE** (max iterations reached with remaining issues): Use AskUserQuestion:
-  - **Question:** "Review completed with remaining issues. Continue shipping?"
-  - **Options:**
-    1. "Yes, continue anyway"
-    2. "No, abort"
-  - If "No, abort": exit with `Fast ship aborted: unresolved review issues.`
-- **If CANCELLED**: abort with `Fast ship aborted: review was cancelled.`
+Always runs. Execute WORKFLOW.md → "Create Pull Request". Footer should read `*Shipped with [candid-fast-ship](https://github.com/ron-myers/candid)*`.
 
-### Step 5: Run Build (Optional)
+### Step 9: Update Issue Tracker
 
-**Skip if** `fastShip.build` is `false`. Output: `Skipping build (not enabled in fastShip config)`
+**Skip if** `fastShip.issueTracker` is `false` → `Skipping issue tracker (not enabled in fastShip config)`. Skip if `ship.issueTracker` is absent → `Skipping issue tracker (issueTracker not configured in ship)`.
 
-**Skip if** `fastShip.build` is `true` but `ship.buildCommand` is not set. Output: `Skipping build (buildCommand not configured in ship)`
+Otherwise execute WORKFLOW.md → "Update Issue Tracker", using `ship.issueTracker.*` for provider, state, prompt, and team prefixes.
 
-Display:
-```
-Step [N]/[totalSteps]: Running build...
-$ [buildCommand]
-```
+**Note:** `fastShip.issueTracker: true` acts as the enable toggle — `ship.issueTracker.enabled` is ignored in fast-ship mode.
 
-Execute the build command:
-```bash
-[buildCommand]
-```
+### Step 10: Auto-Merge
 
-**If build fails** (non-zero exit code):
-```
-Build failed. Fast ship aborted.
-```
-Show the build output so the user can diagnose.
-Abort.
+**Skip if** `fastShip.autoMerge` is `false` → `Auto-merge: disabled (manual merge required)`. Otherwise execute WORKFLOW.md → "Auto-Merge".
 
-**If build succeeds:**
-```
-Build passed.
-```
+### Step 11: Post-Merge Command
 
-### Step 6: Run Tests (Optional)
+**Skip if** `fastShip.postMergeCommand` is `false` → `Skipping post-merge command (not enabled in fastShip config)`. Skip if `ship.postMergeCommand` is not set → `Skipping post-merge command (postMergeCommand not configured in ship)`. Skip if `fastShip.autoMerge` is `false` → `Skipping post-merge command (auto-merge not enabled)`. Skip if auto-merge failed in Step 10 → `Skipping post-merge command (auto-merge failed)`. Otherwise execute WORKFLOW.md → "Post-Merge Command".
 
-**Skip if** `fastShip.tests` is `false`. Output: `Skipping tests (not enabled in fastShip config)`
+### Step 12: Summary
 
-**Skip if** `fastShip.tests` is `true` but `ship.testCommand` is not set. Output: `Skipping tests (testCommand not configured in ship)`
-
-Display:
-```
-Step [N]/[totalSteps]: Running tests...
-$ [testCommand]
-```
-
-Execute the test command:
-```bash
-[testCommand]
-```
-
-**If tests fail** (non-zero exit code):
-```
-Tests failed. Fast ship aborted.
-```
-Show the test output so the user can diagnose.
-Abort.
-
-**If tests succeed:**
-```
-Tests passed.
-```
-
-### Step 7: Create Pull Request
-
-Display:
-```
-Step [N]/[totalSteps]: Creating pull request...
-```
-
-#### 7.1: Generate PR Title
-
-```bash
-git log [targetBranch]..HEAD --oneline
-```
-
-- **Single commit:** Use that commit message as the title
-- **Multiple commits:** Clean the branch name into a title:
-  - Remove prefix (e.g., `feature/`, `fix/`, `ron-myers/`)
-  - Replace hyphens/underscores with spaces
-  - Capitalize first letter
-  - Example: `feature/add-auth-middleware` → `Add auth middleware`
-
-Truncate title to 70 characters if needed.
-
-#### 7.2: Generate PR Body
-
-```bash
-git log [targetBranch]..HEAD --pretty=format:"- %s"
-```
-
-Assemble the body:
-
-```markdown
-## Summary
-[commit list from git log]
-
-## Verification
-- Review: [PASS — N iterations, M issues fixed | SKIPPED]
-- Build: [PASS | SKIPPED]
-- Tests: [PASS | SKIPPED]
-
----
-*Shipped with [candid-fast-ship](https://github.com/ron-myers/candid)*
-```
-
-#### 7.3: Push Branch
-
-```bash
-git push -u origin [currentBranch]
-```
-
-If push fails, abort with error message.
-
-#### 7.4: Create PR
-
-```bash
-gh pr create --base [targetBranch] --title "[title]" --body "[body]"
-```
-
-Capture the PR URL from stdout. If creation fails, abort with error message.
-
-Output: `PR created: [URL]`
-
-### Step 8: Update Issue Tracker (Optional)
-
-**Skip if** `fastShip.issueTracker` is `false`. Output: `Skipping issue tracker (not enabled in fastShip config)`
-
-**Skip if** `fastShip.issueTracker` is `true` but `ship.issueTracker` is not present in config. Output: `Skipping issue tracker (issueTracker not configured in ship)`
-
-**Skip if** `ship.issueTracker.provider` is `"none"`. Output: `Skipping issue tracker update (provider set to "none")`
-
-**Skip if** `ship.issueTracker.provider` is anything other than `"linear"`:
-```
-⚠️  Issue tracker provider "[provider]" is not yet supported.
-Request support at: https://github.com/ron-myers/candid/issues
-```
-Continue to Step 9.
-
-**Skip if** `ship.issueTracker.provider` is `"linear"` but the Linear MCP tool (`mcp__claude_ai_Linear__save_issue`) is unavailable. Output: `Linear MCP not available — skipping issue update`
-
-Note: `fastShip.issueTracker: true` acts as the enable toggle — `ship.issueTracker.enabled` is ignored in fast ship mode.
-
-If enabled and configured, proceed using the same logic as candid-ship Step 8 (extract issue ID from branch name, render prompt, pre-call invariant check, call MCP).
-
-Display:
-```
-Step [N]/[totalSteps]: Updating issue tracker ([provider])...
-```
-
-Use `ship.issueTracker.teamPrefixes`, `ship.issueTracker.state`, and `ship.issueTracker.prompt` for the update.
-
-**On success:** Output: `Updated [issueId] → [state]`
-
-**On error:**
-```
-⚠️  Issue tracker update failed: [error message]
-PR is still open at: [URL]
-```
-Do NOT abort.
-
-### Step 9: Auto-Merge (Optional)
-
-**Skip if** `fastShip.autoMerge` is `false`. Output: `Auto-merge: disabled (manual merge required)`
-
-If `fastShip.autoMerge` is `true`:
-
-Display:
-```
-Step [N]/[totalSteps]: Enabling auto-merge...
-```
-
-```bash
-gh pr merge [PR_URL] --squash --auto
-```
-
-If auto-merge fails:
-```
-⚠️  Auto-merge failed: [error message]
-The repository may not have auto-merge enabled in Settings → General → Pull Requests.
-PR is still open at: [URL]
-```
-Do NOT abort.
-
-If auto-merge succeeds:
-```
-Auto-merge enabled. PR will merge when checks pass.
-```
-
-### Step 10: Run Post-Merge Command (Optional)
-
-**Skip if** `fastShip.postMergeCommand` is `false`. Output: `Skipping post-merge command (not enabled in fastShip config)`
-
-**Skip if** `fastShip.postMergeCommand` is `true` but `ship.postMergeCommand` is not set. Output: `Skipping post-merge command (postMergeCommand not configured in ship)`
-
-**Skip if** `fastShip.autoMerge` is `false`. Output: `Skipping post-merge command (auto-merge not enabled)`
-
-**Skip if** auto-merge failed in Step 9. Output: `Skipping post-merge command (auto-merge failed)`
-
-If all conditions are met:
-
-Display:
-```
-Step [N]/[totalSteps]: Running post-merge command...
-$ [postMergeCommand]
-```
-
-Execute:
-```bash
-[postMergeCommand]
-```
-
-**If command fails:**
-```
-⚠️  Post-merge command failed: [error output]
-PR is still merging at: [URL]
-```
-Do NOT abort.
-
-**If command succeeds:**
-```
-Post-merge command completed.
-```
-
-### Step 11: Display Summary
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Candid Fast Ship Complete
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Review:   [PASS (N iterations, M issues fixed) | SKIPPED]
-Build:    [PASS | SKIPPED]
-Tests:    [PASS | SKIPPED]
-PR:       [URL]
-Issue:    [Updated DIS-509 → In Review | Skipped | Failed: <error>]
-Merge:    [Auto-merge enabled | Manual merge required | Auto-merge failed]
-Post-merge: [PASS | SKIPPED | FAILED | N/A]
-```
+Execute WORKFLOW.md → "Display Summary" with header `Candid Fast Ship Complete`.
 
 ## Configuration
 
@@ -447,6 +129,7 @@ Add to `.candid/config.json` alongside the `ship` field:
 {
   "fastShip": {
     "review": false,
+    "install": false,
     "build": false,
     "tests": false,
     "issueTracker": false,
@@ -459,42 +142,29 @@ Add to `.candid/config.json` alongside the `ship` field:
 
 All fields are optional. Boolean fields default to `false`. `targetBranch` defaults to `ship.targetBranch` → `mergeTargetBranches[0]` → `"main"`.
 
-Command values, target branch, and issue tracker configuration are inherited from the `ship` block — `fastShip` only controls which steps run.
-
-### Field Descriptions
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `fastShip.review` | boolean | `false` | Run candid-loop code review before creating PR. |
-| `fastShip.build` | boolean | `false` | Run `ship.buildCommand` before creating PR. Skipped if `ship.buildCommand` is not set. |
-| `fastShip.tests` | boolean | `false` | Run `ship.testCommand` before creating PR. Skipped if `ship.testCommand` is not set. |
-| `fastShip.issueTracker` | boolean | `false` | Update issue tracker after PR creation. Uses `ship.issueTracker` for provider/state/prompt config. Skipped if `ship.issueTracker` is not configured. |
-| `fastShip.autoMerge` | boolean | `false` | Auto-merge PR after creation via `gh pr merge --squash --auto`. |
-| `fastShip.postMergeCommand` | boolean | `false` | Run `ship.postMergeCommand` after auto-merge succeeds. Skipped if `ship.postMergeCommand` is not set or auto-merge is not enabled. |
-| `fastShip.targetBranch` | string | `ship.targetBranch` or first `mergeTargetBranches` or `"main"` | PR target branch. |
+For full validation rules see `skills/candid-review/CONFIG.md` (the `fastShip` section).
 
 ### Examples
 
 **Minimal — just create a PR:**
 ```json
-{
-  "fastShip": {}
-}
+{ "fastShip": {} }
 ```
 
 **Build check + PR only:**
 ```json
-{
-  "fastShip": {
-    "build": true
-  }
-}
+{ "fastShip": { "build": true } }
 ```
 
-**Build + auto-merge (no review, no tests):**
+**Install + build + auto-merge:**
 ```json
 {
+  "ship": {
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build"
+  },
   "fastShip": {
+    "install": true,
     "build": true,
     "autoMerge": true
   }
@@ -503,12 +173,7 @@ Command values, target branch, and issue tracker configuration are inherited fro
 
 **Docs change — just PR and issue tracker update:**
 ```json
-{
-  "fastShip": {
-    "issueTracker": true,
-    "autoMerge": true
-  }
-}
+{ "fastShip": { "issueTracker": true, "autoMerge": true } }
 ```
 
 ## CLI Examples

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -1165,6 +1165,7 @@ Use AskUserQuestion:
 
 If "Custom — let me choose": Ask the user to confirm each of the following with Yes/No:
 - Enable review (candid-loop)?
+- Enable install? (only shown if `ship.installCommand` was configured)
 - Enable build? (only shown if `ship.buildCommand` was configured)
 - Enable tests? (only shown if `ship.testCommand` was configured)
 - Enable issue tracker update? (only shown if `ship.issueTracker` was configured)

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -73,6 +73,7 @@ Valid config file format:
 - `ship` (optional): Configuration for the candid-ship shipping workflow. If not present, candid-ship uses defaults for all settings.
   - `ship.buildCommand` (optional): Shell command for build verification before creating PR. If not set, build step is skipped. Must be a non-empty string.
   - `ship.testCommand` (optional): Shell command for running tests before creating PR. If not set, test step is skipped. Must be a non-empty string.
+  - `ship.installCommand` (optional): Shell command to install dependencies before build. Runs before `buildCommand` (and before `testCommand`). If not set, the install step is skipped. Common values: `"pnpm install"`, `"npm ci"`, `"poetry install"`, `"bundle install"`. Must be a non-empty string.
   - `ship.targetBranch` (optional): Branch name for PR target. Defaults to first entry in `mergeTargetBranches` or `"main"`. Must be a non-empty string.
   - `ship.autoMerge` (optional): Whether to auto-merge the PR after creation via `gh pr merge --squash --auto`. Defaults to `false`. Must be a boolean.
   - `ship.additionalPrompt` (optional): Extra prompt text passed to candid-loop/candid-review as additional review context. Must be a non-empty string.
@@ -85,6 +86,7 @@ Valid config file format:
     - `ship.issueTracker.prompt` (optional): Customizable prompt template sent to the tracker's MCP server. Supports `{issueId}`, `{state}`, and `{provider}` placeholders. The rendered prompt **must restrict the action to a single issue** — multiple-issue updates are explicitly disallowed. Defaults to: `Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.` This default also restricts the change to the `state` field (no assignee/label/title changes), is idempotent (no-op if already in `{state}`), and stops on a missing-issue error rather than searching for a fallback. candid-init writes this default into `.candid/config.json` so it's discoverable and easy to edit. Must be a non-empty string.
 - `fastShip` (optional): Configuration for the `candid-fast-ship` minimal shipping workflow. Unlike `ship` (which runs all steps by default), `fastShip` is **opt-in**: every step is disabled by default and must be explicitly enabled. Command values and issue tracker configuration are inherited from the `ship` block. If not present, `candid-fast-ship` runs with all steps disabled (PR creation only).
   - `fastShip.review` (optional): Run candid-loop code review. Defaults to `false`. Must be a boolean.
+  - `fastShip.install` (optional): Run `ship.installCommand`. Skipped silently if `ship.installCommand` is not set. Defaults to `false`. Must be a boolean.
   - `fastShip.build` (optional): Run `ship.buildCommand`. Skipped silently if `ship.buildCommand` is not set. Defaults to `false`. Must be a boolean.
   - `fastShip.tests` (optional): Run `ship.testCommand`. Skipped silently if `ship.testCommand` is not set. Defaults to `false`. Must be a boolean.
   - `fastShip.issueTracker` (optional): Update issue tracker after PR creation. Uses `ship.issueTracker` for provider, state, and prompt configuration. `ship.issueTracker.enabled` is ignored — this toggle takes precedence. Skipped silently if `ship.issueTracker` is not configured. Defaults to `false`. Must be a boolean.
@@ -101,8 +103,8 @@ Valid config file format:
 5. **mergeTargetBranches field validation** - If present, must be an array of non-empty strings. Empty arrays or invalid values show warning and are ignored.
 6. **AutoCommit field validation** - If `autoCommit` field is present, must be a boolean (`true` or `false`). Invalid values show warning and are ignored.
 7. **DecisionRegister field validation** - If `decisionRegister` field is present, must be an object. If `decisionRegister.enabled` is present, must be a boolean. If `decisionRegister.path` is present, must be a non-empty string. If `decisionRegister.mode` is present, must be exactly `"lookup"` or `"load"` (case-sensitive). Invalid values show warning and are ignored (feature defaults to disabled).
-8. **Ship field validation** - If `ship` field is present, must be an object. If `ship.buildCommand` is present, must be a non-empty string. If `ship.testCommand` is present, must be a non-empty string. If `ship.targetBranch` is present, must be a non-empty string. If `ship.autoMerge` is present, must be a boolean. If `ship.additionalPrompt` is present, must be a non-empty string. If `ship.postMergeCommand` is present, must be a non-empty string. If `ship.issueTracker` is present, must be an object. If `ship.issueTracker.provider` is present, must be a non-empty string. If `ship.issueTracker.enabled` is present, must be a boolean. If `ship.issueTracker.teamPrefixes` is present, must be an array of non-empty strings. If `ship.issueTracker.state` is present, must be a non-empty string. If `ship.issueTracker.prompt` is present, must be a non-empty string. Invalid values show warning and are ignored — the ship continues without the issue tracker step.
-9. **FastShip field validation** - If `fastShip` field is present, must be an object. Boolean fields (`review`, `build`, `tests`, `issueTracker`, `autoMerge`, `postMergeCommand`) must be booleans if present. `targetBranch` must be a non-empty string if present. Invalid values show warning and are ignored — `fastShip` defaults to all steps disabled.
+8. **Ship field validation** - If `ship` field is present, must be an object. If `ship.buildCommand` is present, must be a non-empty string. If `ship.testCommand` is present, must be a non-empty string. If `ship.installCommand` is present, must be a non-empty string. If `ship.targetBranch` is present, must be a non-empty string. If `ship.autoMerge` is present, must be a boolean. If `ship.additionalPrompt` is present, must be a non-empty string. If `ship.postMergeCommand` is present, must be a non-empty string. If `ship.issueTracker` is present, must be an object. If `ship.issueTracker.provider` is present, must be a non-empty string. If `ship.issueTracker.enabled` is present, must be a boolean. If `ship.issueTracker.teamPrefixes` is present, must be an array of non-empty strings. If `ship.issueTracker.state` is present, must be a non-empty string. If `ship.issueTracker.prompt` is present, must be a non-empty string. Invalid values show warning and are ignored — the ship continues without the issue tracker step.
+9. **FastShip field validation** - If `fastShip` field is present, must be an object. Boolean fields (`review`, `install`, `build`, `tests`, `issueTracker`, `autoMerge`, `postMergeCommand`) must be booleans if present. `targetBranch` must be a non-empty string if present. Invalid values show warning and are ignored — `fastShip` defaults to all steps disabled.
 10. **Unknown fields ignored** - Any fields other than `tone`, `exclude`, `focus`, `mergeTargetBranches`, `autoCommit`, `decisionRegister`, `ship`, and `fastShip` are ignored for forward compatibility
 10. **Empty object is valid** - `{}` is a valid config with no preferences set, system continues to next source
 
@@ -318,6 +320,18 @@ Using constructive tone (from interactive prompt)
     "testCommand": "npm test",
     "targetBranch": "main",
     "autoMerge": false
+  }
+}
+```
+
+**With install before build:**
+```json
+{
+  "ship": {
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
+    "targetBranch": "main"
   }
 }
 ```

--- a/skills/candid-ship/SKILL.md
+++ b/skills/candid-ship/SKILL.md
@@ -61,15 +61,15 @@ Candid Ship Plan
 
 Branch: [currentBranch] → [targetBranch]
 
-Steps:
-  1. 🔍 Review code (candid-loop)           [or SKIP]
-  2. 🛠️  Install: [installCommand]          [only if installCommand is set]
-  3. 🔨 Build: [buildCommand]               [or SKIP — not configured]
-  4. 🧪 Tests: [testCommand]                [or SKIP — not configured]
-  5. 📋 Create pull request
-  6. 🎯 Update issue tracker ([provider]): state="[state]"  [only if issueTracker.enabled]
-  7. 🔀 Auto-merge: enabled                 [or disabled]
-  8. 🚀 Post-merge: [postMergeCommand]      [only if postMergeCommand is set]
+Steps (numbers assigned dynamically — only running steps get a number):
+  [N]. 🔍 Review code (candid-loop)           [or SKIP]
+  [N]. 🛠️  Install: [installCommand]          [only if installCommand is set]
+  [N]. 🔨 Build: [buildCommand]               [or SKIP — not configured]
+  [N]. 🧪 Tests: [testCommand]                [or SKIP — not configured]
+  [N]. 📋 Create pull request
+  [N]. 🎯 Update issue tracker ([provider]): state="[state]"  [only if issueTracker.enabled]
+  [N]. 🔀 Auto-merge: enabled                 [or disabled]
+  [N]. 🚀 Post-merge: [postMergeCommand]      [only if postMergeCommand is set]
 ```
 
 If `additionalPrompt` is set, append: `Review context: "[additionalPrompt]"`.

--- a/skills/candid-ship/SKILL.md
+++ b/skills/candid-ship/SKILL.md
@@ -5,55 +5,25 @@ description: Ship your changes - review, build, test, create PR, and optionally 
 
 # Candid Ship
 
-Orchestrate the full shipping workflow: review code via candid-loop, run build and tests, create a GitHub PR, and optionally auto-merge. Aborts on any failure.
+Orchestrate the full shipping workflow: review code via candid-loop, run install/build/tests, create a GitHub PR, optionally update an issue tracker and auto-merge. Aborts on any failure before PR creation.
+
+`candid-ship` runs all configured steps **by default** — the user opts out with `--skip-*` flags. (Compare `candid-fast-ship`, which is opt-in.)
 
 ## Workflow
 
-Execute these steps in order:
+Execute these steps in order. The mechanics for each step are defined in `skills/candid-ship/WORKFLOW.md`. This file specifies the **skip semantics** unique to `candid-ship`.
 
 ### Step 1: Pre-Flight Checks
 
-Verify the environment is ready for shipping.
-
-#### 1.1: Check gh CLI
-
-```bash
-gh auth status 2>&1
-```
-
-If command fails or `gh` not found:
-```
-Pre-flight failed: GitHub CLI (gh) is not installed or not authenticated.
-Install: https://cli.github.com/
-Authenticate: gh auth login
-```
-Abort.
-
-#### 1.2: Check Git Repository
-
-```bash
-git rev-parse --is-inside-work-tree 2>&1
-```
-
-If not inside a git repo: abort with `Pre-flight failed: Not inside a git repository.`
-
-#### 1.3: Check Current Branch
-
-```bash
-git branch --show-current
-```
-
-Store as `currentBranch`. If empty (detached HEAD): abort with `Pre-flight failed: Detached HEAD state. Check out a branch first.`
+Run the pre-flight checks from WORKFLOW.md → "Pre-Flight Checks".
 
 ### Step 2: Load Configuration
 
-Load ship configuration from CLI flags and config files.
+Read config per WORKFLOW.md → "Load Configuration", extracting these `ship.*` fields plus `mergeTargetBranches`:
 
-**Precedence (highest to lowest):**
-1. CLI flags
-2. Project config (`.candid/config.json` → `ship` field)
-3. User config (`~/.candid/config.json` → `ship` field)
-4. Defaults
+`buildCommand`, `testCommand`, `installCommand`, `targetBranch`, `autoMerge`, `additionalPrompt`, `postMergeCommand`, `issueTracker` (full sub-tree).
+
+When loading from project config, output: `Using ship settings from project config`. From user config: `Using ship settings from user config`.
 
 #### Parse CLI Flags
 
@@ -62,87 +32,27 @@ Load ship configuration from CLI flags and config files.
 | `--auto-merge` | Enable auto-merge | from config |
 | `--no-auto-merge` | Disable auto-merge | from config |
 | `--skip-review` | Skip candid-loop step | `false` |
+| `--skip-install` | Skip install step | `false` |
 | `--skip-build` | Skip build command | `false` |
 | `--skip-tests` | Skip test command | `false` |
 | `--dry-run` | Show plan without executing | `false` |
 
 If both `--auto-merge` and `--no-auto-merge` are provided, `--no-auto-merge` wins.
 
-#### Check Project Config
-
-```bash
-jq -r '.ship // null' .candid/config.json 2>/dev/null
-```
-
-If the `ship` field exists, extract:
-- `buildCommand` (string) — shell command for build verification
-- `testCommand` (string) — shell command for tests
-- `targetBranch` (string) — PR target branch
-- `autoMerge` (boolean) — auto-merge after PR creation
-- `additionalPrompt` (string) — extra context for candid-loop/review
-- `postMergeCommand` (string) — shell command to run after auto-merge succeeds
-- `issueTracker` (object) — issue tracker auto-update config with `provider`, `enabled`, `teamPrefixes`, `state`, `prompt` sub-fields
-
-Output when loading: `Using ship settings from project config`
-
-#### Check User Config
-
-Same procedure for `~/.candid/config.json` if project config doesn't have `ship` field.
-
-Output when loading: `Using ship settings from user config`
-
-#### Resolve targetBranch Default
-
-If `targetBranch` is not set by config:
-1. Check `mergeTargetBranches` in project config → use first entry
-2. Check `mergeTargetBranches` in user config → use first entry
-3. Default to `"main"`
-
-Verify the target branch exists:
-```bash
-git rev-parse --verify [targetBranch] 2>/dev/null || git rev-parse --verify origin/[targetBranch] 2>/dev/null
-```
-
-If target branch doesn't exist: abort with `Target branch "[targetBranch]" does not exist locally or on remote.`
-
-#### Apply Defaults
-
-For any options not set:
-```
-buildCommand = null (skip build if not set)
-testCommand = null (skip tests if not set)
-targetBranch = resolved per above
-autoMerge = false
-additionalPrompt = null
-postMergeCommand = null (skip if not set)
-issueTracker.provider = "linear" (only "linear" is currently supported)
-issueTracker.enabled = false
-issueTracker.teamPrefixes = ["DIS", "ENG", "DISC"]
-issueTracker.state = "In Review"
-issueTracker.prompt = "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
-```
-
-#### Validate Current Branch != Target Branch
-
-If `currentBranch == targetBranch`:
-```
-Cannot ship: you are on the target branch ([targetBranch]). Check out a feature branch first.
-```
-Abort.
-
-#### Check Commits Ahead
-
-```bash
-git log --oneline [targetBranch]..HEAD 2>/dev/null | head -20
-```
-
-If no commits ahead: abort with `No commits ahead of [targetBranch]. Nothing to ship.`
+After loading, run the `targetBranch` resolution and branch-state validation from WORKFLOW.md → "Resolve targetBranch" / "Validate Branch State".
 
 ### Step 3: Display Plan
 
-Calculate `totalSteps = 4 + (issueTracker.enabled ? 1 : 0) + 1 + (postMergeCommand is set ? 1 : 0)`. Use this value as the step total in all step progress displays throughout the workflow. Renumber the visible step list (below) to skip rows for any disabled optional steps.
+Calculate `totalSteps` = 1 (PR creation always runs) + number of optional steps that will run. An optional step counts when:
+- `review`: `--skip-review` is not set
+- `install`: `--skip-install` is not set AND `installCommand` is set
+- `build`: `--skip-build` is not set AND `buildCommand` is set
+- `tests`: `--skip-tests` is not set AND `testCommand` is set
+- `issueTracker`: `issueTracker.enabled` is `true`
+- `autoMerge`: `autoMerge` is `true`
+- `postMergeCommand`: `autoMerge` is `true` AND `postMergeCommand` is set
 
-Show what will be executed:
+Renumber the displayed step list to skip rows for any disabled optional steps.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -153,367 +63,59 @@ Branch: [currentBranch] → [targetBranch]
 
 Steps:
   1. 🔍 Review code (candid-loop)           [or SKIP]
-  2. 🔨 Build: [buildCommand]               [or SKIP — not configured]
-  3. 🧪 Tests: [testCommand]                [or SKIP — not configured]
-  4. 📋 Create pull request
-  5. 🎯 Update issue tracker ([provider]): state="[state]"  [only shown if issueTracker.enabled]
-  6. 🔀 Auto-merge: enabled                 [or disabled]
-  7. 🚀 Post-merge: [postMergeCommand]      [only shown if postMergeCommand is set]
+  2. 🛠️  Install: [installCommand]          [only if installCommand is set]
+  3. 🔨 Build: [buildCommand]               [or SKIP — not configured]
+  4. 🧪 Tests: [testCommand]                [or SKIP — not configured]
+  5. 📋 Create pull request
+  6. 🎯 Update issue tracker ([provider]): state="[state]"  [only if issueTracker.enabled]
+  7. 🔀 Auto-merge: enabled                 [or disabled]
+  8. 🚀 Post-merge: [postMergeCommand]      [only if postMergeCommand is set]
 ```
 
-If `additionalPrompt` is set:
-```
-Review context: "[additionalPrompt]"
-```
+If `additionalPrompt` is set, append: `Review context: "[additionalPrompt]"`.
 
-**If `--dry-run`:**
-Output: `Dry run complete. No changes made.`
-Exit.
+**If `--dry-run`:** Output `Dry run complete. No changes made.` and exit.
 
-**If not dry-run:** Use AskUserQuestion:
+**Otherwise:** Use AskUserQuestion: "Proceed with this shipping plan?" with options "Yes, ship it" / "No, cancel". On "No, cancel": exit with `Ship cancelled.`
 
-**Question:** "Proceed with this shipping plan?"
+### Step 4: Run Review
 
-**Options:**
-1. "Yes, ship it"
-2. "No, cancel"
+**Skip if** `--skip-review` is set → `Skipping review (--skip-review)`. Otherwise execute WORKFLOW.md → "Run Review (candid-loop)".
 
-If "No, cancel": exit with `Ship cancelled.`
+### Step 5: Install Dependencies
 
-### Step 4: Run Review (candid-loop)
+**Skip if** `--skip-install` is set → `Skipping install (--skip-install)`. Skip if `installCommand` is not configured → `Skipping install (not configured)`. Otherwise execute WORKFLOW.md → "Install Dependencies".
 
-**Skip if** `--skip-review` flag is set. Output: `Skipping review (--skip-review)`
+### Step 6: Run Build
 
-Display:
-```
-Step 1/[totalSteps]: Running code review...
-```
+**Skip if** `--skip-build` is set → `Skipping build (--skip-build)`. Skip if `buildCommand` is not configured → `Skipping build (not configured)`. Otherwise execute WORKFLOW.md → "Run Build".
 
-Invoke candid-loop via the Skill tool: `/candid-loop`
+### Step 7: Run Tests
 
-If `additionalPrompt` is set, include it in the skill invocation by adding this instruction before invoking:
-> "IMPORTANT: During this review, also consider the following additional context: [additionalPrompt]"
+**Skip if** `--skip-tests` is set → `Skipping tests (--skip-tests)`. Skip if `testCommand` is not configured → `Skipping tests (not configured)`. Otherwise execute WORKFLOW.md → "Run Tests".
 
-After candid-loop completes, check its summary output:
+### Step 8: Create Pull Request
 
-- **If PASS** (no issues remaining): continue. Output: `Review passed.`
-- **If INCOMPLETE** (max iterations reached with remaining issues): Use AskUserQuestion:
-  - **Question:** "Review completed with remaining issues. Continue shipping?"
-  - **Options:**
-    1. "Yes, continue anyway"
-    2. "No, abort"
-  - If "No, abort": exit with `Ship aborted: unresolved review issues.`
-- **If CANCELLED**: abort with `Ship aborted: review was cancelled.`
+Always runs. Execute WORKFLOW.md → "Create Pull Request".
 
-### Step 5: Run Build
+### Step 9: Update Issue Tracker
 
-**Skip if** `--skip-build` flag is set OR `buildCommand` is not configured.
+Execute WORKFLOW.md → "Update Issue Tracker". The skip conditions there map directly to ship's behavior. Notes:
 
-If skipped due to no config: Output: `Skipping build (not configured)`
-If skipped due to flag: Output: `Skipping build (--skip-build)`
+- The default `teamPrefixes` (`DIS`, `ENG`, `DISC`) reflect one Linear workspace. **Edit `ship.issueTracker.teamPrefixes` in `.candid/config.json` to match your workspace's team keys.**
+- The default `prompt` encodes four invariants (single-issue, single-field, idempotent, no fallback search). Custom prompts must preserve "single issue" and "no fallback search" or the pre-call check will refuse the call.
 
-Display:
-```
-Step 2/[totalSteps]: Running build...
-$ [buildCommand]
-```
+### Step 10: Auto-Merge
 
-Execute the build command:
-```bash
-[buildCommand]
-```
+**Skip if** `autoMerge` is `false` → `Auto-merge: disabled (manual merge required)`. Otherwise execute WORKFLOW.md → "Auto-Merge".
 
-**If build fails** (non-zero exit code):
-```
-Build failed. Ship aborted.
-```
-Show the build output so the user can diagnose.
-Abort.
+### Step 11: Post-Merge Command
 
-**If build succeeds:**
-```
-Build passed.
-```
+**Skip if** `postMergeCommand` is not configured → `Skipping post-merge command (not configured)`. Skip if `autoMerge` is `false` → `Skipping post-merge command (auto-merge disabled)`. Skip if auto-merge failed in Step 10 → `Skipping post-merge command (auto-merge failed)`. Otherwise execute WORKFLOW.md → "Post-Merge Command".
 
-### Step 6: Run Tests
+### Step 12: Summary
 
-**Skip if** `--skip-tests` flag is set OR `testCommand` is not configured.
-
-If skipped due to no config: Output: `Skipping tests (not configured)`
-If skipped due to flag: Output: `Skipping tests (--skip-tests)`
-
-Display:
-```
-Step 3/[totalSteps]: Running tests...
-$ [testCommand]
-```
-
-Execute the test command:
-```bash
-[testCommand]
-```
-
-**If tests fail** (non-zero exit code):
-```
-Tests failed. Ship aborted.
-```
-Show the test output so the user can diagnose.
-Abort.
-
-**If tests succeed:**
-```
-Tests passed.
-```
-
-### Step 7: Create Pull Request
-
-Display:
-```
-Step 4/[totalSteps]: Creating pull request...
-```
-
-#### 7.1: Generate PR Title
-
-```bash
-git log [targetBranch]..HEAD --oneline
-```
-
-- **Single commit:** Use that commit message as the title
-- **Multiple commits:** Clean the branch name into a title:
-  - Remove prefix (e.g., `feature/`, `fix/`, `ron-myers/`)
-  - Replace hyphens/underscores with spaces
-  - Capitalize first letter
-  - Example: `feature/add-auth-middleware` → `Add auth middleware`
-
-Truncate title to 70 characters if needed.
-
-#### 7.2: Generate PR Body
-
-```bash
-git log [targetBranch]..HEAD --pretty=format:"- %s"
-```
-
-Assemble the body:
-
-```markdown
-## Summary
-[commit list from git log]
-
-## Verification
-- Review: [PASS — N iterations, M issues fixed | SKIPPED]
-- Build: [PASS | SKIPPED]
-- Tests: [PASS | SKIPPED]
-
----
-*Shipped with [candid-ship](https://github.com/ron-myers/candid)*
-```
-
-#### 7.3: Push Branch
-
-Ensure the branch is pushed to remote:
-
-```bash
-git push -u origin [currentBranch]
-```
-
-If push fails, abort with error message.
-
-#### 7.4: Create PR
-
-```bash
-gh pr create --base [targetBranch] --title "[title]" --body "[body]"
-```
-
-Capture the PR URL from stdout. If creation fails, abort with error message.
-
-Output: `PR created: [URL]`
-
-### Step 8: Update Issue Tracker (Optional)
-
-This step transitions the linked issue in the configured tracker (Linear today, more providers planned) to the configured state. The step is fully optional and skipped silently in every case where it can't or shouldn't run — the ship continues regardless.
-
-**Skip if** `issueTracker` is missing from config. Output: `No issue tracker configured — skipping`. Continue to Step 9.
-
-**Skip if** `issueTracker.enabled` is `false`. Output: `Skipping issue tracker update (disabled)`. Continue to Step 9.
-
-**Skip if** `issueTracker.provider` is `"none"`. Output: `Skipping issue tracker update (provider set to "none")`. Continue to Step 9.
-
-**Skip if** `issueTracker.provider` is anything other than `"linear"`:
-```
-⚠️  Issue tracker provider "[provider]" is not yet supported.
-Request support at: https://github.com/ron-myers/candid/issues
-```
-Continue to Step 9.
-
-**Skip if** `issueTracker.provider` is `"linear"` but the Linear MCP tool (`mcp__claude_ai_Linear__save_issue`) is unavailable. Output: `Linear MCP not available — skipping issue update`. Continue to Step 9.
-
-If enabled, the provider is supported, and the corresponding MCP is available, proceed.
-
-Display:
-```
-Step [N]/[totalSteps]: Updating issue tracker ([provider])...
-```
-(where `N` is the count of active steps so far + 1 — typically 5 if review, build, and tests all ran; lower otherwise)
-
-#### 8.1: Extract Issue Identifier
-
-Build a case-insensitive regex from `issueTracker.teamPrefixes`:
-
-```
-pattern = (PREFIX1|PREFIX2|...)-\d+
-```
-
-For example, with `teamPrefixes = ["DIS", "ENG", "DISC"]`:
-
-```
-pattern = (DIS|ENG|DISC)-\d+/i
-```
-
-Match the pattern against `currentBranch`. Examples:
-- `ron-myers/dis-509-add-auth` → matches `dis-509` → normalize to `DIS-509`
-- `feature/ENG-1234-fix-login` → matches `ENG-1234`
-- `feature/refactor-auth` → no match
-
-If no match, output `No issue ID found in branch name — skipping` and continue to Step 9. **This is not an error** — branches without a tracked issue ship normally.
-
-If matched, normalize the captured ID to uppercase (e.g. `dis-509` → `DIS-509`).
-
-**Note for editors:** The default `teamPrefixes` list (`DIS`, `ENG`, `DISC`) reflects one Linear workspace's team keys. **Edit this list in `.candid/config.json`** to match your workspace's team prefixes — every Linear team has its own key (the letters before the dash in any issue ID).
-
-#### 8.2: Render the Prompt
-
-Take `issueTracker.prompt` and substitute placeholders:
-
-- `{issueId}` → the matched issue ID (e.g. `DIS-509`)
-- `{state}` → `issueTracker.state` (e.g. `In Review`)
-- `{provider}` → `issueTracker.provider` (e.g. `linear`)
-
-Default prompt:
-```
-Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.
-```
-
-The default codifies four invariants that protect the user from accidental fan-out:
-1. **Single issue** — only `{issueId}` is touched, never any other issue.
-2. **Single field** — only the `state` field changes; assignees, labels, priority, title, description are untouched.
-3. **Idempotent** — already in `{state}`? Succeed without action.
-4. **No fallback search** — if the issue is missing or inaccessible, stop. Don't look for "similar" issues.
-
-The user can customize the prompt (e.g. add a comment, set an assignee), but **any custom prompt must preserve invariants 1 and 4** — single issue, no search fallback. Without those, a chatty MCP could fan out and modify unrelated issues.
-
-#### 8.3: Pre-Call Invariant Check
-
-Before calling the MCP, scan the rendered prompt for the single-issue restriction. If the user has customized `issueTracker.prompt` and stripped this protection, abort the issue-tracker step rather than risk fan-out.
-
-Treat the prompt as preserving the single-issue invariant if it contains any of these substrings (case-insensitive): `"only this one issue"`, `"only this single issue"`, `"only one issue"`, `"this issue only"`. If none match:
-
-```
-⚠️  Issue tracker prompt is missing the single-issue restriction.
-Refusing to call the MCP. Restore the invariant in `ship.issueTracker.prompt` (see candid-ship docs).
-```
-Continue to Step 9 without calling the MCP. The PR is already created.
-
-This check is defense-in-depth at the prompt layer. The structured `id` argument to the next step's MCP call already enforces single-issue scope from the API side.
-
-#### 8.4: Update Issue State (Linear)
-
-Call the Linear MCP using the rendered prompt as the instruction context, with the structured `id` and `state` arguments:
-
-```
-mcp__claude_ai_Linear__save_issue
-  id: "[matched issue ID]"
-  state: "[issueTracker.state]"
-```
-
-The structured arguments are the source of truth for what gets updated. The rendered prompt is the natural-language instruction wrapping this call — it shapes Claude's intent when invoking the tool but the `id` field is what the API enforces.
-
-**On success:** Output: `Updated [issueId] → [state]` (e.g. `Updated DIS-509 → In Review`)
-
-**On error** (issue not found, permission denied, state name not recognized, etc.):
-```
-⚠️  Issue tracker update failed: [error message]
-PR is still open at: [URL]
-```
-Do NOT abort — the PR already exists and shouldn't be wasted. Continue to Step 9.
-
-### Step 9: Auto-Merge (Optional)
-
-**Skip if** `autoMerge` is `false`. Output: `Auto-merge: disabled (manual merge required)`
-
-If `autoMerge` is `true`:
-
-Display:
-```
-Step [N]/[totalSteps]: Enabling auto-merge...
-```
-(where `N` is the count of active steps so far + 1)
-
-```bash
-gh pr merge [PR_URL] --squash --auto
-```
-
-If auto-merge fails (e.g., repo doesn't have auto-merge enabled):
-```
-⚠️  Auto-merge failed: [error message]
-The repository may not have auto-merge enabled in Settings → General → Pull Requests.
-PR is still open at: [URL]
-```
-Do NOT abort — the PR was already created. Continue to summary.
-
-If auto-merge succeeds:
-```
-Auto-merge enabled. PR will merge when checks pass.
-```
-
-### Step 10: Run Post-Merge Command (Conditional)
-
-**Skip if** `postMergeCommand` is not configured. Output: `Skipping post-merge command (not configured)`
-
-**Skip if** `autoMerge` is `false`. Output: `Skipping post-merge command (auto-merge disabled)`
-
-**Skip if** auto-merge failed in Step 8. Output: `Skipping post-merge command (auto-merge failed)`
-
-If all conditions are met (command configured, auto-merge enabled, auto-merge succeeded):
-
-Display:
-```
-Step [N]/[totalSteps]: Running post-merge command...
-$ [postMergeCommand]
-```
-(where `N` is the active step number — `totalSteps` itself, since post-merge is always the last step when present)
-
-Execute the post-merge command:
-```bash
-[postMergeCommand]
-```
-
-**If command fails** (non-zero exit code):
-```
-⚠️  Post-merge command failed: [error output]
-PR is still merging at: [URL]
-```
-Do NOT abort — the PR was already created and auto-merge is enabled. Continue to summary.
-
-**If command succeeds:**
-```
-Post-merge command completed.
-```
-
-### Step 11: Display Summary
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Candid Ship Complete
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Review:   [PASS (N iterations, M issues fixed) | SKIPPED]
-Build:    [PASS | SKIPPED]
-Tests:    [PASS | SKIPPED]
-PR:       [URL]
-Issue:    [Updated DIS-509 → In Review | Skipped — no match | Skipped — provider unsupported | Failed: <error>]   [only shown if issueTracker.enabled]
-Merge:    [Auto-merge enabled | Manual merge required | Auto-merge failed]
-Post-merge: [PASS | SKIPPED | FAILED | N/A]
-```
+Execute WORKFLOW.md → "Display Summary" with header `Candid Ship Complete`.
 
 ## Configuration
 
@@ -527,6 +129,7 @@ Add to `.candid/config.json`:
   "ship": {
     "buildCommand": "npm run build",
     "testCommand": "npm test",
+    "installCommand": "pnpm install",
     "targetBranch": "stable",
     "autoMerge": false,
     "additionalPrompt": "Focus on security and ensure all API endpoints have auth middleware",
@@ -535,69 +138,47 @@ Add to `.candid/config.json`:
       "provider": "linear",
       "enabled": true,
       "teamPrefixes": ["DIS", "ENG", "DISC"],
-      "state": "In Review",
-      "prompt": "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
+      "state": "In Review"
     }
   }
 }
 ```
 
-### Field Descriptions
+### Field Reference
 
-> **Note:** `issueTracker` is an optional, opt-in integration. When omitted, the issue-tracker step is skipped silently — the rest of the ship runs unchanged. Currently `provider: "linear"` is the only supported provider; it requires the Linear MCP server installed and authenticated. To request support for another tracker (Asana, Jira, GitHub Issues, etc.), open an issue at https://github.com/ron-myers/candid/issues.
+For full type, default, and validation rules see `skills/candid-review/CONFIG.md` (the `ship` section). Highlights:
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `ship.buildCommand` | string | `null` | Shell command for build verification. Skip if not set. |
-| `ship.testCommand` | string | `null` | Shell command for running tests. Skip if not set. |
-| `ship.targetBranch` | string | first `mergeTargetBranches` or `"main"` | Branch to target for PR. |
-| `ship.autoMerge` | boolean | `false` | Auto-merge PR after creation via `gh pr merge --squash --auto`. |
-| `ship.additionalPrompt` | string | `null` | Extra context passed to candid-loop/review. |
-| `ship.postMergeCommand` | string | `null` | Shell command to run after auto-merge succeeds. Skipped if auto-merge is disabled or fails. |
-| `ship.issueTracker.provider` | string | `"linear"` | Issue tracker to integrate with. Currently only `"linear"` is supported. Other values produce a warning with a link to request support. |
-| `ship.issueTracker.enabled` | boolean | `false` | Enable automatic issue state update after PR creation. Opt-in. |
-| `ship.issueTracker.teamPrefixes` | string[] | `["DIS", "ENG", "DISC"]` | Team keys to match in branch names (e.g. Linear team keys). **Edit this list to match your tracker workspace's team prefixes.** |
-| `ship.issueTracker.state` | string | `"In Review"` | The workflow state to transition the issue to. Must match a state name in your tracker workspace. |
-| `ship.issueTracker.prompt` | string | see default below | Customizable prompt template sent to the MCP. Supports `{issueId}`, `{state}`, `{provider}` placeholders. **Must restrict the action to one issue.** |
+- `buildCommand` / `testCommand` / `installCommand` / `additionalPrompt` / `postMergeCommand` default to `null` — the corresponding step is skipped if not set.
+- `targetBranch` defaults to first `mergeTargetBranches` entry, else `"main"`.
+- `autoMerge` defaults to `false`.
+- `issueTracker` is opt-in (`enabled: false` by default). When enabled, `provider: "linear"` is the only supported value today; other values warn and skip. The default `prompt` is documented in CONFIG.md and codifies the four safety invariants.
 
-**Default prompt:**
-```
-Update issue {issueId}: set its state to "{state}". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in "{state}", report success without action. If the issue is missing or inaccessible, report the error and stop.
-```
+> **Note:** `issueTracker` is an optional integration. When omitted, the issue-tracker step is skipped silently — the rest of the ship runs unchanged. To request support for another tracker (Asana, Jira, GitHub Issues, etc.), open an issue at https://github.com/ron-myers/candid/issues.
 
 ### Examples
 
 **Minimal — just PR creation:**
 ```json
-{
-  "ship": {
-    "targetBranch": "main"
-  }
-}
+{ "ship": { "targetBranch": "main" } }
 ```
 
-**Full CI pipeline with auto-merge:**
+**Full pipeline with install, auto-merge, and Linear:**
 ```json
 {
   "ship": {
-    "buildCommand": "npm run build",
-    "testCommand": "npm test",
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
     "targetBranch": "stable",
     "autoMerge": true,
     "additionalPrompt": "Ensure error handling covers all async operations",
-    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger"
-  }
-}
-```
-
-**Python project:**
-```json
-{
-  "ship": {
-    "buildCommand": "python -m py_compile src/**/*.py",
-    "testCommand": "pytest -v",
-    "targetBranch": "main",
-    "autoMerge": false
+    "postMergeCommand": "curl -X POST https://deploy.example.com/trigger",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["DIS", "ENG"],
+      "state": "In Review"
+    }
   }
 }
 ```
@@ -611,20 +192,25 @@ Update issue {issueId}: set its state to "{state}". Update only this one issue a
 # Force auto-merge
 /candid-ship --auto-merge
 
-# Quick ship — skip review, just build/test/PR
+# Quick ship — skip review, just install/build/test/PR
 /candid-ship --skip-review
+
+# Skip install (deps already up to date)
+/candid-ship --skip-install
 
 # See what would happen without doing it
 /candid-ship --dry-run
 
-# Skip everything except PR creation
-/candid-ship --skip-review --skip-build --skip-tests
+# PR only
+/candid-ship --skip-review --skip-install --skip-build --skip-tests
 ```
 
 ## Remember
 
 The goal of candid-ship is to **automate the entire shipping workflow** so you can go from code to merged PR with one command.
 
-**Fail-fast principle:** Any failure (review incomplete, build fail, test fail) aborts immediately with a clear message. The only exception is auto-merge failure — the PR is already created and shouldn't be wasted.
+**Fail-fast principle:** Any failure (review incomplete, install/build/test fail) aborts immediately with a clear message. Post-PR steps (issue tracker, auto-merge, post-merge) warn but never abort — the PR is already created and shouldn't be wasted.
 
-**Pre-flight checks:** Always validate the environment before starting. It's frustrating to complete a full review + build + test cycle only to discover gh isn't installed.
+**Pre-flight checks:** Always validate the environment before starting. It's frustrating to complete a full review + install + build + test cycle only to discover gh isn't installed.
+
+**Install before build:** Setting `installCommand` (e.g. `pnpm install`, `npm ci`, `poetry install`) keeps build/test failures focused on real code issues rather than missing dependencies.

--- a/skills/candid-ship/WORKFLOW.md
+++ b/skills/candid-ship/WORKFLOW.md
@@ -1,0 +1,279 @@
+# Shared Ship Workflow
+
+Steps shared between `candid-ship` and `candid-fast-ship`. Each calling skill decides **whether** each step runs (via its `--skip-*` flags or `fastShip.*` toggles). This document defines **how** each step runs once that decision is made.
+
+## Conventions
+
+**Skip output:** When a step is skipped, output `Skipping [step name] ([reason])`. The reason is whatever the calling skill says — an active flag (`--skip-build`), config absence (`buildCommand not configured`), toggle off (`not enabled in fastShip config`), etc.
+
+**Step numbering:** The calling skill computes `totalSteps` = count of steps that will actually execute. Each running step displays `Step [N]/[totalSteps]: ...` where `N` is the active step number among only the running steps.
+
+**Fail-fast:** Any non-zero exit from review/install/build/tests aborts the ship with `[Step] failed. Ship aborted.` and shows command output. The exception is post-PR steps (issue tracker, auto-merge, post-merge) — those warn but never abort, since the PR already exists.
+
+---
+
+## Pre-Flight Checks
+
+Run all three checks in one bash invocation:
+
+```bash
+gh auth status >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git branch --show-current
+```
+
+Map outcomes to aborts:
+- First failure (gh) → `Pre-flight failed: GitHub CLI (gh) is not installed or not authenticated.` Tell the user: install at https://cli.github.com/ and authenticate with `gh auth login`.
+- Second failure (git rev-parse) → `Pre-flight failed: Not inside a git repository.`
+- Empty stdout (no current branch) → `Pre-flight failed: Detached HEAD state. Check out a branch first.`
+
+On success, store stdout as `currentBranch`.
+
+---
+
+## Load Configuration
+
+Read `.candid/config.json` once with the Read tool and parse it as JSON in memory. Extract every field the calling skill needs in a single pass. If the relevant top-level field (`ship` or `fastShip`) is absent, repeat with `~/.candid/config.json`. If neither file has it, apply defaults.
+
+For field types, defaults, and validation rules see `skills/candid-review/CONFIG.md` (the `ship` and `fastShip` sections). The defaults summarized:
+
+- `ship.buildCommand`, `ship.testCommand`, `ship.installCommand`, `ship.additionalPrompt`, `ship.postMergeCommand` → `null` (skip the step if not set)
+- `ship.targetBranch` → first `mergeTargetBranches` entry, else `"main"`
+- `ship.autoMerge` → `false`
+- `ship.issueTracker.provider` → `"linear"`; `enabled` → `false`; `teamPrefixes` → `["DIS", "ENG", "DISC"]`; `state` → `"In Review"`; `prompt` → see CONFIG.md (the default codifies four invariants)
+- `fastShip.review`, `build`, `tests`, `install`, `issueTracker`, `autoMerge`, `postMergeCommand` → `false`
+
+### Resolve targetBranch
+
+Priority: caller's explicit `targetBranch` (e.g. `fastShip.targetBranch` or `ship.targetBranch`) → first `mergeTargetBranches` entry → `"main"`.
+
+Verify it exists locally or on remote:
+```bash
+git rev-parse --verify [targetBranch] 2>/dev/null || git rev-parse --verify origin/[targetBranch] 2>/dev/null
+```
+If neither resolves, abort: `Target branch "[targetBranch]" does not exist locally or on remote.`
+
+### Validate Branch State
+
+If `currentBranch == targetBranch`: abort with `Cannot ship: you are on the target branch ([targetBranch]). Check out a feature branch first.`
+
+Check commits ahead:
+```bash
+git rev-list --count [targetBranch]..HEAD
+```
+If `0`: abort with `No commits ahead of [targetBranch]. Nothing to ship.`
+
+---
+
+## Install Dependencies
+
+Display:
+```
+Step [N]/[totalSteps]: Installing dependencies...
+$ [installCommand]
+```
+
+Execute the install command. On non-zero exit: `Install failed. Ship aborted.` Show output and abort. On success: `Install passed.`
+
+---
+
+## Run Review (candid-loop)
+
+Display:
+```
+Step [N]/[totalSteps]: Running code review...
+```
+
+Invoke `candid-loop` via the Skill tool. If `additionalPrompt` is set, prepend this instruction before invoking:
+> "IMPORTANT: During this review, also consider the following additional context: [additionalPrompt]"
+
+After candid-loop completes, check its summary:
+- **PASS** (no issues remaining) → continue. Output: `Review passed.`
+- **INCOMPLETE** (max iterations reached, issues remain) → use AskUserQuestion: "Review completed with remaining issues. Continue shipping?" with options "Yes, continue anyway" / "No, abort". On "No, abort": exit with `Ship aborted: unresolved review issues.`
+- **CANCELLED** → abort with `Ship aborted: review was cancelled.`
+
+---
+
+## Run Build
+
+Display:
+```
+Step [N]/[totalSteps]: Running build...
+$ [buildCommand]
+```
+
+Execute. On non-zero exit: `Build failed. Ship aborted.` Show output and abort. On success: `Build passed.`
+
+---
+
+## Run Tests
+
+Display:
+```
+Step [N]/[totalSteps]: Running tests...
+$ [testCommand]
+```
+
+Execute. On non-zero exit: `Tests failed. Ship aborted.` Show output and abort. On success: `Tests passed.`
+
+---
+
+## Create Pull Request
+
+Display:
+```
+Step [N]/[totalSteps]: Creating pull request...
+```
+
+### Read commits once
+
+```bash
+git log [targetBranch]..HEAD --pretty=format:"%s"
+```
+
+Store output as `commitSubjects` (one commit subject per line).
+
+### Generate Title
+
+- **Single line:** use verbatim (truncate to 70 chars).
+- **Multiple lines:** derive from `currentBranch`:
+  - Strip prefix (`feature/`, `fix/`, `[username]/`, etc.)
+  - Replace `-` and `_` with spaces
+  - Capitalize first letter
+  - Truncate to 70 chars
+  - Example: `feature/add-auth-middleware` → `Add auth middleware`
+
+### Generate Body
+
+```markdown
+## Summary
+[each line of commitSubjects prefixed with "- "]
+
+## Verification
+- Install: [PASS | SKIPPED]
+- Review: [PASS — N iterations, M issues fixed | SKIPPED]
+- Build: [PASS | SKIPPED]
+- Tests: [PASS | SKIPPED]
+
+---
+*Shipped with [candid-ship](https://github.com/ron-myers/candid)*
+```
+
+Omit any Verification row whose step was skipped. (Or keep with `SKIPPED` — match the calling skill's footer convention.)
+
+### Push and Create
+
+```bash
+git push -u origin [currentBranch]
+```
+On failure, abort with the error message.
+
+```bash
+gh pr create --base [targetBranch] --title "[title]" --body "[body]"
+```
+Capture stdout as the PR URL. On failure, abort with the error message.
+
+Output: `PR created: [URL]`
+
+---
+
+## Update Issue Tracker
+
+The issue-tracker step is post-PR — it warns on every failure mode but never aborts.
+
+### Skip Conditions
+
+Skip silently with the matching reason:
+- `issueTracker` config absent → `No issue tracker configured — skipping`
+- `issueTracker.enabled` is `false` (or `fastShip.issueTracker` is `false` when called from fast-ship) → `Skipping issue tracker update (disabled)`
+- `provider` is `"none"` → `Skipping issue tracker update (provider set to "none")`
+- `provider` is anything other than `"linear"` → warn `⚠️  Issue tracker provider "[provider]" is not yet supported. Request support at: https://github.com/ron-myers/candid/issues` and skip
+- Linear MCP tool (`mcp__claude_ai_Linear__save_issue`) unavailable → `Linear MCP not available — skipping issue update`
+
+### Extract Issue Identifier
+
+Build a case-insensitive regex from `teamPrefixes`:
+```
+pattern = (PREFIX1|PREFIX2|...)-\d+
+```
+Match against `currentBranch`. Examples with `["DIS", "ENG", "DISC"]`:
+- `ron-myers/dis-509-add-auth` → `DIS-509`
+- `feature/ENG-1234-fix-login` → `ENG-1234`
+- `feature/refactor-auth` → no match
+
+If no match: `No issue ID found in branch name — skipping`. **Not an error.** Branches without a tracked issue ship normally.
+
+If matched, normalize to uppercase.
+
+### Render the Prompt
+
+Substitute `{issueId}`, `{state}`, `{provider}` in `issueTracker.prompt`. The default prompt encodes four invariants (single-issue, single-field, idempotent, no fallback search) — see `skills/candid-review/CONFIG.md` for the full text.
+
+### Pre-Call Invariant Check
+
+Custom prompts that strip the single-issue restriction risk fan-out. Treat the rendered prompt as preserving the invariant only if it contains one of (case-insensitive): `"only this one issue"`, `"only this single issue"`, `"only one issue"`, `"this issue only"`. If none match:
+```
+⚠️  Issue tracker prompt is missing the single-issue restriction.
+Refusing to call the MCP. Restore the invariant in `ship.issueTracker.prompt` (see candid-ship docs).
+```
+Skip the MCP call. The structured `id` argument enforces single-issue scope from the API side; the prompt check is defense-in-depth.
+
+### Call the MCP (Linear)
+
+```
+mcp__claude_ai_Linear__save_issue
+  id: "[matched issue ID]"
+  state: "[issueTracker.state]"
+```
+
+The structured `id` is authoritative; the rendered prompt shapes Claude's intent.
+
+- **Success:** `Updated [issueId] → [state]` (e.g. `Updated DIS-509 → In Review`)
+- **Error** (issue not found, permission, bad state name, etc.): warn `⚠️  Issue tracker update failed: [error message]. PR is still open at: [URL]` and continue.
+
+---
+
+## Auto-Merge
+
+Display:
+```
+Step [N]/[totalSteps]: Enabling auto-merge...
+```
+
+```bash
+gh pr merge [PR_URL] --squash --auto
+```
+
+- **Success:** `Auto-merge enabled. PR will merge when checks pass.`
+- **Failure** (e.g. repo doesn't allow auto-merge): warn `⚠️  Auto-merge failed: [error message]. The repository may not have auto-merge enabled in Settings → General → Pull Requests. PR is still open at: [URL]`. Continue — the PR exists.
+
+---
+
+## Post-Merge Command
+
+Display:
+```
+Step [N]/[totalSteps]: Running post-merge command...
+$ [postMergeCommand]
+```
+
+Execute. On non-zero exit: warn `⚠️  Post-merge command failed: [error output]. PR is still merging at: [URL]`. Continue. On success: `Post-merge command completed.`
+
+---
+
+## Display Summary
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[Candid Ship Complete | Candid Fast Ship Complete]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Install:  [PASS | SKIPPED]
+Review:   [PASS (N iterations, M issues fixed) | SKIPPED]
+Build:    [PASS | SKIPPED]
+Tests:    [PASS | SKIPPED]
+PR:       [URL]
+Issue:    [Updated DIS-509 → In Review | Skipped — <reason> | Failed: <error>]   (only if issue tracker enabled)
+Merge:    [Auto-merge enabled | Manual merge required | Auto-merge failed]
+Post-merge: [PASS | SKIPPED | FAILED | N/A]
+```
+
+Omit the `Install:` row if `installCommand` was not configured. Omit the `Issue:` row if the issue tracker was not enabled.

--- a/skills/candid-ship/WORKFLOW.md
+++ b/skills/candid-ship/WORKFLOW.md
@@ -45,11 +45,14 @@ For field types, defaults, and validation rules see `skills/candid-review/CONFIG
 
 Priority: caller's explicit `targetBranch` (e.g. `fastShip.targetBranch` or `ship.targetBranch`) → first `mergeTargetBranches` entry → `"main"`.
 
-Verify it exists locally or on remote:
+Resolve to a concrete ref, **preferring `origin/[targetBranch]` when it exists** so that a stale local branch doesn't silently include already-shipped commits:
+
 ```bash
-git rev-parse --verify [targetBranch] 2>/dev/null || git rev-parse --verify origin/[targetBranch] 2>/dev/null
+target_ref=$(git rev-parse --verify origin/[targetBranch] 2>/dev/null || git rev-parse --verify [targetBranch] 2>/dev/null)
 ```
-If neither resolves, abort: `Target branch "[targetBranch]" does not exist locally or on remote.`
+If `target_ref` is empty, abort: `Target branch "[targetBranch]" does not exist locally or on remote.`
+
+Use `target_ref` (not the bare branch name) for every subsequent diff/log comparison in this workflow.
 
 ### Validate Branch State
 
@@ -57,7 +60,7 @@ If `currentBranch == targetBranch`: abort with `Cannot ship: you are on the targ
 
 Check commits ahead:
 ```bash
-git rev-list --count [targetBranch]..HEAD
+git rev-list --count $target_ref..HEAD
 ```
 If `0`: abort with `No commits ahead of [targetBranch]. Nothing to ship.`
 
@@ -125,8 +128,10 @@ Step [N]/[totalSteps]: Creating pull request...
 
 ### Read commits once
 
+Use the `target_ref` resolved in "Resolve targetBranch" — preferring `origin/[targetBranch]` so a stale local branch doesn't pollute the PR body with already-shipped commits.
+
 ```bash
-git log [targetBranch]..HEAD --pretty=format:"%s"
+git log $target_ref..HEAD --pretty=format:"%s"
 ```
 
 Store output as `commitSubjects` (one commit subject per line).
@@ -181,9 +186,10 @@ The issue-tracker step is post-PR — it warns on every failure mode but never a
 
 ### Skip Conditions
 
-Skip silently with the matching reason:
-- `issueTracker` config absent → `No issue tracker configured — skipping`
-- `issueTracker.enabled` is `false` (or `fastShip.issueTracker` is `false` when called from fast-ship) → `Skipping issue tracker update (disabled)`
+The calling skill resolves its own enable toggle (`ship.issueTracker.enabled` for candid-ship, `fastShip.issueTracker` for candid-fast-ship) before invoking this section. Once invoked, skip silently with the matching reason:
+
+- `ship.issueTracker` config absent → `No issue tracker configured — skipping`
+- Caller's enable toggle is `false` → `Skipping issue tracker update (disabled)`
 - `provider` is `"none"` → `Skipping issue tracker update (provider set to "none")`
 - `provider` is anything other than `"linear"` → warn `⚠️  Issue tracker provider "[provider]" is not yet supported. Request support at: https://github.com/ron-myers/candid/issues` and skip
 - Linear MCP tool (`mcp__claude_ai_Linear__save_issue`) unavailable → `Linear MCP not available — skipping issue update`


### PR DESCRIPTION
## Summary
- Apply candid-review fixes (5 issues)
- Optimize candid-ship for tokens; add installCommand support

## Verification
- Review: PASS — 1 iteration, 5 issues fixed
- Build: SKIPPED (not configured)
- Tests: SKIPPED (not configured)
- Docs site: built locally after npm install (verifying the user's exact complaint that motivated installCommand)

## What's in this PR
**New install step** (`ship.installCommand` / `fastShip.install` / `--skip-install`): runs before build/tests when configured. Common values: `pnpm install`, `npm ci`, `poetry install`. Addresses the failure mode where build/test logs are really stale-dependency errors.

**Shared workflow doc**: extracted `skills/candid-ship/WORKFLOW.md` and refactored both `candid-ship/SKILL.md` (631 → 215 lines) and `candid-fast-ship/SKILL.md` (532 → 197 lines) to reference it. Each skill owns only the skip semantics unique to its mode (`--skip-*` flags vs `fastShip.*` toggles).

**Token-efficiency wins**: single `git log` call for PR title + body; `git rev-list --count` replaces `git log | head -20`; field-descriptions table now references CONFIG.md rather than duplicating it.

**Documentation coverage**: CONFIG.md (schema, validation, examples), `docs/core-features/candid-ship`, `docs/core-features/candid-fast-ship`, `docs/reference/config-options`, command files, examples/ship/config.json, candid-init's Custom-mode prompt, CHANGELOG 1.15.0 entry.

**Self-review fixes applied this iteration**:
- 📜 Updated `.candid/Technical.md` to document the WORKFLOW.md cross-skill shared-spec pattern (alongside CONFIG.md)
- 📋 Plan-display step numbers in both SKILL.md files use `[N]` placeholders to match the dynamic numbering
- 📋 Issue-tracker skip conditions in WORKFLOW.md rephrased to be caller-agnostic
- 🤔 WORKFLOW.md prefers \`origin/[targetBranch]\` when resolving \`target_ref\` so a stale local branch doesn't pollute PR bodies with already-shipped commits
- 💭 Same Technical.md edit also documents this as a recommended pattern

**Open decision-register questions**:
1. Should \`additionalPrompt\` cross-skill propagation become a structured arg through candid-loop/review?
2. Is \`skills/candid-ship/WORKFLOW.md\` the right home, or should it move to \`skills/_shared/\`?

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*