### PR TITLE
Add candid-chrome-qa skill for live browser testing (v1.16.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
         "source": "url",
         "url": "https://github.com/ron-myers/candid.git"
       },
-      "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
+      "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
       "version": "1.16.0",
       "author": {
         "name": "Ron Myers",
@@ -27,7 +27,13 @@
         "quality",
         "architecture",
         "full-stack",
-        "todos"
+        "todos",
+        "qa",
+        "testing",
+        "browser",
+        "chrome",
+        "a11y",
+        "accessibility"
       ]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
-      "version": "1.10.0",
+      "version": "1.16.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "candid",
-  "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, and seamless todo integration.",
+  "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
   "version": "1.16.0",
   "author": {
     "name": "Ron Myers",
@@ -16,6 +16,12 @@
     "todos",
     "quality",
     "architecture",
-    "full-stack"
+    "full-stack",
+    "qa",
+    "testing",
+    "browser",
+    "chrome",
+    "a11y",
+    "accessibility"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **End-of-pass summary**: writes the `summary` block to JSON and prints to stdout — total finding count, severity breakdown, category breakdown, and the title + URL of every P0/P1 finding. JSON file remains the source of truth; stdout is a courtesy for users without a triage tool
   - **CLI flags**: `--url <url>` (skip URL prompt), `--mobile-only` (invert default to mobile-only)
   - **Hard rules enforced**: never click destructive actions (delete/disconnect/drop/force/publish/purchase) without explicit per-action approval; never silently downgrade to source-only review when data is missing; never invent the schema; never batch-write findings; never skip mobile or cross-cutting probes; never use a stale tab
-  - **Comprehensive docs**: dedicated `/docs/core-features/candid-chrome-qa` page covering quick start, the flush-capture cycle, edge-case patterns, schema reference with v1→v2 migration table, severity scale → Linear priority mapping, and FAQ
-  - **Requires** the `mcp__claude-in-chrome__*` tools (auto-loaded via `ToolSearch` on first use) and a running web app reachable via HTTP
+  - **Pre-flight step 0** detects whether the Claude in Chrome MCP is installed (via `ToolSearch`) and aborts with a clear install link if absent. Batch-loads every browser tool the skill will use so subsequent calls don't pay per-tool ToolSearch overhead
+  - **Project-context loading**: pre-flight reads `Technical.md` for QA-relevant rules (browser support matrix, accessibility target, API base path, design-system constraints, auth setup) and an optional `chromeQA` block in `.candid/config.json` (`defaultUrl`, `apiPathPattern`, `desktopViewport`, `mobileViewport`) — keeps the skill from being an island next to the rest of the Candid pack
+  - **Deterministic finding IDs**: `id` is now `F-` + the first 8 hex chars of `SHA-1(url|title)`, so the same finding in a re-run gets the same ID and downstream tools can dedup across passes
+  - **Deterministic slug + filename collision handling**: file slug derived from the first 4 words of `goal` (lowercased, alphanumerics + hyphens, ≤40 chars). If today's file with the same slug exists, the skill writes to `<YYYY-MM-DD>-<HHmm>-<slug>.json` instead of overwriting
+  - **Comprehensive docs**: dedicated `/docs/core-features/candid-chrome-qa` page covering quick start, the flush-capture cycle, edge-case patterns, schema reference with v1→v2 migration table, severity scale → Linear priority mapping, configuration reference, Technical.md integration, and FAQ
+  - **Requires** the Claude in Chrome MCP installed in your Claude Code environment and a running web app reachable via HTTP
+
+### Changed
+
+- **Plugin description + keywords** updated in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` to surface the new browser-QA capability for marketplace discovery — added keywords `qa`, `testing`, `browser`, `chrome`, `a11y`, `accessibility`
 
 ## [1.15.0] - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-04-25
+
+### Added
+
+- **Candid Chrome QA** (`/candid-chrome-qa`): A new skill that drives a real Chrome session against your running web app, walks the target like a real user across desktop and mobile, runs DOM/console/network probes, and emits structured findings JSON to `.context/findings/<date>-<slug>.json` for downstream triage
+  - **Pre-flight protocol**: verifies dev server (curl health check), confirms a fresh Chrome tab, resizes to desktop default (1440x900), navigates and confirms logged-in state, clears the console baseline, and verifies required data is present before any QA work begins. Aborts with a focused error if any check fails — no silent downgrade to source-only review
+  - **Per-target flush-capture cycle**: for each route or tab, flush console + network telemetry, exercise 2–3 main interactions plus 1 edge case, capture telemetry against a console-triage table (P0–P3 mapping for the noisy stuff: TypeError, hydration mismatch, CORS, deprecated lifecycle, unmounted setState, etc.) and a network health threshold table (4xx rate, response time, payload size, duplicate requests). Findings appended per-finding, never batched
+  - **Mobile pass required by default**: resizes to 390x844 and re-walks the top 5 targets with a 44×44px touch-target probe. Falls back to ~500px if Chrome's UI chrome enforces a larger min content width. Mobile-only bugs surface in roughly 30% of passes
+  - **Cross-cutting probes**: a single `javascript_exec` call per pass enumerates icon-only buttons without aria-labels, images without alt text, and inputs without labels — catches DOM-level a11y violations that click-by-click testing misses
+  - **Schema v2.0** (best-in-class redesign over the source skill): top-level adds `schemaVersion`, `summary` block (severity + category counts populated at end-of-pass); per-finding adds `category` (bug/a11y/perf/ux/copy/security/compat — separate routing dimension from severity), `viewport` (desktop/mobile/both — first-class mobile signal), `url` (full repro URL), `capturedAt` (per-finding ISO8601 timestamp), `confidence` (definite/likely/suspected); renames `tag` → `surface`; promotes `evidence.consoleErrors` from `string[]` to `[{level, message}]` and `evidence.networkRequests` from `string[]` to `[{method, url, status, durationMs?}]`; drops `body` (pure derivation) and `status` (consumer-owned). v1 triage tool consumers will need migration — see `schemaVersion` field
+  - **End-of-pass summary**: writes the `summary` block to JSON and prints to stdout — total finding count, severity breakdown, category breakdown, and the title + URL of every P0/P1 finding. JSON file remains the source of truth; stdout is a courtesy for users without a triage tool
+  - **CLI flags**: `--url <url>` (skip URL prompt), `--mobile-only` (invert default to mobile-only)
+  - **Hard rules enforced**: never click destructive actions (delete/disconnect/drop/force/publish/purchase) without explicit per-action approval; never silently downgrade to source-only review when data is missing; never invent the schema; never batch-write findings; never skip mobile or cross-cutting probes; never use a stale tab
+  - **Comprehensive docs**: dedicated `/docs/core-features/candid-chrome-qa` page covering quick start, the flush-capture cycle, edge-case patterns, schema reference with v1→v2 migration table, severity scale → Linear priority mapping, and FAQ
+  - **Requires** the `mcp__claude-in-chrome__*` tools (auto-loaded via `ToolSearch` on first use) and a running web app reachable via HTTP
+
 ## [1.15.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The review process follows these steps:
 - **Todo Integration** - Convert issues to tracked todos with multi-select
 - **Issue Categorization** - Organized by severity (Critical → Architectural)
 - **Context Optimization** - Audit and optimize token usage for leaner, deeper reviews
+- **Live Browser QA** - Drive a real Chrome session against your running app, walk it like a real user across desktop and mobile, and emit structured findings JSON ready for triage
 
 ## Installation
 
@@ -64,6 +65,13 @@ Then restart Claude Code.
 ```
 /candid-review --auto-commit
 ```
+
+**Live browser QA pass:**
+```
+/candid-chrome-qa
+```
+
+Drives a real Chrome session against your running app, walks it like a real user across desktop and mobile, and writes structured findings to `.context/findings/<date>-<slug>.json`. See [Candid Chrome QA docs](https://www.candid.tools/docs/core-features/candid-chrome-qa) for the full workflow and v2.0 schema reference.
 
 ## Documentation
 

--- a/commands/candid-chrome-qa.md
+++ b/commands/candid-chrome-qa.md
@@ -1,0 +1,32 @@
+---
+command: candid-chrome-qa
+description: Drive a real Chrome session against a running web app, find bugs, and write structured findings to .context/findings/
+skill: candid-chrome-qa
+args:
+  - name: url
+    description: App URL to test (overrides prompted value, e.g. http://localhost:3000)
+    required: false
+  - name: mobile-only
+    description: Skip desktop pass and run mobile-only (390x844). Explicit opt-in — desktop is the default and runs first otherwise.
+    required: false
+---
+
+Run a structured QA pass on a running web app via Chrome. Walks the target like a real user across desktop and mobile, runs DOM/console/network probes, and emits findings as schema-compliant JSON to `.context/findings/<date>-<slug>.json`.
+
+Usage:
+```
+/candid-chrome-qa                                          # Prompts for goal, prompt, and URL
+/candid-chrome-qa --url http://localhost:3000              # Skip URL prompt
+/candid-chrome-qa --mobile-only                            # Mobile pass only (rare; desktop runs first by default)
+```
+
+When invoked, you'll be asked for:
+- **goal** — what surface to test (e.g. "Agent Config tabs, all 16")
+- **prompt** — free-form QA plan (edge cases, hot spots, recently-changed surfaces)
+- **app URL** — verified before any work begins (curl health check)
+
+Output:
+- **JSON findings file** at `.context/findings/<YYYY-MM-DD>-<slug>.json` — v2.0 schema with `context`, `findings`, and end-of-pass `summary` blocks
+- **Stdout summary** at end of pass — severity counts, category breakdown, and titles + URLs of every P0/P1 finding
+
+Requires the `mcp__claude-in-chrome__*` tools to be available (auto-loaded via ToolSearch on first use).

--- a/docs/app/docs/core-features/_meta.js
+++ b/docs/app/docs/core-features/_meta.js
@@ -10,5 +10,6 @@ export default {
   'context-optimization': 'Context Optimization',
   'candid-ship': 'Candid Ship',
   'candid-fast-ship': 'Candid Fast Ship',
+  'candid-chrome-qa': 'Candid Chrome QA',
   'slash-commands': 'Slash Commands',
 }

--- a/docs/app/docs/core-features/candid-chrome-qa/page.mdx
+++ b/docs/app/docs/core-features/candid-chrome-qa/page.mdx
@@ -246,14 +246,49 @@ The skill enforces these — it will refuse to act otherwise:
 3. **Never invent the schema.** v2.0 fields, byte-for-byte. Downstream consumers depend on it.
 4. **Never batch-write findings at the end.** Append per-finding. Context can exhaust mid-pass.
 5. **Never claim "no issues" without running the cross-cutting probes.**
-6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute.
+6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute. **Exception:** `--mobile-only` explicitly opts out of this rule.
 7. **Never use a stale tab.** Always confirm tab context first.
+8. **Never proceed without verifying Claude in Chrome is loaded** in pre-flight — without it, every browser tool call fails opaquely.
+
+## Configuration
+
+Optional `chromeQA` block in `.candid/config.json`:
+
+```json
+{
+  "chromeQA": {
+    "defaultUrl": "http://localhost:3000",
+    "apiPathPattern": "/api/",
+    "desktopViewport": "1440x900",
+    "mobileViewport": "390x844"
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `defaultUrl` | (prompted) | Skip the URL prompt on every run |
+| `apiPathPattern` | `/api/` | What path prefix to capture when pulling network telemetry — useful for non-standard backends (e.g. `/v2/api/`, `supabase`) |
+| `desktopViewport` | `1440x900` | Viewport size for the desktop pass |
+| `mobileViewport` | `390x844` | Viewport size for the mobile pass |
+
+## Technical.md integration
+
+If your project has a `Technical.md` (Candid's standards file — see [Technical.md docs](/docs/core-features/technical-md)), the skill reads it during pre-flight and uses any QA-relevant rules during the pass. Project-specific rules to encode there:
+
+- **Browser support matrix** (e.g. "support last 2 Chrome / Safari / Firefox; no IE")
+- **Accessibility target** (WCAG A / AA / AAA)
+- **API base path** (e.g. "/v2/api/")
+- **Design-system constraints** (e.g. "all CTA buttons use Button.Primary; no inline styles")
+- **Auth setup** (e.g. "test account `qa@example.com` lives in `.env.local`")
+
+Findings against Technical.md rules surface with `surface: "Technical.md"` so they're easy to filter downstream.
 
 ## Requirements
 
 - A running web app reachable via HTTP (typically `http://localhost:<port>`)
-- The `mcp__claude-in-chrome__*` tools available in your Claude Code environment (auto-loaded on first use via `ToolSearch`)
-- A writable `.context/findings/` directory in your workspace
+- The Claude in Chrome MCP installed in your Claude Code environment — the skill checks for `mcp__claude-in-chrome__*` tools in pre-flight step 0 and aborts with an install link if absent
+- A writable `.context/` directory in your workspace (the skill creates `.context/findings/` if missing)
 
 ## FAQ
 
@@ -265,14 +300,22 @@ Yes, but be explicit about it. The skill's "Hard Rules" prevent destructive acti
 
 Pre-flight aborts with a focused error: `Pre-flight failed: <url> returned 000 (not 2xx/3xx). Start your dev server and re-run.` No browser work happens until the server responds.
 
+### What if Claude in Chrome isn't installed?
+
+Pre-flight step 0 catches this and prints an install link. Run `/candid-chrome-qa` again after you've installed the MCP and restarted Claude Code.
+
 ### Why JSON instead of a markdown report?
 
 Findings are designed to feed downstream triage tools that turn them into Linear issues. The JSON contract is stable across passes; markdown rendering can be done at consumption time. The end-of-pass stdout summary covers the "I just want to read it" case.
 
 ### What if my findings file already exists for today?
 
-The skill suffixes `-<HHmm>` to avoid clobbering a prior pass. Two passes on the same day produce two files, both preserved.
+The skill switches to a `<YYYY-MM-DD>-<HHmm>-<slug>.json` filename to avoid clobbering a prior pass. Two passes on the same day produce two files, both preserved.
 
 ### Can I disable the mobile pass?
 
-Mobile is required by default — a third of bugs are mobile-only. If you genuinely don't need it, run `/candid-chrome-qa --mobile-only` to invert (mobile-only) or run twice with focused goals.
+Mobile is required by default — a third of bugs are mobile-only. There is no flag to skip it; if you truly want desktop-only, run a single-target pass and stop after the desktop section. The `--mobile-only` flag does the **opposite** — it skips desktop and runs mobile only (use sparingly; it's an explicit opt-out of Hard Rule 6).
+
+### Can the same finding be deduplicated across passes?
+
+Yes. The `id` field is a deterministic SHA-1 hash of `<url>|<title>` — the same finding in a re-run gets the same ID. Triage tools can use this to suppress duplicates.

--- a/docs/app/docs/core-features/candid-chrome-qa/page.mdx
+++ b/docs/app/docs/core-features/candid-chrome-qa/page.mdx
@@ -1,0 +1,278 @@
+export const metadata = {
+  title: 'Candid Chrome QA - Live browser testing for your web app',
+  description: 'Drive a real Chrome session against your running web app, walk it like a real user across desktop and mobile, and emit structured findings JSON ready for triage.',
+}
+
+# Candid Chrome QA
+
+Drive a real Chrome session against your running web app, walk it like a real user, and write structured findings to disk for triage. Catches the bugs your unit tests miss — UX quirks, mobile-only layout breaks, accessibility violations, console errors, slow API calls.
+
+## Quick Start
+
+```
+/candid-chrome-qa
+```
+
+You'll be asked for:
+
+- **goal** — what surface to test (e.g. "Agent Config tabs, all 16")
+- **prompt** — free-form QA plan (edge cases, hot spots, recently-changed surfaces)
+- **app URL** — verified before any work begins (curl health check)
+
+The pass writes findings to `.context/findings/<YYYY-MM-DD>-<slug>.json` and prints a summary to your terminal at the end.
+
+```
+/candid-chrome-qa --url http://localhost:3000     # Skip URL prompt
+/candid-chrome-qa --mobile-only                   # Mobile pass only
+```
+
+## How It Works
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Chrome QA
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Goal:   Agent Config tabs, all 16
+URL:    http://localhost:3000
+
+Steps:
+  1. ✅ Pre-flight (server up, fresh tab, baseline cleared)
+  2. 🖥️  Desktop pass (1440x900) — walk every target
+  3. 📱 Mobile pass (390x844) — top 5 targets re-walked
+  4. 🔍 Cross-cutting probes (a11y, touch targets)
+  5. 📝 Append findings to JSON (per-finding, not batched)
+  6. 📊 Final summary (file + stdout)
+```
+
+Each target gets the **flush-capture cycle**: clear console + network → exercise interactions + 1 edge case → wait → capture telemetry → append finding. This keeps every step's signal clean.
+
+## Pre-Flight Checks
+
+Before any QA work, candid-chrome-qa verifies:
+
+- **Dev server is up** — `curl` health check on the URL. Anything other than 2xx/3xx aborts with a clear ask.
+- **Fresh Chrome tab** — uses `mcp__claude-in-chrome__tabs_context_mcp` to enumerate, creates a new tab unless you say otherwise.
+- **Desktop default viewport** — `1440x900`.
+- **Logged-in state confirmed** — if you land on a login or onboarding route, the skill asks before proceeding.
+- **Console baseline cleared** — sets the high-water mark so per-target probes only show fresh entries.
+- **Required data present** — if the goal touches lists/details and the account is empty, the skill asks rather than silently downgrading to source-only review.
+- **Findings file opened** — `.context/findings/<YYYY-MM-DD>-<slug>.json` initialised with the schema and empty `findings: []`.
+
+If any check fails, the pass stops with a focused error before any browser work begins.
+
+## Per-Target Loop
+
+For each target identified in `goal` + `prompt`:
+
+1. Navigate (sidebar buttons, not direct URLs, for client-side routing apps)
+2. Flush console + network telemetry
+3. Read interactive elements
+4. Exercise 2–3 main interactions + **1 edge case** (empty input, invalid format, rapid double-click, navigation while dirty)
+5. Wait 1–2s for in-flight requests
+6. Capture telemetry — apply the console triage table and network thresholds
+7. Append findings to disk (immediately, not buffered)
+8. Reset state if you mutated something that affects subsequent targets
+
+### Edge-case patterns
+
+The "1 edge case" per target reaches for one of these — they catch the majority of production-only failures:
+
+- **Race condition** — fire 3+ identical requests within 500 ms (rapid double-click save). Watch for mixed 200/500 on the same endpoint.
+- **Stale state** — mutate → navigate away → come back. Missing re-fetch after mutation = stale state.
+- **Silent failure** — perform an action that returns 200, then refresh and verify the change actually persisted.
+- **Memory drift** — repeat an action 20× and snapshot `document.querySelectorAll('*').length` early vs late.
+- **Idle WebSocket** — for real-time features, idle 60s and check console for close events without reconnect.
+
+## Cross-Cutting Probes
+
+Run once per pass via `javascript_exec`. These catch things click-by-click won't:
+
+- **A11y probe** — counts icon-only buttons without labels, images without alt text, inputs without labels.
+- **Touch-target probe** (mobile) — flags any tappable element under 44×44 px.
+
+Both probes return structured data the skill turns into findings tagged `category: "a11y"`.
+
+## Mobile Pass
+
+After desktop, the skill resizes to `390x844` and re-walks the 5 most-used targets (or your specified subset). The touch-target probe runs here. Mobile-only bugs surface in roughly 30% of passes — this step is required, not optional.
+
+> **Resize ceiling:** Chrome may enforce a minimum content width of ~1075 px depending on UI chrome. If 390 doesn't take effect, the skill falls back to the smallest reachable width (often ~500 px) — the mobile breakpoint still triggers, the desktop sidebar still hides, and the hamburger drawer still appears. The actual width is recorded in the finding's `evidence`.
+
+## Output Schema (v2.0)
+
+Every finding file looks like this:
+
+```json
+{
+  "schemaVersion": "2.0",
+  "context": {
+    "createdAt": "2026-04-25T18:30:00Z",
+    "scope": "Agent Config tabs, all 16",
+    "originatingPrompt": "Walk every tab, exercise save/cancel, hammer phone provisioning",
+    "environment": {
+      "url": "http://localhost:3000",
+      "branch": "feature/agent-config-v2",
+      "commit": "8001a89",
+      "viewport": "1440x900",
+      "agentModel": "claude-opus-4-7"
+    }
+  },
+  "findings": [
+    {
+      "id": "F-a3f29b71",
+      "severity": "P0",
+      "category": "bug",
+      "surface": "dashboard/agents/[id]/voice",
+      "viewport": "both",
+      "url": "http://localhost:3000/dashboard/agents/agent_123/voice",
+      "title": "Save button does nothing on Voice tab when phone is unprovisioned",
+      "repro": "1. Open agent\n2. Voice tab\n3. Click Save",
+      "expected": "Either save or show validation error",
+      "actual": "Click registers, no network call, no error, no state change",
+      "evidence": {
+        "consoleErrors": [
+          {"level": "warn", "message": "[react-hook-form] missing required: phoneNumber"}
+        ],
+        "networkRequests": [],
+        "filesLikelyTouched": ["app/src/components/agent/VoiceTab.tsx:142"]
+      },
+      "suggestedFix": "Surface the form validation error in the UI; current handler swallows it",
+      "groupHint": "form-state",
+      "confidence": "definite",
+      "capturedAt": "2026-04-25T18:34:12Z"
+    }
+  ],
+  "summary": {
+    "total": 19,
+    "bySeverity": {"p0": 2, "p1": 5, "p2": 8, "p3": 2, "p4": 1, "p5": 1},
+    "byCategory": {"bug": 8, "a11y": 4, "perf": 2, "ux": 3, "copy": 1, "security": 0, "compat": 1}
+  }
+}
+```
+
+### Per-finding required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | `F-<8charSlug>` |
+| `severity` | enum | `P0` (urgent) → `P5` (idea) |
+| `category` | enum | `bug` \| `a11y` \| `perf` \| `ux` \| `copy` \| `security` \| `compat` |
+| `surface` | string | Route or component name |
+| `viewport` | enum | `desktop` \| `mobile` \| `both` |
+| `url` | string | Full repro URL with query/hash |
+| `title` | string | One-line, < 80 chars |
+| `repro` | string | Numbered steps |
+| `expected` | string | One-line expected behaviour |
+| `actual` | string | One-line observed behaviour |
+| `suggestedFix` | string | One-line fix proposal |
+| `groupHint` | string | Topic slug for clustering related findings |
+| `confidence` | enum | `definite` \| `likely` \| `suspected` |
+| `capturedAt` | ISO8601 | Per-finding timestamp |
+
+`evidence` is optional but include any non-obvious signal you captured.
+
+### Severity scale
+
+Maps to Linear priority:
+
+| Severity | Meaning | Linear |
+|----------|---------|--------|
+| **P0** | feature broken, blocks user | Urgent |
+| **P1** | clear bug or a11y violation | High |
+| **P2** | UX polish | Medium |
+| **P3** | perf concern | Medium |
+| **P4** | copy / wording | Low |
+| **P5** | enhancement idea | No priority |
+
+### Migrating from v1
+
+`schemaVersion: "2.0"` is the current contract. v1 consumers expecting `body`, `status`, `tag`, or stringified `consoleErrors`/`networkRequests` arrays need migration:
+
+- `tag` → `surface` (rename)
+- `consoleErrors: string[]` → `[{level, message}]`
+- `networkRequests: string[]` → `[{method, url, status, durationMs?}]`
+- `body` field — **dropped** (pure derivation; render at consumption time from `repro`/`expected`/`actual`)
+- `status` field — **dropped** (finding lifecycle is the consumer's concern, not the producer's)
+
+## Final Summary
+
+When the pass completes, the skill writes the `summary` block to the JSON file **and** prints to stdout:
+
+```
+Chrome QA pass: Agent Config tabs, all 16
+Total findings: 19
+
+Severity:
+  P0 (urgent):   2
+  P1 (high):     5
+  P2 (medium):   8
+  P3 (perf):     2
+  P4 (copy):     1
+  P5 (idea):     1
+
+Category:
+  bug:      8
+  a11y:     4
+  perf:     2
+  ux:       3
+  copy:     1
+  compat:   1
+
+Top issues (P0 + P1):
+  • [P0] Save button does nothing on Voice tab when phone is unprovisioned — http://localhost:3000/dashboard/agents/agent_123/voice
+  • [P0] Empty agent list crashes dashboard render — http://localhost:3000/dashboard
+  • [P1] Phone number input accepts non-numeric characters — http://localhost:3000/dashboard/agents/new
+  ...
+
+Findings file: .context/findings/2026-04-25-agent-config.json
+```
+
+This is a courtesy for users who don't run a triage tool — the JSON file is always the source of truth.
+
+## CLI Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--url <url>` | App URL to test (overrides prompted value) | (prompted) |
+| `--mobile-only` | Skip desktop pass and run mobile-only | `false` |
+
+## Hard Rules
+
+The skill enforces these — it will refuse to act otherwise:
+
+1. **Never click destructive actions** without explicit approval each time: delete, disconnect, drop, force, publish, purchase.
+2. **Never silently downgrade** from live QA to source-only review. If data is missing, ask.
+3. **Never invent the schema.** v2.0 fields, byte-for-byte. Downstream consumers depend on it.
+4. **Never batch-write findings at the end.** Append per-finding. Context can exhaust mid-pass.
+5. **Never claim "no issues" without running the cross-cutting probes.**
+6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute.
+7. **Never use a stale tab.** Always confirm tab context first.
+
+## Requirements
+
+- A running web app reachable via HTTP (typically `http://localhost:<port>`)
+- The `mcp__claude-in-chrome__*` tools available in your Claude Code environment (auto-loaded on first use via `ToolSearch`)
+- A writable `.context/findings/` directory in your workspace
+
+## FAQ
+
+### Can I use it on production URLs?
+
+Yes, but be explicit about it. The skill's "Hard Rules" prevent destructive actions by default — but production URLs deserve a careful read of the goal/prompt before kicking off a pass that mutates data.
+
+### What if the dev server isn't running?
+
+Pre-flight aborts with a focused error: `Pre-flight failed: <url> returned 000 (not 2xx/3xx). Start your dev server and re-run.` No browser work happens until the server responds.
+
+### Why JSON instead of a markdown report?
+
+Findings are designed to feed downstream triage tools that turn them into Linear issues. The JSON contract is stable across passes; markdown rendering can be done at consumption time. The end-of-pass stdout summary covers the "I just want to read it" case.
+
+### What if my findings file already exists for today?
+
+The skill suffixes `-<HHmm>` to avoid clobbering a prior pass. Two passes on the same day produce two files, both preserved.
+
+### Can I disable the mobile pass?
+
+Mobile is required by default — a third of bugs are mobile-only. If you genuinely don't need it, run `/candid-chrome-qa --mobile-only` to invert (mobile-only) or run twice with focused goals.

--- a/skills/candid-chrome-qa/SKILL.md
+++ b/skills/candid-chrome-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: candid-chrome-qa
-description: Drive a real Chrome session against a running web app, find bugs, and emit structured findings JSON. Use when the user asks for a QA pass, smoke test, UX audit, accessibility check, or "find bugs / polish / a11y / perf / copy issues on <route>". Walks the target like a real user across desktop and mobile via mcp__claude-in-chrome__*, runs DOM/console/network probes, and writes findings to .context/findings/<date>-<slug>.json against the v2 schema in this skill.
+description: Drive a real Chrome session against a running web app to find bugs and write structured findings JSON. Use when the user asks for a QA pass, smoke test, UX audit, accessibility check, or "find bugs / polish / a11y / perf / copy issues" on a route.
 ---
 
 # Candid Chrome QA
@@ -14,22 +14,96 @@ This is a **technique skill**. Follow the order. The schema is non-negotiable.
 When invoked, the user provides (or you confirm):
 - **goal** — surface to test, e.g. "Agent Config / AI Setup, all 16 tabs"
 - **prompt** — free-form QA plan (what to exercise, edge cases, hot spots)
-- **app URL** — usually `http://localhost:<port>`. Verify before you start.
+- **app URL** — usually `http://localhost:<port>`. Verify before you start. Skipped if the user passes `--url` or `chromeQA.defaultUrl` is set in `.candid/config.json`.
 
-If any input is missing, ask. Don't guess.
+CLI flags:
+- `--url <url>` — provide the app URL up front, skipping the prompt.
+- `--mobile-only` — explicit opt-out from the desktop pass. Runs **only** the mobile pass (390x844). Documented exception to Hard Rule 6.
+
+If any required input is missing after flags + config, ask. Don't guess.
 
 ## Pre-flight — MANDATORY before any QA work
 
 Run in order. If any step fails, stop and surface to the user — do not invent workarounds.
 
-1. **Verify the dev server.** `curl -s -o /dev/null -w "%{http_code}" <url>`. Anything other than 2xx/3xx → ask the user to start it. Don't assume the port — `lsof -ti:<port>` to confirm a process is listening.
-2. **Get tab context.** `mcp__claude-in-chrome__tabs_context_mcp` (load via ToolSearch first if not already loaded). Re-use a tab only if the user explicitly says so; otherwise create a fresh tab with `tabs_create_mcp`.
-3. **Resize to desktop default.** `resize_window` to 1440x900 unless the user specifies.
-4. **Navigate.** `navigate` to the app URL. Wait 2s.
-5. **Confirm logged-in state.** `read_page interactive` or `javascript_exec` for `({url: location.href, title: document.title})`. If on a login or onboarding route, ask the user before proceeding.
-6. **Clear console baseline.** `read_console_messages` with `pattern: "."`, `clear: true` — sets the high-water mark so per-target probes only show fresh entries.
-7. **Verify required data.** If the goal touches lists/details that need seeded data and the account is empty, **ask the user**: create test data, seed via fixture, switch accounts, or downgrade to source-review. Do not silently switch to source review.
-8. **Open the findings file.** Create `.context/findings/<YYYY-MM-DD>-<slug>.json` with the schema below, empty `findings: []`, and the `context` block populated. Append to it after each finding — never batch-write at the end. If a same-day file with the same slug already exists, suffix `-<HHmm>` to avoid clobbering a prior pass.
+### 0. Verify Claude in Chrome is available
+
+Run `ToolSearch` with `query: "mcp__claude-in-chrome"`. If it returns zero `mcp__claude-in-chrome__*` tools, stop:
+
+```
+Claude in Chrome MCP is not installed in this Claude Code environment.
+Install it before running /candid-chrome-qa:
+  https://github.com/anthropics/claude-in-chrome
+Then restart Claude Code.
+```
+
+If it does return tools, batch-load every tool you'll need so subsequent calls don't pay per-tool ToolSearch overhead:
+
+```
+ToolSearch query: "select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__tabs_create_mcp,mcp__claude-in-chrome__resize_window,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__read_console_messages,mcp__claude-in-chrome__read_network_requests,mcp__claude-in-chrome__javascript_tool"
+```
+
+### 1. Load project context
+
+- If `Technical.md` exists in the project root, read it and note any QA-relevant rules: browser support matrix, accessibility target (WCAG A/AA/AAA), API base path, design-system constraints, auth setup. Use these rules during the pass — every Technical.md violation you find should be a finding tagged with `surface: "Technical.md"` and `category` matching the rule's domain.
+- If `.candid/config.json` exists, read the optional `chromeQA` block:
+
+  ```json
+  {
+    "chromeQA": {
+      "defaultUrl": "http://localhost:3000",
+      "apiPathPattern": "/api/",
+      "desktopViewport": "1440x900",
+      "mobileViewport": "390x844"
+    }
+  }
+  ```
+
+  All fields optional. Defaults: URL prompted, `apiPathPattern: "/api/"`, viewports as shown.
+
+### 2. Verify the dev server
+
+`curl -s -o /dev/null -w "%{http_code}" <url>`. Anything other than 2xx/3xx → ask the user to start it. The HTTP code is the source of truth — don't run `lsof` or process probes.
+
+### 3. Get tab context and reuse policy
+
+`mcp__claude-in-chrome__tabs_context_mcp`. Re-use a tab only if the user explicitly says so; otherwise create a fresh tab with `tabs_create_mcp`.
+
+### 4. Resize to desktop default
+
+`resize_window` to the configured `desktopViewport` (default `1440x900`).
+
+### 5. Navigate
+
+`navigate` to the app URL. Wait 2s for the initial render to settle.
+
+### 6. Confirm logged-in state
+
+`read_page interactive` or `javascript_tool` for `({url: location.href, title: document.title})`. If on a login or onboarding route, ask the user explicitly:
+
+```
+You're on <url>. Should I:
+  (a) Wait while you log in (then continue),
+  (b) Switch to a different account / URL, or
+  (c) Stop?
+```
+
+Do not attempt to log in for them.
+
+### 7. Clear console baseline
+
+`read_console_messages` with `pattern: "."`, `clear: true` — sets the high-water mark so per-target probes only show fresh entries.
+
+### 8. Verify required data
+
+If the goal touches lists/details that need seeded data and the account is empty, **ask the user**: create test data, seed via fixture, switch accounts, or downgrade to source-review. Do not silently switch to source review.
+
+### 9. Open the findings file
+
+1. **Make the directory:** `mkdir -p .context/findings`
+2. **Generate the slug** from `goal`: lowercase the first 4 words, replace non-alphanumerics with `-`, collapse repeated `-`, trim trailing `-`, truncate to 40 chars. Example: goal `"Agent Config / AI Setup, all 16 tabs"` → `agent-config-ai-setup`.
+3. **Choose the filename:** `.context/findings/<YYYY-MM-DD>-<slug>.json`. If that file already exists, switch to `<YYYY-MM-DD>-<HHmm>-<slug>.json` (current local time, 24h). Never overwrite a prior pass.
+4. **Write the initial schema** with `findings: []`, the `context` block populated, and `summary` omitted (it's added at end-of-pass). Append findings to disk after each one — never batch-write at the end.
 
 ## Per-target loop (one route or one tab at a time)
 
@@ -42,10 +116,12 @@ For each target identified in `goal` + `prompt`, use the **flush-capture cycle**
 5. **Wait** 1–2s for in-flight requests to complete.
 6. **Capture telemetry.**
    - `read_console_messages({pattern: "error|warn|fail|hydration|nested|aria|deprecat|key"})` — apply console triage table below.
-   - `read_network_requests({urlPattern: "/api/"})` (or `supabase`, or the relevant domain) — apply network health thresholds below.
-   - **Fallback if entries are redacted** (`[BLOCKED: Cookie/query string data]`): run `javascript_exec` with `performance.getEntriesByType('resource').filter(r => r.responseStatus >= 400 || r.responseStatus === 0).map(r => ({url: r.name, status: r.responseStatus, type: r.initiatorType}))` to recover full URLs from inside the page.
+   - `read_network_requests({urlPattern: "<chromeQA.apiPathPattern>"})` (default `/api/`; or `supabase`, or whatever Technical.md / config indicates) — apply network health thresholds below.
+   - **Fallback if entries are redacted** (`[BLOCKED: Cookie/query string data]`): run `javascript_tool` with `performance.getEntriesByType('resource').filter(r => r.responseStatus >= 400 || r.responseStatus === 0).map(r => ({url: r.name, status: r.responseStatus, type: r.initiatorType}))` to recover full URLs from inside the page.
 7. **Append findings.** Each finding written to disk immediately, not buffered.
 8. **Reset state** if you mutated something that affects subsequent targets (escape dirty-form modals via Discard, etc.).
+
+If a target produces no findings, append a single `confidence: "definite"`, `severity: "P5"`, `title: "✓ no issues — probes ran clean"` finding so coverage is provable.
 
 ### Console triage table
 
@@ -82,11 +158,11 @@ When picking your "1 edge case" per target, reach for one of these — they catc
 - **Stale state** — mutate → navigate away → come back. Does it show the new data? Missing re-fetch after mutation = stale state.
 - **Silent failure** — perform action that returns 200, then refresh and verify the change actually persisted. Optimistic UI lies.
 - **Memory drift** — repeat an action 20× and snapshot `document.querySelectorAll('*').length` early vs late. Significant growth = leak.
-- **Idle WebSocket** — for real-time features, idle 60s and check console for close events without reconnect.
+- **Idle WebSocket** — for real-time features, idle 60s and check console for close events without reconnect. **Skip on multi-target passes** (>5 targets) unless the user explicitly asks — a 60s idle per target adds up fast.
 
 ## Cross-cutting probes — run once per pass
 
-Use `javascript_exec` to probe the DOM systematically. These catch things click-by-click won't.
+Use `javascript_tool` to probe the DOM systematically. These catch things click-by-click won't.
 
 ```js
 // A11y probe — count and enumerate
@@ -111,15 +187,17 @@ Array.from(document.querySelectorAll('button, a, [role="button"]'))
   .slice(0,15)
 ```
 
-## Mobile pass — required, not optional
+## Mobile pass — required by default
 
 After desktop pass:
-1. `resize_window` to 390x844.
+1. `resize_window` to the configured `mobileViewport` (default `390x844`).
 2. Re-walk the 5 most-used targets (or user-specified subset).
 3. Run the touch-target probe above.
 4. Note layout overflow, hidden CTAs, modal dismissal, keyboard behaviour for inputs, fixed-position elements that overlap content.
 
 **Resize ceiling fallback:** Chrome may enforce a minimum content width of ~1075 px on the active tab depending on UI chrome. If `resize_window` to 390 wide doesn't take effect, try the smallest you can reach (often ~500 px) — the mobile breakpoint still triggers, the desktop sidebar still hides, and the hamburger drawer still appears. Note the actual width reached in the finding's `evidence`.
+
+**`--mobile-only` flag** inverts the default: skip the desktop pass entirely and run only the mobile sequence above. This is an **explicit opt-out** of Hard Rule 6 (which forbids running mobile without desktop). Use sparingly — most QA passes need both.
 
 ## Hot-spot stress — when the user provides recent commits or known weak points
 
@@ -133,86 +211,100 @@ Every finding file looks like this. Producers write the `schemaVersion`, `contex
 {
   "schemaVersion": "2.0",
   "context": {
-    "createdAt": "<ISO8601>",
-    "scope": "<goal verbatim>",
-    "originatingPrompt": "<prompt verbatim>",
+    "createdAt": "2026-04-25T18:30:00Z",
+    "scope": "Agent Config / AI Setup, all 16 tabs",
+    "originatingPrompt": "Walk every tab; exercise save/cancel; hammer phone provisioning",
     "environment": {
       "url": "http://localhost:3000",
-      "branch": "<git branch>",
-      "commit": "<short sha>",
+      "branch": "feature/agent-config-v2",
+      "commit": "8001a89",
       "viewport": "1440x900",
-      "agentModel": "<your model id>"
+      "agentModel": "claude-opus-4-7"
     }
   },
   "findings": [
     {
-      "id": "F-<8charSlug>",
-      "severity": "P0|P1|P2|P3|P4|P5",
-      "category": "bug|a11y|perf|ux|copy|security|compat",
-      "surface": "<route or component, e.g. 'dashboard/calls' or 'AgentConfigForm'>",
-      "viewport": "desktop|mobile|both",
-      "url": "<full URL where reproduced, including query/hash>",
-      "title": "<one line, <80 chars>",
-      "repro": "1. step\n2. step\n3. step",
-      "expected": "<one line>",
-      "actual": "<one line>",
+      "id": "F-a3f29b71",
+      "severity": "P0",
+      "category": "bug",
+      "surface": "dashboard/agents/[id]/voice",
+      "viewport": "both",
+      "url": "http://localhost:3000/dashboard/agents/agent_123/voice",
+      "title": "Save button does nothing on Voice tab when phone is unprovisioned",
+      "repro": "1. Open agent\n2. Voice tab\n3. Click Save",
+      "expected": "Either save or show validation error",
+      "actual": "Click registers, no network call, no error, no state change",
       "evidence": {
         "consoleErrors": [
-          {"level": "error|warn|info", "message": "..."}
+          {"level": "warn", "message": "[react-hook-form] missing required: phoneNumber"}
         ],
         "networkRequests": [
-          {"method": "GET", "url": "/api/x", "status": 400, "durationMs": 1234}
+          {"method": "POST", "url": "/api/agents/agent_123", "status": 0, "durationMs": 0}
         ],
-        "filesLikelyTouched": ["app/src/.../Foo.tsx:120"]
+        "filesLikelyTouched": ["app/src/components/agent/VoiceTab.tsx:142"]
       },
-      "suggestedFix": "<one line>",
-      "groupHint": "<topic-slug, e.g. 'form-state' or 'phone-provisioning'>",
-      "confidence": "definite|likely|suspected",
-      "capturedAt": "<ISO8601>"
+      "suggestedFix": "Surface the form validation error in the UI; current handler swallows it",
+      "groupHint": "form-state",
+      "confidence": "definite",
+      "capturedAt": "2026-04-25T18:34:12Z"
     }
   ],
   "summary": {
-    "total": 0,
-    "bySeverity": {"p0": 0, "p1": 0, "p2": 0, "p3": 0, "p4": 0, "p5": 0},
-    "byCategory": {"bug": 0, "a11y": 0, "perf": 0, "ux": 0, "copy": 0, "security": 0, "compat": 0}
+    "total": 19,
+    "bySeverity": {"p0": 2, "p1": 5, "p2": 8, "p3": 2, "p4": 1, "p5": 1},
+    "byCategory": {"bug": 8, "a11y": 4, "perf": 2, "ux": 3, "copy": 1, "security": 0, "compat": 1}
   }
 }
 ```
 
-**Required per-finding fields:** `id`, `severity`, `category`, `surface`, `viewport`, `url`, `title`, `repro`, `expected`, `actual`, `suggestedFix`, `groupHint`, `confidence`, `capturedAt`. `evidence` is optional but include any non-obvious signal you captured.
+### Required per-finding fields
 
-**Severity scale (maps to Linear priority):**
-- **P0** — feature broken, blocks user (Linear: Urgent)
-- **P1** — clear bug or a11y violation (Linear: High)
-- **P2** — UX polish (Linear: Medium)
-- **P3** — perf concern (Linear: Medium)
-- **P4** — copy / wording (Linear: Low)
-- **P5** — enhancement idea (Linear: No priority)
+`id`, `severity`, `category`, `surface`, `viewport`, `url`, `title`, `repro`, `expected`, `actual`, `suggestedFix`, `groupHint`, `confidence`, `capturedAt`. `evidence` is optional but include any non-obvious signal you captured.
 
-**Category** (separate from severity — describes *type* of issue, for routing):
-- **bug** — functional defect, broken behaviour
-- **a11y** — accessibility violation (missing label, contrast, focus order, ARIA)
-- **perf** — performance issue (slow request, large payload, jank)
-- **ux** — interaction polish (confusing flow, unexpected modal, form quirk)
-- **copy** — wording, grammar, microcopy
-- **security** — exposed data, missing auth check, XSS shape
-- **compat** — browser/viewport/OS-specific issue
+### Enum values (use exactly these strings)
 
-**Viewport** records where the bug was observed: `desktop` (1440x900 default), `mobile` (390x844), or `both` (reproduces in either).
+- **`severity`**: `"P0"`, `"P1"`, `"P2"`, `"P3"`, `"P4"`, `"P5"`
+- **`category`**: `"bug"`, `"a11y"`, `"perf"`, `"ux"`, `"copy"`, `"security"`, `"compat"`
+- **`viewport`**: `"desktop"`, `"mobile"`, `"both"`
+- **`confidence`**: `"definite"`, `"likely"`, `"suspected"` (default `"definite"` if uncertain)
+- **`evidence.consoleErrors[].level`**: `"error"`, `"warn"`, `"info"`
 
-**Confidence** lets triage prioritise: `definite` (saw it; reproducible), `likely` (saw it; haven't re-verified), `suspected` (signal in console/network but couldn't isolate the trigger). Default `definite`.
+### ID generation (deterministic — enables dedup across passes)
 
-**`groupHint`** is a short slug shared across related findings — used by downstream tools to bundle into one workspace. Examples: `form-state`, `phone-provisioning`, `analytics-defaults`, `mobile-layout`. If a finding is unique, use a unique slug.
+`id` is `F-` + the first 8 hex chars of the SHA-1 of `<url>|<title>`. Example: `F-a3f29b71`. Use `javascript_tool` to compute it inside the page if needed:
 
-**Schema migration note:** This is v2.0. v1 consumers expecting `body`, `status`, `tag`, or stringified `consoleErrors`/`networkRequests` arrays will need migration. The `body` field (rendered markdown view) was dropped — consumers should render from the structured fields at read time. The `status` field was dropped — finding lifecycle is the consumer's concern, not the producer's.
+```js
+crypto.subtle.digest('SHA-1', new TextEncoder().encode(`${url}|${title}`))
+  .then(buf => 'F-' + Array.from(new Uint8Array(buf)).slice(0,4).map(b => b.toString(16).padStart(2,'0')).join(''))
+```
+
+Same finding (same URL + same title) in a re-run gets the same ID — downstream tools can dedup.
+
+### Severity scale
+
+Maps to Linear priority:
+
+| Severity | Meaning | Linear |
+|----------|---------|--------|
+| **P0** | feature broken, blocks user | Urgent |
+| **P1** | clear bug or a11y violation | High |
+| **P2** | UX polish | Medium |
+| **P3** | perf concern | Medium |
+| **P4** | copy / wording | Low |
+| **P5** | enhancement idea | No priority |
+
+`groupHint` is a short slug shared across related findings — used by downstream tools to bundle into one workspace. Examples: `form-state`, `phone-provisioning`, `analytics-defaults`, `mobile-layout`. If a finding is unique, use a unique slug.
+
+**Schema migration note:** This is v2.0. Downstream consumers must target `schemaVersion: "2.0"`. v1 fields (`body`, `status`, `tag`, stringified `consoleErrors`/`networkRequests`) are dropped — consumers expecting them will break. The `body` field (rendered markdown view) is gone — render from the structured fields at read time. The `status` field is gone — finding lifecycle is the consumer's concern.
 
 ## Final summary — required at end of pass
 
-After the last finding is appended, **before** reporting back to the user:
+After the last finding is appended, **before** reporting back to the user, do all of the following atomically (do not declare done until every step lands):
 
 1. **Compute counts** from the file's `findings` array.
-2. **Write the `summary` block** to the JSON file (preserve top-level key order: `schemaVersion`, `context`, `findings`, `summary`).
-3. **Print to stdout** in this format:
+2. **Write the `summary` block** to the JSON file. Preserve top-level key order: `schemaVersion`, `context`, `findings`, `summary`.
+3. **Mentally `JSON.parse`** the file: scan for trailing commas, unquoted keys, unbalanced braces, missing required per-finding fields.
+4. **Print to stdout** in this **exact** format. Always print all 6 severity rows and all 7 category rows (`0` is meaningful — it documents what was looked for).
 
 ```
 Chrome QA pass: <scope>
@@ -243,15 +335,9 @@ Top issues (P0 + P1):
 Findings file: .context/findings/<filename>.json
 ```
 
-If no findings (clean pass), print:
+If there are zero P0 and zero P1 findings, replace the "Top issues" block with `Top issues: none — no P0/P1`. If the entire pass has zero findings (every target appended a `✓ no issues` entry), still print the format above with all rows showing `0`, then add a final line: `Result: clean pass.`
 
-```
-Chrome QA pass: <scope>
-✓ No issues found across <N> targets. Probes ran clean.
-Findings file: .context/findings/<filename>.json
-```
-
-Suppress empty severity/category rows. The JSON file is always the source of truth — stdout is a courtesy for users who don't run a triage tool.
+The JSON file is always the source of truth — stdout is a courtesy for users who don't run a triage tool.
 
 ## Hard rules — do not violate
 
@@ -259,18 +345,19 @@ Suppress empty severity/category rows. The JSON file is always the source of tru
 2. **Never silently downgrade** from live QA to source-only review. If data is missing, ask.
 3. **Never invent the schema.** Use the v2.0 schema above byte-for-byte. Downstream consumers depend on it.
 4. **Never batch-write findings at the end.** Append per-finding. Context can exhaust mid-pass.
-5. **Never claim "no issues" without running the cross-cutting probes.** A finding of "ran probes, all green" is fine; skipping the probes is not.
-6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute.
+5. **Never claim "no issues" without running the cross-cutting probes.** A `✓ no issues — probes ran clean` finding is fine; skipping the probes is not.
+6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute. **Exception:** the `--mobile-only` flag explicitly opts out of this rule — when the flag is passed, skip the desktop pass entirely.
 7. **Never use a stale tab.** Always `tabs_context_mcp` first. If reusing a tab, confirm with the user.
+8. **Never proceed without verifying Claude in Chrome is loaded** (Pre-flight step 0). Without it, every subsequent tool call fails opaquely.
 
 ## Stop conditions
 
 Finished when **all** of:
-- Every target in `goal` has at least one finding line OR an explicit "✓ no issues — probes ran clean" entry.
+- Every target in `goal` has at least one finding entry (real finding OR `✓ no issues — probes ran clean`).
 - Hot-spot tests requested by the user each have explicit ✓ or finding.
-- Mobile pass covers the agreed subset.
+- Mobile pass covers the agreed subset (or `--mobile-only` was passed and you ran only mobile).
 - Cross-cutting probes ran on at least one representative page.
-- File on disk validates against the v2 schema (parses cleanly, no trailing commas, all required per-finding fields present).
+- File on disk validates: mentally simulate `JSON.parse`. Reject if you spot trailing commas, unquoted keys, unbalanced braces, or any per-finding missing a required field.
 - `summary` block populated at end of pass.
 - Stdout summary printed.
 
@@ -280,23 +367,27 @@ If you hit a hard blocker (server down mid-pass, dirty-state trap, unrecoverable
 
 | Excuse | Reality |
 |--------|---------|
-| "I'll write the schema my way, it's clearer" | Triage tool only reads the canonical fields. Your fields get dropped. |
+| "I'll write the schema my way, it's clearer" | Downstream consumers target `schemaVersion: "2.0"` — your custom fields get dropped, and missing v2-required fields break triage. |
 | "Source review is fine since data is missing" | Silent downgrade. Ask first. |
 | "I'll batch findings at the end for cleanliness" | Context exhausts. Findings lost. Append per-finding. |
-| "Mobile is similar to desktop, skip it" | Found mobile-only bugs ~30% of pass. Don't skip. |
+| "Mobile is similar to desktop, skip it" | Found mobile-only bugs ~30% of pass. Don't skip unless `--mobile-only` was passed. |
 | "Console looks clean, skip the probe" | Probes catch DOM-level a11y issues clicks miss. Run them. |
 | "Click-tested ~all interactions, no need for edge cases" | Edge cases (empty/invalid/rapid-double-click) are where the bugs live. Run at least one per target. |
 | "User said skip the pre-flight" | They didn't. Ask before skipping. |
 | "I'll add `body` back, it's cleaner for humans" | v2 dropped `body` deliberately — pure derivation. Render at consumption time. |
-| "I'll skip the stdout summary, the JSON has the data" | The summary is the pass's headline. Users who don't run a triage tool need it. |
+| "I'll skip the stdout summary, the JSON has the data" | The summary is the pass's headline. Users without a triage tool need it. |
+| "I'll use `'P0\|P1\|P2'` as the severity since the schema example showed it" | The schema example shows real values like `"P0"`. Pipe-delimited strings are TypeScript-style enum docs, not JSON values. Use one exact string. |
+| "I don't need `mkdir -p` — the directory probably exists" | It probably doesn't. Make it explicitly. |
 
 ## Red flags — STOP and re-read this skill
 
 - About to write findings without `repro/expected/actual` structure
-- About to skip mobile pass to "save time"
+- About to skip the desktop pass without `--mobile-only` having been passed
 - About to invent a new top-level field in the JSON
 - About to click "Delete" / "Disconnect" / "Force" without asking
 - About to silently use a stale tab from a prior session
 - About to skip the final summary (JSON `summary` block + stdout block)
+- About to call `mcp__claude-in-chrome__*` without having run Pre-flight step 0
+- About to write `"P0|P1|P2|P3|P4|P5"` as the value of a `severity` field
 
 All of these mean: stop, re-read the relevant section, follow the protocol.

--- a/skills/candid-chrome-qa/SKILL.md
+++ b/skills/candid-chrome-qa/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: candid-chrome-qa
+description: Drive a real Chrome session against a running web app, find bugs, and emit structured findings JSON. Use when the user asks for a QA pass, smoke test, UX audit, accessibility check, or "find bugs / polish / a11y / perf / copy issues on <route>". Walks the target like a real user across desktop and mobile via mcp__claude-in-chrome__*, runs DOM/console/network probes, and writes findings to .context/findings/<date>-<slug>.json against the v2 schema in this skill.
+---
+
+# Candid Chrome QA
+
+Drive a real Chrome session against a running web app, find issues, and write structured findings to disk for downstream triage. Part of the Candid plugin's QA workflow — sits alongside `/candid-review` (code) and `/candid-ship` (release).
+
+This is a **technique skill**. Follow the order. The schema is non-negotiable.
+
+## Inputs
+
+When invoked, the user provides (or you confirm):
+- **goal** — surface to test, e.g. "Agent Config / AI Setup, all 16 tabs"
+- **prompt** — free-form QA plan (what to exercise, edge cases, hot spots)
+- **app URL** — usually `http://localhost:<port>`. Verify before you start.
+
+If any input is missing, ask. Don't guess.
+
+## Pre-flight — MANDATORY before any QA work
+
+Run in order. If any step fails, stop and surface to the user — do not invent workarounds.
+
+1. **Verify the dev server.** `curl -s -o /dev/null -w "%{http_code}" <url>`. Anything other than 2xx/3xx → ask the user to start it. Don't assume the port — `lsof -ti:<port>` to confirm a process is listening.
+2. **Get tab context.** `mcp__claude-in-chrome__tabs_context_mcp` (load via ToolSearch first if not already loaded). Re-use a tab only if the user explicitly says so; otherwise create a fresh tab with `tabs_create_mcp`.
+3. **Resize to desktop default.** `resize_window` to 1440x900 unless the user specifies.
+4. **Navigate.** `navigate` to the app URL. Wait 2s.
+5. **Confirm logged-in state.** `read_page interactive` or `javascript_exec` for `({url: location.href, title: document.title})`. If on a login or onboarding route, ask the user before proceeding.
+6. **Clear console baseline.** `read_console_messages` with `pattern: "."`, `clear: true` — sets the high-water mark so per-target probes only show fresh entries.
+7. **Verify required data.** If the goal touches lists/details that need seeded data and the account is empty, **ask the user**: create test data, seed via fixture, switch accounts, or downgrade to source-review. Do not silently switch to source review.
+8. **Open the findings file.** Create `.context/findings/<YYYY-MM-DD>-<slug>.json` with the schema below, empty `findings: []`, and the `context` block populated. Append to it after each finding — never batch-write at the end. If a same-day file with the same slug already exists, suffix `-<HHmm>` to avoid clobbering a prior pass.
+
+## Per-target loop (one route or one tab at a time)
+
+For each target identified in `goal` + `prompt`, use the **flush-capture cycle** so each step's telemetry is clean:
+
+1. **Navigate / click into target.** Use sidebar buttons rather than direct URL when the app has client-side routing.
+2. **Flush telemetry.** `read_network_requests({clear: true})` and `read_console_messages({pattern: ".", clear: true})` — discard prior chatter.
+3. **`read_page interactive`** to enumerate elements.
+4. **Action.** Exercise 2–3 main interactions (toggle, type, save, cancel) and **1 edge case** (empty input, invalid format, rapid double-click, navigation while dirty).
+5. **Wait** 1–2s for in-flight requests to complete.
+6. **Capture telemetry.**
+   - `read_console_messages({pattern: "error|warn|fail|hydration|nested|aria|deprecat|key"})` — apply console triage table below.
+   - `read_network_requests({urlPattern: "/api/"})` (or `supabase`, or the relevant domain) — apply network health thresholds below.
+   - **Fallback if entries are redacted** (`[BLOCKED: Cookie/query string data]`): run `javascript_exec` with `performance.getEntriesByType('resource').filter(r => r.responseStatus >= 400 || r.responseStatus === 0).map(r => ({url: r.name, status: r.responseStatus, type: r.initiatorType}))` to recover full URLs from inside the page.
+7. **Append findings.** Each finding written to disk immediately, not buffered.
+8. **Reset state** if you mutated something that affects subsequent targets (escape dirty-form modals via Discard, etc.).
+
+### Console triage table
+
+| Console output | Severity |
+|---|---|
+| Uncaught TypeError / ReferenceError | **P0** |
+| Unhandled Promise rejection | **P0** |
+| React: "Cannot update a component while rendering a different component" | **P1** |
+| React: "Each child in a list should have a unique 'key' prop" (if data-dependent) | **P1** |
+| Hydration mismatch (`<button>` inside `<button>`, etc.) | **P2** |
+| CORS policy errors | **P1** |
+| Any `Error:` in red not in the ignorable list | **P1** |
+| `componentWillMount`/`findDOMNode` deprecation | **P2** |
+| "Can't perform a React state update on an unmounted component" | **P2** |
+| Large-payload performance warnings | **P3** |
+| **Ignorable:** "Download the React DevTools", `/favicon.ico` 404, source map warnings, Clerk dev-mode warning, third-party analytics errors | skip |
+
+### Network health thresholds
+
+| Metric | Good | Concerning | Bad |
+|---|---|---|---|
+| Error rate (4xx/5xx) | < 1% | 1–5% | > 5% |
+| Avg response time | < 200 ms | 200 ms – 1 s | > 1 s |
+| Payload per request | < 100 KB | 100 KB – 1 MB | > 1 MB |
+| Duplicate requests within 200 ms | 0 | 1–2 | 3+ identical |
+
+Anything in **Bad** → P0/P1. **Concerning** → P2/P3.
+
+### Edge-case bug patterns to probe
+
+When picking your "1 edge case" per target, reach for one of these — they catch the majority of production-only failures:
+
+- **Race condition** — fire 3+ identical requests within 500 ms (rapid double-click save). Look for mixed 200/500 on the same endpoint.
+- **Stale state** — mutate → navigate away → come back. Does it show the new data? Missing re-fetch after mutation = stale state.
+- **Silent failure** — perform action that returns 200, then refresh and verify the change actually persisted. Optimistic UI lies.
+- **Memory drift** — repeat an action 20× and snapshot `document.querySelectorAll('*').length` early vs late. Significant growth = leak.
+- **Idle WebSocket** — for real-time features, idle 60s and check console for close events without reconnect.
+
+## Cross-cutting probes — run once per pass
+
+Use `javascript_exec` to probe the DOM systematically. These catch things click-by-click won't.
+
+```js
+// A11y probe — count and enumerate
+({
+  iconButtonsNoLabel: Array.from(document.querySelectorAll('button')).filter(b =>
+    !b.innerText.trim() && !b.getAttribute('aria-label') && !b.getAttribute('aria-labelledby')).length,
+  imagesNoAlt: Array.from(document.querySelectorAll('img')).filter(i => !i.alt && i.getAttribute('aria-hidden') !== 'true').length,
+  inputsNoLabel: Array.from(document.querySelectorAll('input, textarea, select')).filter(i => {
+    if (i.type === 'hidden') return false;
+    if (i.getAttribute('aria-label') || i.getAttribute('aria-labelledby')) return false;
+    if (i.id && document.querySelector('label[for="'+i.id+'"]')) return false;
+    return !i.closest('label');
+  }).length
+})
+```
+
+```js
+// Touch-target probe (mobile only)
+Array.from(document.querySelectorAll('button, a, [role="button"]'))
+  .map(el => ({label: (el.innerText||el.getAttribute('aria-label')||'').slice(0,40), w: el.offsetWidth, h: el.offsetHeight}))
+  .filter(x => x.w > 0 && (x.w < 44 || x.h < 44))
+  .slice(0,15)
+```
+
+## Mobile pass — required, not optional
+
+After desktop pass:
+1. `resize_window` to 390x844.
+2. Re-walk the 5 most-used targets (or user-specified subset).
+3. Run the touch-target probe above.
+4. Note layout overflow, hidden CTAs, modal dismissal, keyboard behaviour for inputs, fixed-position elements that overlap content.
+
+**Resize ceiling fallback:** Chrome may enforce a minimum content width of ~1075 px on the active tab depending on UI chrome. If `resize_window` to 390 wide doesn't take effect, try the smallest you can reach (often ~500 px) — the mobile breakpoint still triggers, the desktop sidebar still hides, and the hamburger drawer still appears. Note the actual width reached in the finding's `evidence`.
+
+## Hot-spot stress — when the user provides recent commits or known weak points
+
+For each: drive the recently-changed surface harder. Resize to 700px tall to stress sidebar/scroll fixes; switch orgs mid-edit to stress org-scope; trigger validation; double-click save.
+
+## Output schema (v2.0) — exact, do not modify
+
+Every finding file looks like this. Producers write the `schemaVersion`, `context`, `findings`, and (at end of pass) `summary` blocks. Consumers should target `schemaVersion: "2.0"`.
+
+```json
+{
+  "schemaVersion": "2.0",
+  "context": {
+    "createdAt": "<ISO8601>",
+    "scope": "<goal verbatim>",
+    "originatingPrompt": "<prompt verbatim>",
+    "environment": {
+      "url": "http://localhost:3000",
+      "branch": "<git branch>",
+      "commit": "<short sha>",
+      "viewport": "1440x900",
+      "agentModel": "<your model id>"
+    }
+  },
+  "findings": [
+    {
+      "id": "F-<8charSlug>",
+      "severity": "P0|P1|P2|P3|P4|P5",
+      "category": "bug|a11y|perf|ux|copy|security|compat",
+      "surface": "<route or component, e.g. 'dashboard/calls' or 'AgentConfigForm'>",
+      "viewport": "desktop|mobile|both",
+      "url": "<full URL where reproduced, including query/hash>",
+      "title": "<one line, <80 chars>",
+      "repro": "1. step\n2. step\n3. step",
+      "expected": "<one line>",
+      "actual": "<one line>",
+      "evidence": {
+        "consoleErrors": [
+          {"level": "error|warn|info", "message": "..."}
+        ],
+        "networkRequests": [
+          {"method": "GET", "url": "/api/x", "status": 400, "durationMs": 1234}
+        ],
+        "filesLikelyTouched": ["app/src/.../Foo.tsx:120"]
+      },
+      "suggestedFix": "<one line>",
+      "groupHint": "<topic-slug, e.g. 'form-state' or 'phone-provisioning'>",
+      "confidence": "definite|likely|suspected",
+      "capturedAt": "<ISO8601>"
+    }
+  ],
+  "summary": {
+    "total": 0,
+    "bySeverity": {"p0": 0, "p1": 0, "p2": 0, "p3": 0, "p4": 0, "p5": 0},
+    "byCategory": {"bug": 0, "a11y": 0, "perf": 0, "ux": 0, "copy": 0, "security": 0, "compat": 0}
+  }
+}
+```
+
+**Required per-finding fields:** `id`, `severity`, `category`, `surface`, `viewport`, `url`, `title`, `repro`, `expected`, `actual`, `suggestedFix`, `groupHint`, `confidence`, `capturedAt`. `evidence` is optional but include any non-obvious signal you captured.
+
+**Severity scale (maps to Linear priority):**
+- **P0** — feature broken, blocks user (Linear: Urgent)
+- **P1** — clear bug or a11y violation (Linear: High)
+- **P2** — UX polish (Linear: Medium)
+- **P3** — perf concern (Linear: Medium)
+- **P4** — copy / wording (Linear: Low)
+- **P5** — enhancement idea (Linear: No priority)
+
+**Category** (separate from severity — describes *type* of issue, for routing):
+- **bug** — functional defect, broken behaviour
+- **a11y** — accessibility violation (missing label, contrast, focus order, ARIA)
+- **perf** — performance issue (slow request, large payload, jank)
+- **ux** — interaction polish (confusing flow, unexpected modal, form quirk)
+- **copy** — wording, grammar, microcopy
+- **security** — exposed data, missing auth check, XSS shape
+- **compat** — browser/viewport/OS-specific issue
+
+**Viewport** records where the bug was observed: `desktop` (1440x900 default), `mobile` (390x844), or `both` (reproduces in either).
+
+**Confidence** lets triage prioritise: `definite` (saw it; reproducible), `likely` (saw it; haven't re-verified), `suspected` (signal in console/network but couldn't isolate the trigger). Default `definite`.
+
+**`groupHint`** is a short slug shared across related findings — used by downstream tools to bundle into one workspace. Examples: `form-state`, `phone-provisioning`, `analytics-defaults`, `mobile-layout`. If a finding is unique, use a unique slug.
+
+**Schema migration note:** This is v2.0. v1 consumers expecting `body`, `status`, `tag`, or stringified `consoleErrors`/`networkRequests` arrays will need migration. The `body` field (rendered markdown view) was dropped — consumers should render from the structured fields at read time. The `status` field was dropped — finding lifecycle is the consumer's concern, not the producer's.
+
+## Final summary — required at end of pass
+
+After the last finding is appended, **before** reporting back to the user:
+
+1. **Compute counts** from the file's `findings` array.
+2. **Write the `summary` block** to the JSON file (preserve top-level key order: `schemaVersion`, `context`, `findings`, `summary`).
+3. **Print to stdout** in this format:
+
+```
+Chrome QA pass: <scope>
+Total findings: <N>
+
+Severity:
+  P0 (urgent):   <n>
+  P1 (high):     <n>
+  P2 (medium):   <n>
+  P3 (perf):     <n>
+  P4 (copy):     <n>
+  P5 (idea):     <n>
+
+Category:
+  bug:      <n>
+  a11y:     <n>
+  perf:     <n>
+  ux:       <n>
+  copy:     <n>
+  security: <n>
+  compat:   <n>
+
+Top issues (P0 + P1):
+  • [P0] <title> — <url>
+  • [P1] <title> — <url>
+  ...
+
+Findings file: .context/findings/<filename>.json
+```
+
+If no findings (clean pass), print:
+
+```
+Chrome QA pass: <scope>
+✓ No issues found across <N> targets. Probes ran clean.
+Findings file: .context/findings/<filename>.json
+```
+
+Suppress empty severity/category rows. The JSON file is always the source of truth — stdout is a courtesy for users who don't run a triage tool.
+
+## Hard rules — do not violate
+
+1. **Never click destructive actions** without explicit user approval each time: delete agent/account, disconnect Twilio/integrations, drop data, irreversible API operations, "force send", "publish", "purchase".
+2. **Never silently downgrade** from live QA to source-only review. If data is missing, ask.
+3. **Never invent the schema.** Use the v2.0 schema above byte-for-byte. Downstream consumers depend on it.
+4. **Never batch-write findings at the end.** Append per-finding. Context can exhaust mid-pass.
+5. **Never claim "no issues" without running the cross-cutting probes.** A finding of "ran probes, all green" is fine; skipping the probes is not.
+6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute.
+7. **Never use a stale tab.** Always `tabs_context_mcp` first. If reusing a tab, confirm with the user.
+
+## Stop conditions
+
+Finished when **all** of:
+- Every target in `goal` has at least one finding line OR an explicit "✓ no issues — probes ran clean" entry.
+- Hot-spot tests requested by the user each have explicit ✓ or finding.
+- Mobile pass covers the agreed subset.
+- Cross-cutting probes ran on at least one representative page.
+- File on disk validates against the v2 schema (parses cleanly, no trailing commas, all required per-finding fields present).
+- `summary` block populated at end of pass.
+- Stdout summary printed.
+
+If you hit a hard blocker (server down mid-pass, dirty-state trap, unrecoverable error), stop and surface — do not work around it silently.
+
+## Common rationalizations — STOP if you catch yourself
+
+| Excuse | Reality |
+|--------|---------|
+| "I'll write the schema my way, it's clearer" | Triage tool only reads the canonical fields. Your fields get dropped. |
+| "Source review is fine since data is missing" | Silent downgrade. Ask first. |
+| "I'll batch findings at the end for cleanliness" | Context exhausts. Findings lost. Append per-finding. |
+| "Mobile is similar to desktop, skip it" | Found mobile-only bugs ~30% of pass. Don't skip. |
+| "Console looks clean, skip the probe" | Probes catch DOM-level a11y issues clicks miss. Run them. |
+| "Click-tested ~all interactions, no need for edge cases" | Edge cases (empty/invalid/rapid-double-click) are where the bugs live. Run at least one per target. |
+| "User said skip the pre-flight" | They didn't. Ask before skipping. |
+| "I'll add `body` back, it's cleaner for humans" | v2 dropped `body` deliberately — pure derivation. Render at consumption time. |
+| "I'll skip the stdout summary, the JSON has the data" | The summary is the pass's headline. Users who don't run a triage tool need it. |
+
+## Red flags — STOP and re-read this skill
+
+- About to write findings without `repro/expected/actual` structure
+- About to skip mobile pass to "save time"
+- About to invent a new top-level field in the JSON
+- About to click "Delete" / "Disconnect" / "Force" without asking
+- About to silently use a stale tab from a prior session
+- About to skip the final summary (JSON `summary` block + stdout block)
+
+All of these mean: stop, re-read the relevant section, follow the protocol.


### PR DESCRIPTION
## Summary

Adds **`candid-chrome-qa`** — a new skill that drives a real Chrome session against a running web app via `mcp__claude-in-chrome__*`, walks the target like a real user across desktop and mobile, runs DOM/console/network probes, and emits structured findings JSON to `.context/findings/<date>-<slug>.json` for downstream triage.

This is a **port** of a battle-tested personal skill (`~/.claude/skills/chrome-qa-pass/SKILL.md`), originally developed with `superpowers:writing-skills` + `superpowers:testing-skills-with-subagents` discipline (RED → GREEN → VERIFY → REFACTOR cycle on a real customer dashboard, 19 findings produced in the verify pass with 0 schema gaps). Brought into Candid with a Candid-aligned name, voice, command bridge, docs page, and a redesigned **schema v2.0**.

## Workflow

- **Pre-flight**: server health check (curl), fresh Chrome tab via `tabs_context_mcp`, desktop default viewport (1440x900), navigate, confirm logged-in state, clear console baseline, verify required data is present. Aborts on any failure with a focused error — never silently downgrades to source-only review.
- **Per-target flush-capture cycle**: flush console + network telemetry → exercise 2–3 main interactions + 1 edge case → wait → capture telemetry against a console-triage table (P0–P3 mapping for TypeError, hydration mismatch, CORS, deprecated lifecycle, unmounted setState, etc.) and a network-threshold table (4xx rate, response time, payload size, duplicate requests). Findings appended **per-finding**, never batched.
- **Mobile pass required by default**: 390x844 (with ~500px fallback for Chrome's UI-chrome min content width), top 5 targets re-walked, 44×44px touch-target probe.
- **Cross-cutting probes**: a11y (icon buttons without labels, alt text, input labels) + touch-target probe via single `javascript_exec` calls — catches DOM-level issues that click-by-click testing misses.
- **End-of-pass summary**: writes `summary` block to JSON **and** prints to stdout (severity counts, category breakdown, P0/P1 titles + URLs).

## Schema v2.0 — best-in-class redesign

The user owns the downstream triage tool and approved breaking interop in exchange for a better schema. Changes vs source v1:

| Change | v1 | v2 |
|--------|----|----|
| File top-level | (untyped) | + `schemaVersion: "2.0"`, + `summary` block populated at end-of-pass |
| `category` | (absent — encoded in tag) | **new field** — bug/a11y/perf/ux/copy/security/compat (separate routing dimension from severity) |
| `viewport` | (encoded in tag string) | **new field** — desktop/mobile/both (first-class mobile signal) |
| `url` | (absent — guess from tag) | **new field** — full repro URL with query/hash |
| `capturedAt` | (file-level only) | **new field** — per-finding ISO8601 |
| `confidence` | (absent) | **new field** — definite/likely/suspected |
| `tag` | string | **renamed → `surface`** (clearer) |
| `evidence.consoleErrors` | `string[]` | `[{level, message}]` (searchable) |
| `evidence.networkRequests` | `string[]` | `[{method, url, status, durationMs?}]` (sortable) |
| `body` | rendered markdown | **dropped** (pure derivation; render at consumption time) |
| `status` | `"new"` | **dropped** (lifecycle is the consumer's concern) |

v1 triage tool consumers will need migration — see `schemaVersion` field. The skill body includes a migration note and the docs page has a v1→v2 migration table.

## Files

**Added:**
- `skills/candid-chrome-qa/SKILL.md` — the skill (264 lines: schema, probes, triage tables, hard rules, common rationalizations, red flags)
- `commands/candid-chrome-qa.md` — slash-command bridge with `--url` and `--mobile-only` flags
- `docs/app/docs/core-features/candid-chrome-qa/page.mdx` — docs site page (Quick Start → How It Works → Pre-Flight → Per-Target Loop → Cross-Cutting Probes → Mobile Pass → Schema → Final Summary → Hard Rules → FAQ)

**Modified:**
- `docs/app/docs/core-features/_meta.js` — sidebar entry after `candid-fast-ship`
- `README.md` — Key Features bullet + Quick Start usage block
- `CHANGELOG.md` — promoted `[Unreleased]` to `## [1.16.0] - 2026-04-25`
- `.claude-plugin/plugin.json` — bump 1.15.0 → 1.16.0
- `.claude-plugin/marketplace.json` — bump 1.10.0 → 1.16.0 (also catches the file up; recent releases skipped it)

## Test plan

- [ ] Restart Claude Code locally and confirm `candid-chrome-qa` appears in the available-skills list with the new description
- [ ] `/candid-chrome-qa` autocompletes; `--url` and `--mobile-only` are listed
- [ ] Run a smoke pass against a tiny scope on a running app (e.g. `http://localhost:3000`, scope: "homepage hero only"):
  - [ ] Pre-flight runs (curl check, tab context, resize, navigate, console clear)
  - [ ] At least one finding (or explicit "no issues — probes ran clean") appended to `.context/findings/<today>-<slug>.json`
  - [ ] JSON validates: parses cleanly; has `schemaVersion: "2.0"`, `context`, `findings`, `summary`; every finding has all v2 required fields
  - [ ] Stdout summary printed at end of pass (severity counts + top P0/P1)
- [ ] `cd docs && npm run build` succeeds with the new page indexed
- [ ] Update downstream triage tool at localhost:3001 to read v2 schema (separate repo; tracked outside this PR)

## Notes

- **Test fixtures deferred** — original RED/VERIFY artifacts contain customer-specific data (HeyThere agent IDs, Twilio numbers); anonymisation is its own task and can be contributed in a follow-up.
- **No WORKFLOW.md split** — `candid-chrome-qa` is single-skill with no companion to share workflow with, so it stays monolithic (unlike `candid-ship` / `candid-fast-ship` which extracted shared steps in v1.15.0).