### PR TITLE
FAQ accordion: replace static dl with collapsible details/summary

### DIFF
--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -454,28 +454,38 @@ export default function HomePage() {
 
       <section className="faq-section scroll-animate" ref={faqRef}>
         <span className="section-badge">FREQUENTLY ASKED QUESTIONS</span>
-        <dl className="faq-list">
+        <div className="faq-list">
           <div className="faq-item">
-            <dt>Does Candid work with any language?</dt>
-            <dd>Yes, Candid reviews code in any language Claude Code supports. Your Technical.md standards can be language-specific or universal.</dd>
+            <details>
+              <summary>Does Candid work with any language?</summary>
+              <p>Yes, Candid reviews code in any language Claude Code supports. Your Technical.md standards can be language-specific or universal.</p>
+            </details>
           </div>
           <div className="faq-item">
-            <dt>How does Candid pay for Claude Code?</dt>
-            <dd>Candid uses Claude Code however you're already logged in. If you're using an API key, Candid uses that. If you're on Claude Pro or Max, Candid uses that.</dd>
+            <details>
+              <summary>How does Candid pay for Claude Code?</summary>
+              <p>Candid uses Claude Code however you're already logged in. If you're using an API key, Candid uses that. If you're on Claude Pro or Max, Candid uses that.</p>
+            </details>
           </div>
           <div className="faq-item">
-            <dt>Can I use Candid with my team?</dt>
-            <dd>Yes. Share your Technical.md and candid.config.json in your repo. Everyone gets the same standards and configuration automatically.</dd>
+            <details>
+              <summary>Can I use Candid with my team?</summary>
+              <p>Yes. Share your Technical.md and candid.config.json in your repo. Everyone gets the same standards and configuration automatically.</p>
+            </details>
           </div>
           <div className="faq-item">
-            <dt>What's the difference between Harsh and Constructive tone?</dt>
-            <dd>Harsh mode is brutally honest—great for finding issues you might miss. Constructive mode is caring but direct, based on Radical Candor principles.</dd>
+            <details>
+              <summary>What's the difference between Harsh and Constructive tone?</summary>
+              <p>Harsh mode is brutally honest—great for finding issues you might miss. Constructive mode is caring but direct, based on Radical Candor principles.</p>
+            </details>
           </div>
           <div className="faq-item">
-            <dt>What is Radical Candour?</dt>
-            <dd>Radical Candour is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.</dd>
+            <details>
+              <summary>What is Radical Candour?</summary>
+              <p>Radical Candour is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.</p>
+            </details>
           </div>
-        </dl>
+        </div>
       </section>
 
       <section className="cta-section scroll-animate" ref={ctaRef}>

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -861,21 +861,29 @@ header a:has(.logo):hover {
   padding-bottom: 0;
 }
 
-.faq-item dt {
+.faq-item summary {
   font-family: var(--font-display);
   font-weight: 600;
   font-size: 1.25rem;
   color: var(--text-primary);
-  margin-bottom: 0.75rem;
   transition: color 200ms ease;
   cursor: pointer;
+  list-style: none;
 }
 
-.faq-item dt:hover {
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-item details[open] > summary {
+  margin-bottom: 0.75rem;
+}
+
+.faq-item summary:hover {
   color: var(--accent-main);
 }
 
-.faq-item dd {
+.faq-item details > p {
   margin: 0;
   padding: 1.5rem;
   padding-left: 2rem;
@@ -886,11 +894,6 @@ header a:has(.logo):hover {
   background: var(--surface-light);
   border-radius: 8px;
   border-left: 4px solid var(--accent-main);
-}
-
-.faq-item dd::before {
-  content: "";
-  display: none;
 }
 
 /* ===== CTA Section ===== */
@@ -1291,15 +1294,15 @@ html.dark .faq-item {
   border-color: var(--border-light-dark);
 }
 
-html.dark .faq-item dt {
+html.dark .faq-item summary {
   color: var(--text-primary-dark);
 }
 
-html.dark .faq-item dt:hover {
+html.dark .faq-item summary:hover {
   color: var(--accent-main-dark);
 }
 
-html.dark .faq-item dd {
+html.dark .faq-item details > p {
   background: var(--surface-dark);
   color: var(--text-secondary-dark);
   border-left-color: var(--accent-main-dark);

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -890,7 +890,6 @@ header a:has(.logo):hover {
   color: var(--text-secondary);
   font-size: 1rem;
   line-height: 1.7;
-  position: relative;
   background: var(--surface-light);
   border-radius: 8px;
   border-left: 4px solid var(--accent-main);


### PR DESCRIPTION
## Summary

- Replaces always-open `<dl>/<dt>/<dd>` structure with native `<details>/<summary>/<p>` so each FAQ answer is hidden until clicked
- Removes orphaned `position: relative` from answer panel CSS (was only needed for a now-deleted `::before` pseudo-element)
- Updates all CSS selectors and dark mode variants; no JavaScript added

## Verification

- Install: SKIPPED
- Review: PASS — 1 iteration, 1 issue fixed
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*