### PR TITLE
Add /privacy page and footer disclosure for Fathom analytics

### DIFF
--- a/docs/app/(marketing)/layout.jsx
+++ b/docs/app/(marketing)/layout.jsx
@@ -115,6 +115,13 @@ export default function MarketingLayout({ children }) {
           >
             LinkedIn
           </a>
+          {' · '}
+          <Link
+            href="/privacy"
+            onClick={() => trackEvent(EVENTS.PRIVACY_CLICK)}
+          >
+            Privacy
+          </Link>
         </p>
       </footer>
     </div>

--- a/docs/app/(marketing)/privacy/page.jsx
+++ b/docs/app/(marketing)/privacy/page.jsx
@@ -1,0 +1,30 @@
+export const metadata = {
+  title: 'Privacy | Candid',
+  description: 'Privacy policy for candid.tools — what data is collected and how.',
+}
+
+export default function PrivacyPage() {
+  return (
+    <div style={{ maxWidth: '640px', margin: '0 auto', padding: '4rem 1.5rem', lineHeight: '1.7' }}>
+      <h1>Privacy</h1>
+      <p>
+        This site uses{' '}
+        <a href="https://usefathom.com" target="_blank" rel="noopener noreferrer">
+          Fathom Analytics
+        </a>
+        , a privacy-friendly, cookieless analytics service that is GDPR, CCPA, and PECR compliant.
+      </p>
+      <p>
+        No personal data is collected, stored, or sold. Fathom counts page views and referrers in
+        aggregate without tracking individuals or setting cookies.
+      </p>
+      <p>
+        For details on what Fathom collects, see the{' '}
+        <a href="https://usefathom.com/data" target="_blank" rel="noopener noreferrer">
+          Fathom data page
+        </a>
+        .
+      </p>
+    </div>
+  )
+}

--- a/docs/app/components/trackEvent.js
+++ b/docs/app/components/trackEvent.js
@@ -22,6 +22,7 @@ export const EVENTS = {
   SLACK_CLICK: 'slack_click',
   LINKEDIN_CLICK: 'linkedin_click',
   FRITTER_FACTORY_CLICK: 'fritter_factory_click',
+  PRIVACY_CLICK: 'privacy_click',
 
   // Code interactions
   CODE_COPY: 'code_copy',

--- a/docs/app/docs/layout.jsx
+++ b/docs/app/docs/layout.jsx
@@ -33,6 +33,10 @@ export default async function DocsLayout({ children }) {
           <a href="https://www.linkedin.com/company/fritter-factory/" target="_blank" rel="noopener noreferrer">
             LinkedIn
           </a>
+          {' · '}
+          <a href="/privacy">
+            Privacy
+          </a>
         </Footer>
       }
     >


### PR DESCRIPTION
## Summary
- Add /privacy page disclosing Fathom Analytics usage (cookieless, no personal data collected, GDPR/CCPA compliant)
- Add Privacy link to marketing footer (`app/(marketing)/layout.jsx`) with click tracking
- Add Privacy link to docs/Nextra footer (`app/docs/layout.jsx`)
- Add `PRIVACY_CLICK` event to `trackEvent.js`

Fixes F-c2592ca1.

## Verification
- Review: SKIPPED
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-fast-ship](https://github.com/ron-myers/candid)*