### PR TITLE
Fix copy-code button touch target to meet WCAG 2.5.5 minimum (44×44 px)

### DIFF
--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -961,6 +961,12 @@ header a:has(.logo):hover {
   justify-content: center;
 }
 
+.copy-button::before {
+  content: '';
+  position: absolute;
+  inset: -8px;
+}
+
 .code-block-wrapper:hover .copy-button {
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- Fix copy-code button touch target to meet WCAG 2.5.5 minimum (44×44 px)

## Verification
- Install: SKIPPED
- Review: SKIPPED
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-fast-ship](https://github.com/ron-myers/candid)*