### PR TITLE
Add candid-chrome-qa-fix skill (v1.17.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/commands/candid-chrome-qa-fix.md
+++ b/commands/candid-chrome-qa-fix.md
@@ -1,0 +1,72 @@
+---
+command: candid-chrome-qa-fix
+description: Read the latest candid-chrome-qa findings JSON, pick which findings to fix, and dispatch fixes — batched PR, one PR per finding via Conductor deep links, local-only, or issues-only. Optionally files Linear issues per finding.
+skill: candid-chrome-qa-fix
+args:
+  - name: file
+    description: Specific findings file path (skips latest-resolution; e.g. .context/findings/2026-04-25-agent-config.json)
+    required: false
+  - name: severity
+    description: Comma-separated severities to consider (P0,P1,P2,P3,P4)
+    required: false
+  - name: category
+    description: Comma-separated categories to consider (bug,a11y,perf,ux,copy,security,compat)
+    required: false
+  - name: strategy
+    description: One of "batched", "per-finding", "local", "issues-only" — skips the strategy prompt
+    required: false
+  - name: max-parallel
+    description: Per-finding deep-link launch batch size (default 4)
+    required: false
+  - name: print-links
+    description: In per-finding mode, print conductor:// deep links instead of opening them
+    required: false
+  - name: fast
+    description: In batched mode, hand off to /candid-fast-ship instead of /candid-ship
+    required: false
+  - name: create-issues
+    description: Force-enable Linear issue creation (overrides config)
+    required: false
+  - name: no-create-issues
+    description: Force-disable Linear issue creation (overrides config)
+    required: false
+  - name: tracker-team
+    description: Override issueTracker.teamKey for this run (e.g. ENG)
+    required: false
+---
+
+Consume a `candid-chrome-qa` v2.0 findings file and turn it into actual code fixes — with optional Linear issue filing.
+
+Usage:
+
+```
+/candid-chrome-qa-fix                                                        # Latest findings file, full prompts
+/candid-chrome-qa-fix --severity P0,P1                                       # Only urgent + high severity
+/candid-chrome-qa-fix --strategy issues-only                                 # File Linear issues, no fixes
+/candid-chrome-qa-fix --strategy per-finding --print-links                   # Emit conductor:// deep links (dry run)
+/candid-chrome-qa-fix --strategy batched --create-issues --tracker-team ENG  # Batched PR + Linear issues in team ENG
+/candid-chrome-qa-fix --file .context/findings/2026-04-25-foo.json --strategy local
+```
+
+Workflow:
+
+1. **Resolve findings file** — `--file` or latest in `.context/findings/`.
+2. **Validate v2.0 schema** — abort on mismatch.
+3. **Filter & summarize** — drop `✓ no issues` markers; apply `--severity` / `--category`.
+4. **Multi-select** — native checkbox UX for ≤15 findings; bulk presets + custom indices for more.
+5. **Strategy** — batched / per-finding (Conductor) / local / issues-only.
+6. **Issue tracker** — optional Linear issue creation, with dedup probe and single-issue invariant.
+7. **Execute** — apply fixes, create PR, or dispatch deep links.
+8. **Summary** — per-finding status + PR/issue links.
+
+Output:
+
+- **Batched mode**: one PR with all selected fixes; Linear issues linked in PR title + body if enabled.
+- **Per-finding mode**: N `conductor://` deep links, each spawning a fresh Conductor workspace that fixes one finding and ships its own PR.
+- **Local mode**: edits applied to the working tree, no PR.
+- **Issues-only mode**: Linear issues created from each finding; no code changes.
+- **Sidecar log**: `.context/findings/<base>.fixes.md` records every fix applied (timestamp, finding ID, files changed).
+
+Configuration: see `skills/candid-chrome-qa-fix/SKILL.md` → `## Configuration`. Provider details: see `skills/candid-chrome-qa-fix/WORKFLOW.md`.
+
+Requires `mcp__claude_ai_Linear__save_issue` + `mcp__claude_ai_Linear__list_issues` to be available when issue creation is enabled. macOS for `open`-launched Conductor deep links (per-finding mode falls back to `--print-links` on other platforms).

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -47,6 +47,7 @@ export default function HomePage() {
   // Refs for scroll-triggered animations
   const featuresRef = useRef(null)
   const howItWorksRef = useRef(null)
+  const qaFlowRef = useRef(null)
   const commandsRef = useRef(null)
   const communityRef = useRef(null)
   const faqRef = useRef(null)
@@ -80,7 +81,7 @@ export default function HomePage() {
 
     const observer = new IntersectionObserver(observerCallback, observerOptions)
 
-    const refs = [featuresRef, howItWorksRef, commandsRef, communityRef, faqRef, ctaRef]
+    const refs = [featuresRef, howItWorksRef, qaFlowRef, commandsRef, communityRef, faqRef, ctaRef]
     refs.forEach(ref => {
       if (ref.current) {
         observer.observe(ref.current)
@@ -323,6 +324,18 @@ export default function HomePage() {
               <p>Ship a branch and <code>/candid-ship</code> automatically moves the linked issue (Linear today, more soon) to <code>In Review</code>. Provider, state, and prompt are configurable.</p>
             </div>
           </Link>
+          <Link href="/docs/core-features/candid-chrome-qa" className="card-link">
+            <div className="card">
+              <h3>Chrome QA</h3>
+              <p>Drive a real Chrome session with <code>/candid-chrome-qa</code>. Walks your app like a real user across desktop and mobile, writes structured findings JSON for triage.</p>
+            </div>
+          </Link>
+          <Link href="/docs/core-features/candid-chrome-qa-fix" className="card-link">
+            <div className="card">
+              <h3>Chrome QA Fix</h3>
+              <p>Pick which QA findings to fix with <code>/candid-chrome-qa-fix</code>. Batched PR, one PR per finding via Conductor, or file Linear issues — your choice.</p>
+            </div>
+          </Link>
         </div>
       </section>
 
@@ -359,6 +372,43 @@ export default function HomePage() {
         </ol>
       </section>
 
+      <section className="how-it-works scroll-animate" ref={qaFlowRef}>
+        <span className="section-badge">CHROME QA FLOW</span>
+        <h2>From bugs found to bugs fixed</h2>
+        <p className="hero-tagline">
+          QA your running app, then turn findings into shipped fixes — without leaving Claude Code.
+        </p>
+        <ol className="steps-list">
+          <li>
+            <div className="step-content">
+              <strong>QA your app.</strong>
+              <span>Drive a real Chrome session, walk every target across desktop and mobile, and write structured findings to JSON.</span>
+              <Pre className="step-code" trackingId="qa_step_chrome_qa">
+                <code>/candid-chrome-qa</code>
+              </Pre>
+            </div>
+          </li>
+          <li>
+            <div className="step-content">
+              <strong>Pick what to fix.</strong>
+              <span>Multi-select findings by severity or category. Choose batched PR, parallel PRs via Conductor deep links, local-only, or issues-only.</span>
+              <Pre className="step-code" trackingId="qa_step_chrome_qa_fix">
+                <code>/candid-chrome-qa-fix</code>
+              </Pre>
+            </div>
+          </li>
+          <li>
+            <div className="step-content">
+              <strong>Ship it — with issues linked.</strong>
+              <span>Files one Linear issue per finding before any code change, then opens PRs that link back to the tracker. Re-runs are safe — findings are deduplicated by ID.</span>
+              <Pre className="step-code" trackingId="qa_step_ship">
+                <code>/candid-chrome-qa-fix --create-issues --strategy batched</code>
+              </Pre>
+            </div>
+          </li>
+        </ol>
+      </section>
+
       <section className="commands-section scroll-animate" ref={commandsRef}>
         <span className="section-badge">SLASH COMMANDS</span>
         <ul className="commands-list">
@@ -369,6 +419,14 @@ export default function HomePage() {
           <li>
             <code>/candid-init</code>
             <span>Generate a Technical.md file by analyzing your codebase structure.</span>
+          </li>
+          <li>
+            <code>/candid-chrome-qa</code>
+            <span>Drive a real Chrome session against your running web app and write structured findings JSON.</span>
+          </li>
+          <li>
+            <code>/candid-chrome-qa-fix</code>
+            <span>Pick QA findings to fix and ship them — batched PR, parallel PRs via Conductor, or Linear issues only.</span>
           </li>
           <li>
             <code>/candid-validate-standards</code>

--- a/docs/app/docs/core-features/_meta.js
+++ b/docs/app/docs/core-features/_meta.js
@@ -11,5 +11,6 @@ export default {
   'candid-ship': 'Candid Ship',
   'candid-fast-ship': 'Candid Fast Ship',
   'candid-chrome-qa': 'Candid Chrome QA',
+  'candid-chrome-qa-fix': 'Candid Chrome QA Fix',
   'slash-commands': 'Slash Commands',
 }

--- a/docs/app/docs/core-features/candid-chrome-qa-fix/page.mdx
+++ b/docs/app/docs/core-features/candid-chrome-qa-fix/page.mdx
@@ -1,0 +1,283 @@
+export const metadata = {
+  title: 'Candid Chrome QA Fix - Turn QA findings into shipped fixes',
+  description: 'Read the latest candid-chrome-qa findings JSON, pick which findings to fix, and dispatch fixes — batched PR, one PR per finding via Conductor deep links, local-only, or issues-only. Optionally files Linear issues per finding.',
+}
+
+# Candid Chrome QA Fix
+
+Take the structured findings JSON from `/candid-chrome-qa` and turn it into actual code fixes. Pick the findings you want to address, choose how to ship them, and let Candid handle the rest — including filing tracker issues if you want.
+
+## Quick Start
+
+```
+/candid-chrome-qa-fix
+```
+
+Resolves the latest findings file in `.context/findings/`, asks you which findings to fix (multi-select), and asks how to ship them.
+
+```
+/candid-chrome-qa-fix --severity P0,P1                          # Only urgent + high severity
+/candid-chrome-qa-fix --strategy issues-only                    # File Linear issues, no fixes
+/candid-chrome-qa-fix --strategy per-finding --print-links      # Emit conductor:// deep links (dry run)
+/candid-chrome-qa-fix --strategy batched --create-issues --tracker-team ENG
+```
+
+## How It Works
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Chrome QA Fix
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Findings file: .context/findings/2026-04-25-agent-config.json
+
+Steps:
+  1. ✅ Resolve findings file (latest, --file, or pick from recent)
+  2. 🔍 Validate v2.0 schema, drop coverage receipts
+  3. ☑️  Multi-select which findings to fix
+  4. 🚀 Pick a strategy (batched / per-finding / local / issues-only)
+  5. 🎯 Optionally file tracker issues (Linear today)
+  6. 🛠️  Apply fixes — sequentially or via Conductor deep links
+  7. 📋 Open PR(s) and link issues
+  8. 📊 Final summary
+```
+
+Issue creation runs **before** any code change so issue IDs flow into commits, PR titles, PR bodies, and per-finding spawned-workspace prompts.
+
+## Selection UI
+
+The skill's selector adapts to the number of fixable findings.
+
+**≤ 15 findings — native multi-select (true checkboxes):**
+
+```
+[ ] All P0 + P1
+[ ] All fixable
+[ ] [P0] [bug] Save button does nothing on Voice tab — F-a3f29b71
+[ ] [P1] [a11y] Icon button missing label on Header — F-7c29f912
+[ ] [P2] [ux] Toast disappears too fast on mobile — F-2bff1004
+...
+```
+
+**> 15 findings — bulk presets + custom indices:**
+
+```
+1. All fixable
+2. All P0 + P1
+3. All P0 + P1 + P2
+4. Custom selection (enter indices/IDs: 1,3,5-8 or F-a3f29b71)
+5. Cancel
+```
+
+Either path confirms the resolved selection before proceeding.
+
+## Strategies
+
+### Batched PR (default for ≤ 3 findings)
+
+All selected fixes applied sequentially in your current workspace. One PR at the end.
+
+```
+/candid-chrome-qa-fix --strategy batched
+```
+
+PR title (with issues): `Fix N QA findings (ENG-1234, ENG-1235): <top finding title>`. Body lists every finding with severity, surface, URL, and tracker link.
+
+### One PR per finding — parallel via [Conductor](/docs/how-to-guides/conductor)
+
+Emits a `conductor://` deep link per selected finding and `open`s each one. Each link spawns a fresh Conductor workspace that fixes one finding and ships its own PR — fully in parallel.
+
+```
+/candid-chrome-qa-fix --strategy per-finding
+/candid-chrome-qa-fix --strategy per-finding --print-links   # dry run
+```
+
+Conductor is Mac-only — on other platforms the skill falls back to `--print-links` automatically.
+
+### Local-only
+
+Apply fixes to the working tree. No commit, no PR. Useful when you want to read the diff before deciding.
+
+```
+/candid-chrome-qa-fix --strategy local
+```
+
+### Issues-only
+
+Skip code changes entirely. File one tracker issue per selected finding. Useful for triage when you want to track findings without fixing them right away.
+
+```
+/candid-chrome-qa-fix --strategy issues-only
+```
+
+## Issue Tracker Integration
+
+When `chromeQAFix.issueTracker.enabled` is `true` (or `--create-issues` is passed), the skill files one issue per selected finding **before** any code change. Issue IDs are then embedded in commit messages, PR titles, and PR bodies so the tracker shows the PR as a linked attachment.
+
+### Linear (supported today)
+
+```json
+{
+  "chromeQAFix": {
+    "issueTracker": {
+      "enabled": true,
+      "provider": "linear",
+      "teamKey": "ENG",
+      "state": "Backlog",
+      "labels": ["qa-finding", "chrome-qa"],
+      "priorityMap": { "P0": 1, "P1": 2, "P2": 3, "P3": 3, "P4": 4, "P5": 0 },
+      "dedupe": true
+    }
+  }
+}
+```
+
+| Finding field | → Linear field |
+|---|---|
+| `title` | Issue title (prefixed with `[QA] `) |
+| `severity` | Priority (`priorityMap`; defaults: P0→Urgent, P1→High, P2/P3→Medium, P4→Low, P5→No-priority) |
+| `category` | Appended to `labels` |
+| `repro` / `expected` / `actual` / `suggestedFix` | Description (markdown) |
+| `id` | Stored in description for deduplication on re-runs |
+
+### Dedup probe
+
+When `dedupe: true`, the skill calls `mcp__claude_ai_Linear__list_issues` for each finding and reuses an existing issue if its title or description contains the finding's `F-id`. A second `/candid-chrome-qa-fix` run on the same findings file won't create duplicates — it'll reuse the prior issues.
+
+### Other providers
+
+`github`, `jira`, and `asana` are stubbed for the future. They warn with a request-support link and skip the tracker step (code fixes still proceed). Set `provider: "none"` to disable tracker integration without removing the config.
+
+## CLI Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--file <path>` | Use a specific findings file | (latest in `.context/findings/`) |
+| `--severity P0,P1` | Only consider these severities | (all) |
+| `--category bug,a11y` | Only consider these categories | (all) |
+| `--strategy <name>` | One of `batched`, `per-finding`, `local`, `issues-only` | (prompted) |
+| `--max-parallel N` | Per-finding deep-link launch batch size | `4` |
+| `--print-links` | In per-finding mode, print deep links instead of opening them | `false` |
+| `--fast` | In batched mode, hand off to `/candid-fast-ship` instead of `/candid-ship` | `false` |
+| `--create-issues` | Force-enable tracker issue creation | (config) |
+| `--no-create-issues` | Force-disable tracker issue creation | (config) |
+| `--tracker-team <KEY>` | Override `issueTracker.teamKey` for this run | (config) |
+
+## Configuration
+
+Add a `chromeQAFix` block to `.candid/config.json`:
+
+```json
+{
+  "chromeQAFix": {
+    "defaultStrategy": "batched",
+    "maxParallel": 4,
+    "testCommand": "npm test",
+    "branchPrefix": "ron-myers",
+    "conductorRepoPath": "candid-v1",
+    "issueTracker": {
+      "enabled": false,
+      "provider": "linear",
+      "teamKey": "ENG",
+      "state": "Backlog",
+      "labels": ["qa-finding", "chrome-qa"],
+      "priorityMap": { "P0": 1, "P1": 2, "P2": 3, "P3": 3, "P4": 4, "P5": 0 },
+      "dedupe": true
+    }
+  }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `defaultStrategy` | `"batched"` | Used when no `--strategy` flag and selection > 3 findings |
+| `maxParallel` | `4` | Per-finding deep-link launch batch size; sleeps 2s between batches |
+| `testCommand` | `null` | Run after batched/local fixes; skipped if not set |
+| `branchPrefix` | git user | Branch prefix for spawned-workspace branches (`<prefix>/qa-fix-<slug>`) |
+| `conductorRepoPath` | derived | Value for the `path` query param of `conductor://` deep links |
+| `issueTracker.enabled` | `false` | Master switch for the create-issue step |
+| `issueTracker.provider` | `"linear"` | One of `linear`, `github`, `jira`, `asana`, `none` |
+| `issueTracker.teamKey` | none | Required for Linear when enabled |
+| `issueTracker.state` | `"Backlog"` | Initial state for new issues |
+| `issueTracker.labels` | `["qa-finding", "chrome-qa"]` | Base labels; finding's category is appended |
+| `issueTracker.priorityMap` | see schema | Severity → Linear priority |
+| `issueTracker.dedupe` | `true` | Search for existing F-id before creating |
+
+## Hard Rules
+
+The skill enforces these — it will refuse to act otherwise:
+
+1. **Never silently fix without user selection** — always present the multi-select prompt unless explicit CLI flags target a known set.
+2. **Never `open` Conductor deep links on a non-macOS host** — falls back to `--print-links` and warns.
+3. **Never write outside `evidence.filesLikelyTouched`** without explicitly noting the extra files.
+4. **Never claim a fix is shipped without a PR URL.**
+5. **Never assume v1 schema** — validates `schemaVersion === "2.0"` and stops with a clear error otherwise.
+6. **Never URL-encode the deep link incorrectly** — uses real URL-encoders, not hand-rolled string substitution.
+7. **Never spawn more than `maxParallel` Conductor workspaces in a single burst.**
+8. **Never create a Linear issue without the single-issue invariant** present in the rendered prompt.
+9. **Never silently fan out tracker creation** — confirms before creating ≥ 5 new issues.
+10. **Never proceed with `provider !== "linear"`** in v1 — warns and skips the tracker step. Code fixes still proceed.
+11. **Never embed secrets** in issue descriptions, commit messages, or deep-link prompts.
+
+## Final Summary
+
+After execution, the skill prints:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Chrome QA Fix — Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Findings file: .context/findings/2026-04-25-agent-config.json
+Strategy:      batched
+Selected:      4
+Fixed:         3
+Failed:        1
+Skipped:       0
+Issues filed:  4 created, 0 reused, 0 failed
+
+Per finding:
+  ✓ F-a3f29b71 [P0] Save button does nothing — PR: https://github.com/.../pull/123 | Issue: ENG-1234
+  ✓ F-7c29f912 [P1] Icon button missing label — applied locally | Issue: reused ENG-1180
+  ✗ F-2bff1004 [P1] Stale state on org switch — failed (test failure: line 42) | Issue: ENG-1235
+  → F-1c00abcd [P1] Settings save loop — Conductor: ron-myers/qa-fix-settings-save-loop
+```
+
+Glyph legend: `✓` fixed/applied, `✗` failed, `◦` issues-only, `→` dispatched to Conductor.
+
+## Requirements
+
+- A `candid-chrome-qa` v2.0 findings file in `.context/findings/` (run [`/candid-chrome-qa`](/docs/core-features/candid-chrome-qa) first if you don't have one)
+- For Linear issue creation: the Linear MCP (`mcp__claude_ai_Linear__save_issue`) installed in your Claude Code environment
+- For per-finding parallel mode: macOS with [Conductor](https://conductor.build) installed (the skill falls back to `--print-links` on other platforms)
+- A writable `.context/` directory (the skill creates `.context/findings/<base>.fixes.md` to log applied fixes)
+
+## FAQ
+
+### What if no findings file exists yet?
+
+The skill prints `No findings file found in .context/findings/` with a pointer to run `/candid-chrome-qa` first. No action is taken.
+
+### Can I re-run on the same findings file safely?
+
+Yes. With `dedupe: true` (default), the Linear probe finds existing issues by `F-id` and reuses them rather than creating duplicates. The applied-fixes sidecar log (`.context/findings/<base>.fixes.md`) accumulates across runs.
+
+### What happens to findings with `severity: "P5"`?
+
+P5 is reserved by `/candid-chrome-qa` for `✓ no issues — probes ran clean` coverage receipts. The fix skill drops them automatically — they're not bugs, they're proof that probes ran.
+
+### Per-finding mode — what does each Conductor workspace do?
+
+Each spawned workspace receives the full finding JSON, the desired branch name, and step-by-step instructions: rename branch → read files → apply fix → run tests → commit → push → ship via `/candid-fast-ship`. There's no callback to the parent — check Conductor for progress.
+
+### Does the skill modify the findings file?
+
+No. The findings file is the source of truth; the fix lifecycle is the consumer's concern. The skill writes a separate sidecar log at `.context/findings/<base>.fixes.md` recording each fix applied.
+
+### Can I use this with a tracker other than Linear?
+
+Not yet — only Linear is implemented in v1. `github`, `jira`, and `asana` are recognized config values that warn-and-skip with a link to request support. The provider abstraction is documented in the skill's `WORKFLOW.md` so future implementations can plug in cleanly.
+
+### What's the difference between this and `/candid-loop`?
+
+`/candid-loop` runs `/candid-review` repeatedly until code-review issues are gone. `/candid-chrome-qa-fix` consumes a single Chrome QA findings file and routes each finding through fix + ship + (optional) tracker. They're complementary: `/candid-loop` cleans the diff, `/candid-chrome-qa-fix` closes user-observable QA loops.

--- a/docs/app/docs/core-features/slash-commands/page.mdx
+++ b/docs/app/docs/core-features/slash-commands/page.mdx
@@ -152,6 +152,66 @@ Ship low-risk changes — only the steps you enable in `fastShip` config will ru
 
 Configure which steps run in `.candid/config.json` under the `fastShip` key. See [Candid Fast Ship](/docs/core-features/candid-fast-ship) for full documentation.
 
+## /candid-chrome-qa
+
+Drive a real Chrome session against your running web app and write structured findings JSON to `.context/findings/`.
+
+```
+/candid-chrome-qa
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | App URL to test (skips the URL prompt) |
+| `--mobile-only` | Skip the desktop pass and run mobile-only |
+
+### Examples
+
+```
+/candid-chrome-qa
+/candid-chrome-qa --url http://localhost:3000
+/candid-chrome-qa --mobile-only
+```
+
+See [Candid Chrome QA](/docs/core-features/candid-chrome-qa) for full documentation.
+
+## /candid-chrome-qa-fix
+
+Read the latest `candid-chrome-qa` findings JSON, pick which findings to fix, and dispatch fixes — batched PR, one PR per finding via Conductor deep links, local-only, or issues-only. Optionally files Linear issues per finding.
+
+```
+/candid-chrome-qa-fix
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--file <path>` | Use a specific findings file |
+| `--severity P0,P1` | Only consider these severities |
+| `--category bug,a11y` | Only consider these categories |
+| `--strategy <name>` | One of `batched`, `per-finding`, `local`, `issues-only` |
+| `--max-parallel N` | Per-finding deep-link launch batch size (default 4) |
+| `--print-links` | In per-finding mode, print deep links instead of opening them |
+| `--fast` | In batched mode, hand off to `/candid-fast-ship` instead of `/candid-ship` |
+| `--create-issues` | Force-enable Linear issue creation |
+| `--no-create-issues` | Force-disable Linear issue creation |
+| `--tracker-team <KEY>` | Override `issueTracker.teamKey` for this run |
+
+### Examples
+
+```
+/candid-chrome-qa-fix
+/candid-chrome-qa-fix --severity P0,P1
+/candid-chrome-qa-fix --strategy issues-only
+/candid-chrome-qa-fix --strategy per-finding --print-links
+/candid-chrome-qa-fix --strategy batched --create-issues --tracker-team ENG
+```
+
+See [Candid Chrome QA Fix](/docs/core-features/candid-chrome-qa-fix) for full documentation.
+
 ## /candid-validate-standards
 
 Check your Technical.md for issues.

--- a/skills/candid-chrome-qa-fix/SKILL.md
+++ b/skills/candid-chrome-qa-fix/SKILL.md
@@ -1,0 +1,511 @@
+---
+name: candid-chrome-qa-fix
+description: Take a candid-chrome-qa findings JSON, let the user pick which findings to fix, and dispatch fixes — single batched PR, one PR per finding via Conductor deep links, local-only, or issues-only. Optionally files Linear (or other tracker) issues per finding before shipping.
+---
+
+# Candid Chrome QA Fix
+
+Consume a `candid-chrome-qa` findings file (v2.0 schema) and turn it into actual code fixes — with optional issue-tracker filing.
+
+This is a **technique skill**. Follow the order. Sit alongside `/candid-chrome-qa` (the producer) and `/candid-loop` (the analogue for `candid-review` issues).
+
+## Workflow
+
+Execute these steps in order.
+
+### Step 1: Resolve the findings file
+
+Precedence (highest to lowest):
+
+1. CLI flag `--file <path>` — use that exact file. If it doesn't exist or isn't readable, abort.
+2. Latest file by mtime in `.context/findings/*.json`.
+3. If `.context/findings/` is empty/missing, output the message below and stop:
+
+   ```
+   No findings file found in .context/findings/
+   Run /candid-chrome-qa first, then re-run /candid-chrome-qa-fix.
+   ```
+
+If multiple files share the latest mtime within 5 minutes (i.e., 2+ recent runs), list the top 3 with their `context.scope` and `context.createdAt`:
+
+```
+Multiple recent findings files. Pick one:
+  1. 2026-04-25 18:30 — Agent Config / AI Setup, all 16 tabs (.context/findings/2026-04-25-agent-config-ai-setup.json)
+  2. 2026-04-25 16:12 — Dashboard analytics polish (.context/findings/2026-04-25-1612-dashboard-analytics-polish.json)
+  3. 2026-04-24 21:05 — Mobile-only smoke (.context/findings/2026-04-24-mobile-only-smoke.json)
+```
+
+Use `AskUserQuestion` with options for each file plus "Use the latest" and "Cancel".
+
+### Step 2: Validate the schema
+
+Parse the JSON. Validate:
+
+- `schemaVersion === "2.0"`. If not, abort with:
+
+  ```
+  Findings file uses schemaVersion "<value>" — this skill targets v2.0.
+  Re-run /candid-chrome-qa to regenerate, or pass an explicit --file from a v2.0 producer.
+  ```
+
+- `findings` is an array.
+- `context.scope` and `context.createdAt` exist.
+
+If any required per-finding field is missing on any finding (`id`, `severity`, `category`, `surface`, `viewport`, `url`, `title`, `repro`, `expected`, `actual`, `suggestedFix`, `groupHint`, `confidence`, `capturedAt`), warn but proceed — surface the malformed entries in the summary and skip them from the selection list.
+
+### Step 3: Filter & summarize
+
+Build the **fixable list**:
+
+1. Drop findings where `title` starts with `"✓ no issues"` or `severity === "P5"` AND `confidence === "definite"` and `category === "ux"` (those are coverage receipts emitted by chrome-qa for clean targets — not bugs).
+2. Apply CLI filters if present:
+   - `--severity P0,P1` → keep only matching severities.
+   - `--category bug,a11y` → keep only matching categories.
+3. Sort by severity (P0 → P5), then by `groupHint`, then by `capturedAt` ascending.
+
+Print the summary:
+
+```
+Findings file: .context/findings/<filename>.json
+Scope: <context.scope>
+Captured: <context.createdAt>
+
+Fixable: <N>
+  Severity: P0=<n> P1=<n> P2=<n> P3=<n> P4=<n>
+  Category: bug=<n> a11y=<n> perf=<n> ux=<n> copy=<n> security=<n> compat=<n>
+```
+
+If `Fixable === 0`, print `Nothing to fix — every finding is a coverage receipt or filtered out.` and stop.
+
+### Step 4: Multi-select UI ("checkbox list") — hybrid
+
+`AskUserQuestion` supports `multiSelect: true` (true checkbox UX). Use it conditionally based on the fixable count.
+
+Print the numbered list first, regardless of branch:
+
+```
+[ ] 1. [P0] [bug] Save button does nothing on Voice tab — F-a3f29b71
+       /dashboard/agents/agent_123/voice
+       Fix: Surface the form validation error in the UI; current handler swallows it
+[ ] 2. [P1] [a11y] Icon button missing label on Header — F-7c29f912
+       …
+```
+
+#### Step 4a: ≤ 15 fixable — native multi-select
+
+Call `AskUserQuestion` with `multiSelect: true`. Question: `"Which findings would you like to fix? (multi-select)"`. Options, in order:
+
+1. `"All P0 + P1"` (skip if there are zero P0+P1)
+2. `"All fixable"`
+3. One option per finding, formatted: `"[<severity>] [<category>] <title> — <id>"` (truncate titles past 80 chars)
+
+Do NOT add an `"Other"` option — the harness auto-injects free-form input. Do NOT add `"Cancel"` — the user can hit Esc.
+
+Resolve the user's selections:
+- If "All P0 + P1" was selected, expand to every P0 and P1 finding.
+- If "All fixable" was selected, expand to every fixable finding.
+- Otherwise, the picked options map directly to findings by ID.
+- De-duplicate. Preserve severity-then-capture-order.
+
+#### Step 4b: > 15 fixable — bulk presets + custom indices
+
+Call `AskUserQuestion` with single-select. Options:
+
+1. `"All fixable"` (N findings)
+2. `"All P0 + P1"` (only if there are P0+P1)
+3. `"All P0 + P1 + P2"`
+4. `"Custom selection"` — opens a free-form input prompt
+5. `"Cancel"`
+
+If "Custom selection", prompt with: `"Enter indices or finding IDs (comma-separated, ranges OK). Examples: 1,3,5-8 or F-a3f29b71,F-7c29f912"`. Parse:
+
+- Split on commas.
+- For each token: integer → index into the fixable list; `N-M` → range; `F-...` → ID lookup.
+- Reject (and ask again) if any token doesn't resolve.
+
+Either path: confirm the resolved selection with one more `AskUserQuestion`:
+
+```
+Selected <N> findings to fix:
+  • F-a3f29b71 [P0] Save button does nothing
+  • F-7c29f912 [P1] Icon button missing label
+  …
+Proceed?
+```
+
+Options: `"Yes — proceed"`, `"No — re-pick"`, `"Cancel"`.
+
+### Step 5: Strategy selection
+
+Skip this step if `--strategy` was passed. Otherwise:
+
+If `selected.length <= 3`, default to `batched` and skip the prompt. Otherwise ask via `AskUserQuestion`:
+
+```
+How would you like to ship these fixes?
+```
+
+Options:
+
+1. `"One batched PR"` — apply all fixes sequentially in this workspace; single PR at the end.
+2. `"One PR per finding (parallel via Conductor)"` — emit a `conductor://` deep link per finding to spawn isolated Conductor workspaces that fix in parallel.
+3. `"Apply locally only"` — fix everything in this workspace; no PR.
+4. `"File issues only — don't fix"` — create a tracker issue per finding; no code changes.
+
+CLI override: `--strategy batched|per-finding|local|issues-only`.
+
+### Step 6: Issue tracker decision
+
+Skip this step if `strategy === "issues-only"` (issues are always created in that strategy).
+
+Resolve the issue-tracker enable flag (precedence highest to lowest):
+
+1. CLI flag `--no-create-issues` → disabled.
+2. CLI flag `--create-issues` → enabled.
+3. `.candid/config.json` → `chromeQAFix.issueTracker.enabled` → use that.
+4. Default: disabled.
+
+If still disabled, skip this step.
+
+If enabled, ask via `AskUserQuestion`:
+
+```
+Also file these findings in your tracker?
+```
+
+Options:
+
+1. `"Yes — one issue per selected finding"` (linked from the PR)
+2. `"Yes — only for findings I'm NOT fixing right now"` (track for later — only present if there are unselected fixable findings)
+3. `"No — code fixes only, skip tracker"`
+
+Outcome — store one of:
+- `"all-selected"` — create issues for every finding in the selection.
+- `"unselected-only"` — create issues for fixable findings NOT in the selection.
+- `"none"` — skip tracker step.
+
+### Step 7: Create tracker issues (runs BEFORE any code change)
+
+Skip if Step 6 outcome is `"none"` AND `strategy !== "issues-only"`.
+
+Issue creation **must run before** code edits / PR / deep-link spawn so issue IDs flow into commits, PR titles/bodies, and per-finding spawned-workspace prompts.
+
+Provider dispatch — read `chromeQAFix.issueTracker.provider` from config:
+
+| Provider | Behavior |
+|---|---|
+| `linear` | Run the Linear flow defined in `WORKFLOW.md` → `Create Issue From Finding (Linear)`. |
+| `github` / `jira` / `asana` | Warn `⚠️  Issue tracker provider "<provider>" is not yet supported. Request support at: https://github.com/ron-myers/candid/issues` and skip. Code fixes still proceed. |
+| `none` or unset | Silently skip. |
+
+For supported providers, iterate the issue-creation list (selected, unselected, or all-selected per Step 6 / `--strategy issues-only`):
+
+1. Run the **dedup probe** (skip if `issueTracker.dedupe === false`) — see WORKFLOW.md → `Linear Dedup Probe`.
+2. If a single match is found, reuse it (`Reused existing issue [TEAM-123] for F-...`) and continue.
+3. Else, build the payload (see WORKFLOW.md → `Linear Payload`) and call `mcp__claude_ai_Linear__save_issue`.
+4. Capture `{ findingId, issueId, url, status: "created" | "reused" | "failed" | "skipped-ambiguous" }` into the **issue map**.
+
+Pre-create confirmation: if creating ≥ 5 new issues, show the list and ask `"Create N issues in <provider>:<teamKey>? (Y/n)"` via `AskUserQuestion`.
+
+After the loop, print:
+
+```
+Issues filed: <created> (reused: <reused>, failed: <failed>, skipped: <skipped>)
+```
+
+The issue map is passed to the strategy step.
+
+### Step 8: Execute strategy
+
+#### Step 8a: Batched mode (sequential, single PR)
+
+For each selected finding, in severity order (P0 first, then P1, …):
+
+1. Print the finding's `id`, `severity`, `category`, `title`, `repro`, `expected`, `actual`, `suggestedFix`, and any `evidence.filesLikelyTouched`.
+2. Read the files in `evidence.filesLikelyTouched`. If a path doesn't exist, log `[WARN] F-... — filesLikelyTouched path missing: <path>` and skip the finding (mark as failed in the summary).
+3. Apply the smallest change that resolves `actual` to match `expected`, using `suggestedFix` as guidance. NEVER write outside `evidence.filesLikelyTouched` without surfacing it explicitly.
+4. Append a one-line entry to `.context/findings/<base>.fixes.md` (create if missing): `<ISO-timestamp> | F-<id> | <title> | <files-changed>`.
+
+After all selected findings:
+
+5. If `chromeQAFix.testCommand` is set, run it. If it fails, print the error and ask: `"Tests failed. (a) Stop and let me debug, (b) Continue and ship anyway, (c) Stop and rollback?"` via `AskUserQuestion`. On (c), restore from `git stash`.
+6. Build the PR title and body:
+   - **Title** (≤ 72 chars): if issue map has Linear IDs, `"Fix N QA findings (TEAM-123, TEAM-124, …): <top finding title>"`. Otherwise `"Fix N QA findings: <top finding title>"`. Truncate to 72 with `…`.
+   - **Body**: see template in Step 8d below.
+7. Hand off to `/candid-fast-ship` (if `--fast` is set) or `/candid-ship` for the single PR. Pass `--skip-review` since we just edited deliberate fixes — re-reviewing them with `candid-loop` is duplicative and slow. Pass the title and body.
+8. Capture the PR URL.
+
+#### Step 8b: Per-finding mode (Conductor deep links, parallel)
+
+Pre-conditions:
+
+- `process.platform === "darwin"` (Conductor is Mac-only). If not, force `--print-links` and warn `Conductor is Mac-only — falling back to --print-links.`
+- Resolve the deep-link `path` parameter (precedence): `chromeQAFix.conductorRepoPath` → derive from `git remote get-url origin` repo name → ask the user once and offer to save into `.candid/config.json` if neither resolves.
+
+For each selected finding:
+
+1. Generate the branch slug: lowercase the finding's title, replace non-alphanumerics with `-`, collapse repeated `-`, trim trailing `-`, truncate to **22 chars** (so the full `<prefix>/qa-fix-<slug>` stays ≤ 30 chars when the prefix is short).
+2. Build the branch name: `<chromeQAFix.branchPrefix or git config user.name slug>/qa-fix-<slug>`. If the prefix is missing, use the git user's email local-part lowercased, non-alnum → `-`.
+3. Substitute placeholders in the **per-finding spawned-workspace prompt** (below).
+4. URL-encode the resulting prompt with full `encodeURIComponent` semantics — newlines, quotes, JSON braces, equals signs all encoded. Use Bash `jq -rR @uri` or Python's `urllib.parse.quote(..., safe='')` — NEVER hand-roll string substitution.
+5. URL-encode the `path` value.
+6. Build the deep link: `conductor://prompt=<encoded-prompt>&path=<encoded-path>`
+7. **`--print-links` mode**: print the deep link with the finding ID and branch name, do NOT `open` it.
+8. **Default mode**: `open "<deep-link>"` via Bash. After every `chromeQAFix.maxParallel` (default 4) launches, sleep 2s before the next batch to avoid Conductor race conditions on rapid spawn.
+
+After dispatching all links, print:
+
+```
+Conductor workspaces launched: <N>
+  F-a3f29b71 → ron-myers/qa-fix-voice-save-button → conductor://...
+  F-7c29f912 → ron-myers/qa-fix-icon-button-no-label → conductor://...
+  …
+
+Each workspace will: rename branch → fix → test → commit → push → ship PR.
+There is no callback — check Conductor for progress.
+```
+
+The parent skill exits at this point. The actual fixing happens in parallel inside Conductor's workspaces.
+
+##### Per-finding spawned-workspace prompt template
+
+Substitute every `{{placeholder}}` with the literal value:
+
+```
+You're fixing a single Chrome QA finding in a fresh Conductor workspace.
+
+First action: rename the auto-named branch to `{{branchName}}` via `git branch -m {{branchName}}`.
+
+Finding (v2.0 schema):
+{{finding-json}}
+
+{{#if linearIssueUrl}}
+Linear issue: {{linearIssueUrl}}
+Reference this issue in the commit body and PR description.
+{{/if}}
+
+Steps:
+1. Rename the branch as above.
+2. Read the files listed in evidence.filesLikelyTouched.
+3. Apply the smallest change that resolves `actual` to match `expected`, using `suggestedFix` as guidance.
+4. If `.candid/config.json` has `chromeQAFix.testCommand` set, run it. Fix or stop on failure — do NOT proceed past failing tests.
+5. Commit with message: "Fix QA: {{title}}"
+   Body must include:
+     Finding: F-{{id}}
+     URL: {{url}}
+     Repro: {{repro-first-line}}
+     {{#if linearIssueUrl}}Closes {{linearIssueId}}{{/if}}
+6. Push the branch.
+7. Run /candid-fast-ship to open the PR. Title: "Fix QA: {{title}}". Body must include the finding ID, the original URL, and the Linear issue link if present. (candid-fast-ship is opt-in by default — review is already disabled unless explicitly enabled in fastShip config, so no extra flag is needed.)
+8. Print the PR URL when done.
+
+DO NOT modify files unrelated to this finding. DO NOT touch other findings' files.
+```
+
+#### Step 8c: Local-only mode
+
+Run Step 8a's per-finding loop (steps 1–4) but stop before Step 8a/5 (test command, PR creation). Print a summary of files changed. The fixes remain uncommitted in the working tree for the user to review.
+
+#### Step 8d: PR body template (used by 8a)
+
+```
+## QA fixes from `<findings-file-path>`
+
+Origin: `/candid-chrome-qa` pass on <context.scope>, captured <context.createdAt>.
+
+### Fixes
+
+- {{#if linearId}}[{{linearId}}]({{linearUrl}}) — {{/if}}**F-{{id}}** [{{severity}}] {{title}}
+  - Surface: `{{surface}}` ({{viewport}})
+  - URL: {{url}}
+{{#each ...}}
+{{/each}}
+
+---
+
+_Filed by `/candid-chrome-qa-fix` — do not edit this footer; the matching findings file is at `<findings-file-path>`._
+```
+
+### Step 9: Final summary
+
+Always print, regardless of strategy:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Candid Chrome QA Fix — Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Findings file: <path>
+Strategy:      batched | per-finding | local | issues-only
+Selected:      <N>
+Fixed:         <M>
+Failed:        <P>
+Skipped:       <Q>
+Issues filed:  <I> created, <R> reused, <F> failed   (omit row if tracker disabled)
+
+Per finding:
+  ✓ F-a3f29b71 [P0] Save button does nothing — PR: https://github.com/.../pull/123 | Issue: TEAM-1234
+  ✓ F-7c29f912 [P1] Icon button missing label — applied locally | Issue: reused TEAM-1180
+  ✗ F-2bff1004 [P1] Stale state on org switch — failed (test failure: <line>) | Issue: TEAM-1235
+  ◦ F-9af00103 [P2] Touch target too small — issues-only | Issue: TEAM-1236
+  → F-1c00abcd [P1] Settings save loop — Conductor: ron-myers/qa-fix-settings-save-loop
+```
+
+Glyph legend: `✓` = fixed + shipped (or applied), `✗` = fix failed, `◦` = issues-only / no fix attempted, `→` = dispatched to Conductor (per-finding mode).
+
+Omit the `Issue:` column entirely if `issueTracker.enabled === false` or `provider !== "linear"`.
+
+**Exit code:** non-zero on any **fix** failure (`✗`). Issue-create failures warn but don't change the exit code (mirrors candid-ship's post-PR semantics).
+
+## Configuration
+
+### Config File Schema
+
+Add to `.candid/config.json`:
+
+```json
+{
+  "version": 1,
+  "chromeQAFix": {
+    "defaultStrategy": "batched",
+    "maxParallel": 4,
+    "testCommand": "npm test",
+    "branchPrefix": "ron-myers",
+    "conductorRepoPath": "candid-v1",
+    "issueTracker": {
+      "enabled": false,
+      "provider": "linear",
+      "teamKey": "ENG",
+      "state": "Backlog",
+      "labels": ["qa-finding", "chrome-qa"],
+      "priorityMap": { "P0": 1, "P1": 2, "P2": 3, "P3": 3, "P4": 4, "P5": 0 },
+      "dedupe": true,
+      "prompt": "Create one Linear issue from this single QA finding only — this issue only. Do not create issues for any other findings. Do not search for or update any other Linear issues. Use the structured payload exactly."
+    }
+  }
+}
+```
+
+### Field Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `defaultStrategy` | string | `"batched"` | One of `"batched"`, `"per-finding"`, `"local"`, `"issues-only"`. Used when no `--strategy` flag is passed and selection > 3. |
+| `maxParallel` | number | `4` | Per-finding deep-link launch batch size. Sleeps 2s between batches. |
+| `testCommand` | string | `null` | Run after batched/local fixes. Skipped if `null`. |
+| `branchPrefix` | string | git user | Prefix for spawned-workspace branch names (`<prefix>/qa-fix-<slug>`). |
+| `conductorRepoPath` | string | derived | Value for the `path` query param of `conductor://` deep links. |
+| `issueTracker.enabled` | boolean | `false` | Master switch for the create-issue step. |
+| `issueTracker.provider` | string | `"linear"` | One of `"linear"`, `"github"`, `"jira"`, `"asana"`, `"none"`. Only `"linear"` is implemented today. |
+| `issueTracker.teamKey` | string | none | **Required** when `provider === "linear"` and `enabled === true`. Linear team key (e.g. `"ENG"`). |
+| `issueTracker.state` | string | `"Backlog"` | Initial state for new issues. |
+| `issueTracker.labels` | array | `["qa-finding", "chrome-qa"]` | Base labels. The finding's `category` is appended at create time. |
+| `issueTracker.priorityMap` | object | see schema | Map from finding severity to Linear priority (0=No-priority…4=Low; 1=Urgent). |
+| `issueTracker.dedupe` | boolean | `true` | If true, search for existing issues with the same `F-id` before creating. |
+| `issueTracker.prompt` | string | see schema | Encodes the **single-issue invariant**. Custom prompts must contain one of `"only this one issue"`, `"only this single issue"`, `"only one issue"`, `"this issue only"`. |
+
+### Examples
+
+**Minimal — just batched fixes, no tracker:**
+```json
+{ "chromeQAFix": { "testCommand": "npm test" } }
+```
+
+**Linear, dedup on, default state:**
+```json
+{
+  "chromeQAFix": {
+    "issueTracker": {
+      "enabled": true,
+      "provider": "linear",
+      "teamKey": "DIS",
+      "labels": ["qa-finding", "chrome-qa", "from-claude"]
+    }
+  }
+}
+```
+
+**Force local-only by default with issues filed (review then ship manually):**
+```json
+{
+  "chromeQAFix": {
+    "defaultStrategy": "local",
+    "issueTracker": { "enabled": true, "provider": "linear", "teamKey": "ENG" }
+  }
+}
+```
+
+## CLI Examples
+
+```bash
+# Resolve latest findings file, prompt for selection and strategy
+/candid-chrome-qa-fix
+
+# Specific file, only P0 + P1 findings
+/candid-chrome-qa-fix --file .context/findings/2026-04-25-agent-config-ai-setup.json --severity P0,P1
+
+# Per-finding mode — emit deep links but don't open them (dry run)
+/candid-chrome-qa-fix --strategy per-finding --print-links
+
+# File-only mode (no fixes) — file every fixable finding into Linear
+/candid-chrome-qa-fix --strategy issues-only
+
+# Batched + Linear issues + override team
+/candid-chrome-qa-fix --strategy batched --create-issues --tracker-team DIS
+
+# Force-disable tracker even if config has it on
+/candid-chrome-qa-fix --no-create-issues
+```
+
+## CLI Flags
+
+| Flag | Description |
+|---|---|
+| `--file <path>` | Use a specific findings file (skip latest-resolution). |
+| `--severity P0,P1` | Only consider these severities. |
+| `--category bug,a11y` | Only consider these categories. |
+| `--strategy batched\|per-finding\|local\|issues-only` | Skip the strategy prompt. |
+| `--max-parallel N` | Override the per-finding deep-link launch batch size. |
+| `--print-links` | In per-finding mode, print deep links instead of `open`-ing them. |
+| `--fast` | In batched mode, hand off to `/candid-fast-ship` instead of `/candid-ship`. |
+| `--create-issues` | Force-enable issue creation (overrides config). |
+| `--no-create-issues` | Force-disable issue creation (overrides config). |
+| `--tracker-team <KEY>` | Override `issueTracker.teamKey` for this run. |
+
+## Hard Rules — do not violate
+
+1. **Never silently fix without user selection.** Always present the multi-select prompt unless `--strategy` AND a non-interactive selector (`--severity`, `--category`, or both passed together with all matching findings selected) explicitly target a known set.
+2. **Never `open` Conductor deep links on a non-macOS host.** Force `--print-links` mode and warn.
+3. **Never write outside `evidence.filesLikelyTouched`** without explicitly noting the extra files in the per-finding summary line.
+4. **Never claim a fix is shipped without a PR URL** in the final summary (batched/local; per-finding mode legitimately exits before PRs exist).
+5. **Never assume v1 schema.** Validate `schemaVersion === "2.0"` and stop with a clear error otherwise.
+6. **Never URL-encode the deep link incorrectly.** Use a real URL-encoder (`jq @uri`, Python `quote(safe='')`, etc.) — never hand-roll. Newlines, quotes, JSON braces, and `&` all need encoding.
+7. **Never spawn more than `maxParallel` Conductor workspaces in a single burst.** Sleep 2s between batches.
+8. **Never create a Linear issue without the single-issue invariant** present in the rendered prompt — refuse the MCP call. (Mirrors `candid-ship`'s defense-in-depth.)
+9. **Never silently fan out tracker creation.** If creating ≥ 5 new issues, confirm the count and target team before the first `mcp__claude_ai_Linear__save_issue` call. If `issueTracker.dedupe === true`, run the dedup probe first.
+10. **Never proceed with `provider !== "linear"`** in v1 — warn with the standard "request support" message and skip the tracker step. Code fixes still proceed.
+11. **Never embed secrets** (env vars, tokens, cookies, auth headers, request bodies) in issue descriptions, commit messages, or deep-link prompts. Only the structured finding fields are safe — and even those: redact anything in `evidence` that looks like a credential before serializing.
+
+## Common rationalizations — STOP if you catch yourself
+
+| Excuse | Reality |
+|--------|---------|
+| "I'll skip the schema check; the file looks fine" | v1 fields silently dropped break the workflow — title is `tag` in v1, repro/expected/actual don't exist. Validate. |
+| "I'll fix the file even though it's not in `filesLikelyTouched`" | Mark it in the summary so the user can verify. Don't hide unexpected edits. |
+| "I'll URL-encode the prompt by replacing spaces with `%20`" | JSON braces, quotes, newlines, and `&` will break the deep link. Use a real encoder. |
+| "Issue tracker can fail silently — the PR is what matters" | Issue creation IS the source of truth for some teams. Print failures explicitly in the summary. |
+| "I'll skip the dedup probe to save an API call" | A second `/candid-chrome-qa-fix` run on the same findings file will create duplicates. Always probe unless explicitly disabled. |
+| "Conductor isn't installed; I'll just run the fixes here" | The user picked per-finding for a reason. Print the deep links so they can fix it elsewhere or copy-paste them. |
+| "Per-finding mode without macOS — I'll use git worktrees instead" | That's a different feature. Print links and exit. Do not silently swap the implementation. |
+| "I'll create one Linear issue summarizing all findings" | Single-issue invariant. One finding = one issue. |
+| "I'll auto-approve the PR since the fix is small" | Never. The PR is the user's review surface — never auto-approve. |
+
+## Related skills
+
+- `/candid-chrome-qa` — produces the v2.0 findings file this skill consumes.
+- `/candid-loop` — analogous "fix issues in a loop" skill, but for `candid-review` output rather than chrome-qa.
+- `/candid-fast-ship` and `/candid-ship` — invoked at the end of batched mode (and inside each per-finding spawned workspace) to open PRs.
+
+## Provider-specific implementation
+
+See `WORKFLOW.md` for the **Create Issue From Finding** contract and the Linear-specific dedup probe + payload schema. Future provider implementations (GitHub Issues, Jira, Asana) plug into the same contract.

--- a/skills/candid-chrome-qa-fix/WORKFLOW.md
+++ b/skills/candid-chrome-qa-fix/WORKFLOW.md
@@ -1,0 +1,218 @@
+# Candid Chrome QA Fix — Provider Workflow
+
+Provider-specific implementation details for `/candid-chrome-qa-fix` Step 7 (Create tracker issues).
+
+The parent `SKILL.md` calls into one section here per finding: `Create Issue From Finding (<provider>)`. Each provider must implement the same contract.
+
+## Contract
+
+Every provider must satisfy:
+
+```
+input:  finding       — full v2.0 finding object
+        config        — chromeQAFix.issueTracker block (provider-specific overrides nested)
+        findingsFilePath — string path the finding came from (for breadcrumb in description)
+        dedupe        — boolean (config.dedupe, with --create-issues / --no-create-issues respected)
+        teamKey       — config.teamKey (with --tracker-team override applied)
+
+output: { findingId, issueId, url, status }
+        status ∈ {"created", "reused", "failed", "skipped-ambiguous"}
+        For "failed", include `error: <message>`.
+```
+
+The parent skill aggregates outputs into the issue map and stitches issue IDs into PR titles, PR bodies, commit bodies, and per-finding deep-link prompts.
+
+## Create Issue From Finding (Linear)
+
+Linear is the only provider implemented in v1.
+
+### Step 1 — Linear Dedup Probe
+
+Runs only if `config.dedupe === true`.
+
+Call `mcp__claude_ai_Linear__list_issues` filtered by team key. Use the structured `team` parameter when supported; otherwise pass the team key in the natural-language prompt with the same single-issue-search invariant.
+
+The probe asks: "Find any issue in team `<teamKey>` whose title or description contains `F-<id>`."
+
+| Result | Action |
+|---|---|
+| Zero matches | Proceed to create. |
+| One match | Reuse: capture the issue's `id` and `url`. Output: `Reused existing issue [TEAM-1234] for F-<id>`. Set status `"reused"`. |
+| Two or more matches | Skip create. Output: `⚠️  Multiple issues match F-<id> — skipping create. Resolve manually: <comma-separated ids>`. Set status `"skipped-ambiguous"`. |
+
+The probe MUST be by F-id (not by title) — finding titles can be edited in Linear and would no longer match, but F-ids are deterministic SHA-1 outputs of `<url>|<title>` and are stable across re-runs.
+
+### Step 2 — Linear Payload
+
+Build the payload from the finding:
+
+| Linear field | Source |
+|---|---|
+| `team` | `config.teamKey` (string). **Required.** If absent, abort the issue-tracker step entirely with: `⚠️  issueTracker.teamKey is required for provider "linear" — set it in .candid/config.json or pass --tracker-team. Skipping tracker step.` |
+| `title` | `"[QA] " + finding.title` (truncated to 100 chars if needed; never split mid-word). |
+| `description` | The markdown template below. |
+| `priority` | `config.priorityMap[finding.severity]` (default map: `{P0:1, P1:2, P2:3, P3:3, P4:4, P5:0}`). Linear scale: 0=No-priority, 1=Urgent, 2=High, 3=Medium, 4=Low. |
+| `state` | `config.state` (default `"Backlog"`). The Linear MCP accepts state name; case-sensitive. |
+| `labels` | `[...config.labels, finding.category]` deduplicated. Default labels: `["qa-finding", "chrome-qa"]`. |
+
+#### Description template
+
+```
+**Finding ID:** F-{{id}}
+**Severity:** {{severity}}
+**Category:** {{category}}
+**Surface:** `{{surface}}` ({{viewport}})
+**URL:** {{url}}
+**Confidence:** {{confidence}}
+
+## Repro
+
+{{repro}}
+
+## Expected
+
+{{expected}}
+
+## Actual
+
+{{actual}}
+
+## Suggested fix
+
+{{suggestedFix}}
+
+{{#if evidence}}
+## Evidence
+
+<details>
+<summary>Console / network / files touched</summary>
+
+```json
+{{evidence-json-pretty}}
+```
+
+</details>
+{{/if}}
+
+---
+
+_Filed by `/candid-chrome-qa-fix` from `{{findingsFilePath}}`_
+_Group hint: `{{groupHint}}` · Captured: {{capturedAt}}_
+```
+
+Substitution rules:
+
+- `{{evidence-json-pretty}}` is `JSON.stringify(finding.evidence, null, 2)`.
+- Omit the entire `## Evidence` block if `finding.evidence` is missing or empty.
+- All values are inserted verbatim — Linear renders markdown.
+- **Do NOT inject any value not present in the structured finding object.** No env vars, no shell expansions, no remote fetches. The finding is the only source of truth.
+
+### Step 3 — Pre-call Single-Issue Invariant Check
+
+The rendered prompt (the `prompt` template field, with placeholders substituted) MUST contain at least one of these phrases (case-insensitive):
+
+- `"only this one issue"`
+- `"only this single issue"`
+- `"only one issue"`
+- `"this issue only"`
+
+If none match:
+
+```
+⚠️  Issue tracker prompt is missing the single-issue restriction.
+Refusing to call the MCP. Restore the invariant in `chromeQAFix.issueTracker.prompt`
+(see SKILL.md for the default prompt).
+```
+
+Skip the call. The structured payload also enforces single-issue scope (one MCP call = one issue), but the prompt check is **defense-in-depth** matching the candid-ship pattern.
+
+### Step 4 — Call Linear MCP
+
+```
+mcp__claude_ai_Linear__save_issue
+  team: "<teamKey>"
+  title: "<rendered-title>"
+  description: "<rendered-description>"
+  priority: <number 0-4>
+  state: "<state-name>"
+  labels: [...]
+```
+
+**Important:** do NOT pass an `id` field — the absence of `id` is what makes this a create. (Passing `id` updates an existing issue, which is candid-ship's pattern, not ours.)
+
+The natural-language prompt — sent alongside the structured payload — should be the rendered `config.issueTracker.prompt` (default in SKILL.md). The structured payload is authoritative; the prompt shapes Claude's intent.
+
+| Outcome | Action |
+|---|---|
+| Success — returns `{id, url}` | Capture both. Status `"created"`. Output: `Created [TEAM-1234] for F-<id>` |
+| Error (auth, validation, network) | Status `"failed"`. Capture error. Output: `⚠️  Failed to create issue for F-<id>: <error>`. Continue with the next finding — do NOT abort the whole loop. |
+
+### Step 5 — Pre-fan-out Confirmation
+
+If `dedupe` is enabled and the probe found zero matches for **all** N findings (so we're about to create N new issues), AND `N >= 5`:
+
+```
+About to create <N> issues in Linear team <teamKey>:
+  • F-a3f29b71 — [QA] Save button does nothing on Voice tab
+  • F-7c29f912 — [QA] Icon button missing label on Header
+  …
+
+Proceed?
+```
+
+`AskUserQuestion`: `"Yes — create all"`, `"No — cancel issue creation"`. On cancel, set every finding's status to `"skipped-by-user"` and proceed to fixes (do not abort the whole skill).
+
+For `N < 5`, no confirmation needed — proceed.
+
+## Create Issue From Finding (GitHub)
+
+**Not yet implemented.** When invoked, output:
+
+```
+⚠️  Issue tracker provider "github" is not yet supported.
+Request support at: https://github.com/ron-myers/candid/issues
+Skipping tracker step. Code fixes will still proceed.
+```
+
+When implementing in a future PR, the contract surface is:
+
+- Map finding to GitHub issue title + body
+- Map severity to GitHub label (e.g., `priority:p0` … `priority:p5`)
+- Use `gh issue create --repo <owner/repo> --title <title> --body <body> --label <labels>` via Bash (no GitHub MCP required)
+- Dedup probe: `gh issue list --search "F-<id> in:body" --state all --json number,url,title`
+- Output `{ id: "<owner>/<repo>#<number>", url, status }`
+
+## Create Issue From Finding (Jira)
+
+**Not yet implemented.** When invoked, output:
+
+```
+⚠️  Issue tracker provider "jira" is not yet supported.
+Request support at: https://github.com/ron-myers/candid/issues
+Skipping tracker step. Code fixes will still proceed.
+```
+
+Future contract: REST API via `JIRA_TOKEN` env var, project key from config, severity mapped to priority field, F-id stored in `customfield_xxxxx` for dedup.
+
+## Create Issue From Finding (Asana)
+
+**Not yet implemented.** When invoked, output:
+
+```
+⚠️  Issue tracker provider "asana" is not yet supported.
+Request support at: https://github.com/ron-myers/candid/issues
+Skipping tracker step. Code fixes will still proceed.
+```
+
+Future contract: Asana API via `ASANA_TOKEN`, project GID from config, severity mapped to custom field, F-id in description for dedup.
+
+## Provider: "none"
+
+Skip silently. Return `{ findingId, issueId: null, url: null, status: "skipped-disabled" }` for each finding. Used when the user wants the rest of the workflow but explicitly opts out of tracker integration.
+
+## Implementation Notes
+
+- **Each provider MUST run the dedup probe as a single MCP/CLI call**, not one per finding. For Linear: one `list_issues` call per team scoped to a regex of all F-ids if the MCP supports it; otherwise one call per finding (slower but correct). Prefer batched if available.
+- **Issue creation is sequential, not parallel.** Linear MCP rate limits hit fast under bursty creation, and per-finding ordering is observable in the issue map. Sleep 200–500 ms between creates if `N >= 5`.
+- **Capture and surface partial failures.** A failed create for finding 3 must NOT prevent fixes for findings 1, 2, 4, … Mark in the issue map and continue.
+- **Never embed the full evidence body in the natural-language prompt** — only in the structured `description` field. Evidence can contain large network bodies that blow context.


### PR DESCRIPTION
## Changes

- **New skill** `candid-chrome-qa-fix` that consumes a `/candid-chrome-qa` v2.0 findings JSON and routes each finding through fix + ship + (optional) Linear tracker
- **Selection UI** adapts to count: native multi-select for ≤15 findings, bulk presets + custom indices for more
- **Four strategies**: batched single PR, one PR per finding via Conductor deep links, local-only, or issues-only
- **Linear integration** mirrors candid-ship's defense-in-depth pattern (single-issue invariant + structured payload). Dedup probe by `F-id` makes re-runs idempotent. `github`/`jira`/`asana` are stubbed with warn-and-skip messages
- **Docs**: new core-features page, sidebar nav entry, slash-commands reference
- **Homepage**: new "Chrome QA Flow" section with three steps + two new feature cards (Chrome QA, Chrome QA Fix), plus the new commands in the bottom commands list
- **Plugin version** bumped 1.16.0 → 1.17.0

## Files

| Path | Status |
|---|---|
| `skills/candid-chrome-qa-fix/SKILL.md` | new (511 lines) |
| `skills/candid-chrome-qa-fix/WORKFLOW.md` | new (218 lines) — provider-specific impl: contract, Linear payload, future stubs |
| `commands/candid-chrome-qa-fix.md` | new |
| `docs/app/docs/core-features/candid-chrome-qa-fix/page.mdx` | new |
| `docs/app/docs/core-features/_meta.js` | +1 nav entry |
| `docs/app/docs/core-features/slash-commands/page.mdx` | +60 (added `/candid-chrome-qa` and `/candid-chrome-qa-fix` sections) |
| `docs/app/(marketing)/page.jsx` | +60 (qaFlowRef + section + cards + commands) |
| `.claude-plugin/plugin.json` | 1.16.0 → 1.17.0 |

## Quality gates

- Candid review (constructive): ✅ — one inline fix applied (`--no-review` → `--skip-review`)
- Security review: ✅ — diff has no auth flows, no API handlers, no secrets handling; Hard Rule 11 forbids embedding secrets in prompts/issues
- Build: skipped — no top-level `package.json`; `next lint` in `docs/` is broken at the Next 16 level (unrelated to this diff). Vercel CI will validate the docs build on PR.

## Test plan

- [ ] `/candid-chrome-qa-fix` resolves the latest `.context/findings/*.json` and prompts for selection
- [ ] `--strategy local` applies fixes without creating a PR
- [ ] `--strategy issues-only` with `chromeQAFix.issueTracker.enabled: true` creates Linear issues with severity-mapped priority
- [ ] Re-running `--strategy issues-only` reuses existing issues via the dedup probe (no duplicates)
- [ ] `--strategy per-finding --print-links` emits well-formed `conductor://` URLs that decode correctly
- [ ] Homepage renders with the new "Chrome QA Flow" section and two new feature cards (verify on Vercel preview)