### PR TITLE
Fix missing aria-label on docs search inputs (F-32951079)

### DIFF
--- a/docs/app/docs/layout.jsx
+++ b/docs/app/docs/layout.jsx
@@ -1,5 +1,6 @@
 import { Footer, Layout, Navbar } from 'nextra-theme-docs'
 import { getPageMap } from 'nextra/page-map'
+import { Search } from 'nextra/components'
 import 'nextra-theme-docs/style.css'
 import Logo from '../components/Logo'
 import BreadcrumbSchema from '../components/schema/BreadcrumbSchema'
@@ -21,6 +22,7 @@ export default async function DocsLayout({ children }) {
           }
         />
       }
+      search={<Search aria-label="Search documentation" />}
       pageMap={pageMap}
       docsRepositoryBase="https://github.com/ron-myers/candid/tree/main/docs"
       footer={


### PR DESCRIPTION
## Summary
- Fix missing aria-label on docs search inputs (F-32951079)

## Verification
- Install: SKIPPED
- Review: SKIPPED
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-fast-ship](https://github.com/ron-myers/candid)*