### PR TITLE
Standardize spelling to "Radical Candor" throughout docs site

### DIFF
--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -472,8 +472,8 @@ export default function HomePage() {
             <dd>Harsh mode is brutally honest—great for finding issues you might miss. Constructive mode is caring but direct, based on Radical Candor principles.</dd>
           </div>
           <div className="faq-item">
-            <dt>What is Radical Candour?</dt>
-            <dd>Radical Candour is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.</dd>
+            <dt>What is Radical Candor?</dt>
+            <dd>Radical Candor is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.</dd>
           </div>
         </dl>
       </section>

--- a/docs/app/components/schema/FAQSchema.jsx
+++ b/docs/app/components/schema/FAQSchema.jsx
@@ -25,9 +25,9 @@ export default function FAQSchema() {
         'Harsh provides brutally honest feedback, great for finding issues you might miss. Constructive provides caring but direct feedback, based on Radical Candor principles.',
     },
     {
-      question: 'What is Radical Candour?',
+      question: 'What is Radical Candor?',
       answer:
-        "Radical Candour is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.",
+        "Radical Candor is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.",
     },
     {
       question: 'Where does Candid save its state?',

--- a/docs/app/docs/tips-troubleshooting/faq/page.mdx
+++ b/docs/app/docs/tips-troubleshooting/faq/page.mdx
@@ -30,11 +30,11 @@ Yes. Share your Technical.md and `.candid/config.json` in your repo. Everyone ge
 - **Harsh** - Brutally honest feedback, great for finding issues you might miss
 - **Constructive** - Caring but direct feedback, based on Radical Candor principles
 
-### What is Radical Candour?
+### What is Radical Candor?
 
-Radical Candour is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.
+Radical Candor is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.
 
-[Learn more about Radical Candour →](https://www.thestartupstarterkit.com/startup-glossary/radical-candor)
+[Learn more about Radical Candor →](https://www.thestartupstarterkit.com/startup-glossary/radical-candor)
 
 ### Where does Candid save its state?
 


### PR DESCRIPTION
## Summary
- Standardize spelling to "Radical Candor" throughout docs site

## Verification
- Install: SKIPPED
- Review: SKIPPED
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-fast-ship](https://github.com/ron-myers/candid)*