### PR TITLE
Fix a11y on theme toggle + add See Also cross-links to docs

### DIFF
--- a/docs/app/components/ThemeButtonA11y.jsx
+++ b/docs/app/components/ThemeButtonA11y.jsx
@@ -1,0 +1,19 @@
+'use client'
+import { useEffect } from 'react'
+
+export default function ThemeButtonA11y() {
+  useEffect(() => {
+    function patch() {
+      const btn = document.querySelector('button[aria-haspopup="listbox"]:not([aria-label])')
+      if (btn) {
+        btn.setAttribute('aria-label', 'Switch theme')
+        observer.disconnect()
+      }
+    }
+    const observer = new MutationObserver(patch)
+    observer.observe(document.body, { childList: true, subtree: true })
+    patch()
+    return () => observer.disconnect()
+  }, [])
+  return null
+}

--- a/docs/app/docs/core-features/auto-commit/page.mdx
+++ b/docs/app/docs/core-features/auto-commit/page.mdx
@@ -78,3 +78,9 @@ Fixes are committed together, making it easy to revert if needed.
 /candid-review --focus security --auto-commit
 /candid-review --harsh --auto-commit
 ```
+
+## See Also
+
+- [Candid Ship](/docs/core-features/candid-ship) — full pipeline that includes auto-commit as one step
+- [Re-review](/docs/core-features/re-review) — re-run review after an auto-committed fix
+- [Decision Register](/docs/core-features/decision-register) — record decisions made during auto-commit reviews

--- a/docs/app/docs/core-features/candid-chrome-qa-fix/page.mdx
+++ b/docs/app/docs/core-features/candid-chrome-qa-fix/page.mdx
@@ -281,3 +281,9 @@ Not yet — only Linear is implemented in v1. `github`, `jira`, and `asana` are 
 ### What's the difference between this and `/candid-loop`?
 
 `/candid-loop` runs `/candid-review` repeatedly until code-review issues are gone. `/candid-chrome-qa-fix` consumes a single Chrome QA findings file and routes each finding through fix + ship + (optional) tracker. They're complementary: `/candid-loop` cleans the diff, `/candid-chrome-qa-fix` closes user-observable QA loops.
+
+## See Also
+
+- [Candid Chrome QA](/docs/core-features/candid-chrome-qa) — the QA pass that generates the findings file this skill consumes
+- [Candid Ship](/docs/core-features/candid-ship) — the ship step invoked for each finding fix
+- [Focus Modes](/docs/core-features/focus-modes) — narrow which categories of findings get fixed

--- a/docs/app/docs/core-features/candid-chrome-qa/page.mdx
+++ b/docs/app/docs/core-features/candid-chrome-qa/page.mdx
@@ -319,3 +319,9 @@ Mobile is required by default — a third of bugs are mobile-only. There is no f
 ### Can the same finding be deduplicated across passes?
 
 Yes. The `id` field is a deterministic SHA-1 hash of `<url>|<title>` — the same finding in a re-run gets the same ID. Triage tools can use this to suppress duplicates.
+
+## See Also
+
+- [Candid Chrome QA Fix](/docs/core-features/candid-chrome-qa-fix) — automatically fix findings from a QA pass
+- [Candid Ship](/docs/core-features/candid-ship) — ship fixes after resolving QA findings
+- [Technical.md](/docs/core-features/technical-md) — define standards that QA checks enforce

--- a/docs/app/docs/core-features/candid-fast-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-fast-ship/page.mdx
@@ -232,3 +232,9 @@ If you want to ship with just a subset of steps for a one-off run, use `/candid-
 ```
 
 Then `/candid-fast-ship` runs build, creates the PR, updates the Linear issue, and enables auto-merge — no review, no tests.
+
+## See Also
+
+- [Candid Ship](/docs/core-features/candid-ship) — full pipeline with review, tests, and PR creation
+- [Focus Modes](/docs/core-features/focus-modes) — scope what Candid Ship reviews when you do want a review
+- [Candid Loop](/docs/core-features/candid-loop) — run review iterations before shipping

--- a/docs/app/docs/core-features/candid-loop/page.mdx
+++ b/docs/app/docs/core-features/candid-loop/page.mdx
@@ -219,3 +219,10 @@ Candid Loop respects your other settings:
 # Focus reviews on security issues only
 /candid-loop --categories critical
 ```
+
+## See Also
+
+- [Candid Ship](/docs/core-features/candid-ship) — ship your changes after the loop cleans them up
+- [Re-review](/docs/core-features/re-review) — re-run review against an updated baseline
+- [Tone Selection](/docs/core-features/tone-selection) — adjust how direct or gentle loop feedback is
+- [Focus Modes](/docs/core-features/focus-modes) — narrow the loop to specific categories of issues

--- a/docs/app/docs/core-features/candid-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-ship/page.mdx
@@ -480,7 +480,6 @@ Then just run `/candid-ship` and your code goes from review to merged PR.
 
 ## See Also
 
-- [Candid Review](/docs/core-features/candid-review) — the review step Candid Ship runs under the hood
 - [Candid Fast Ship](/docs/core-features/candid-fast-ship) — skip review and tests for low-risk changes
 - [Candid Loop](/docs/core-features/candid-loop) — run review repeatedly until all issues are resolved
 - [Candid Chrome QA](/docs/core-features/candid-chrome-qa) — catch visual and UX bugs before shipping

--- a/docs/app/docs/core-features/candid-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-ship/page.mdx
@@ -477,3 +477,11 @@ A typical shipping workflow with candid-ship configured:
 ```
 
 Then just run `/candid-ship` and your code goes from review to merged PR.
+
+## See Also
+
+- [Candid Review](/docs/core-features/candid-review) — the review step Candid Ship runs under the hood
+- [Candid Fast Ship](/docs/core-features/candid-fast-ship) — skip review and tests for low-risk changes
+- [Candid Loop](/docs/core-features/candid-loop) — run review repeatedly until all issues are resolved
+- [Candid Chrome QA](/docs/core-features/candid-chrome-qa) — catch visual and UX bugs before shipping
+- [Tone Selection](/docs/core-features/tone-selection) — control how direct or gentle review feedback is

--- a/docs/app/docs/core-features/context-optimization/page.mdx
+++ b/docs/app/docs/core-features/context-optimization/page.mdx
@@ -99,3 +99,9 @@ Fixed context total       ~3,700
 ```
 
 After applying optimizations, a before/after summary shows the token reduction.
+
+## See Also
+
+- [Technical.md](/docs/core-features/technical-md) — the primary context file that optimization trims
+- [Focus Modes](/docs/core-features/focus-modes) — reduce context by scoping what gets reviewed per pass
+- [Candid Ship](/docs/core-features/candid-ship) — ships faster when context is optimized

--- a/docs/app/docs/core-features/decision-register/page.mdx
+++ b/docs/app/docs/core-features/decision-register/page.mdx
@@ -164,3 +164,9 @@ Candid avoids duplicate entries for the same logical question. If a question abo
 ## During Init
 
 When running `/candid-init`, you'll be asked whether to enable the decision register. This adds the config to your `.candid/config.json`.
+
+## See Also
+
+- [Technical.md](/docs/core-features/technical-md) — define the standards decisions are measured against
+- [Candid Ship](/docs/core-features/candid-ship) — prior decisions are applied during Candid Ship's review step
+- [Re-review](/docs/core-features/re-review) — decisions persist across re-review baseline resets

--- a/docs/app/docs/core-features/focus-modes/page.mdx
+++ b/docs/app/docs/core-features/focus-modes/page.mdx
@@ -72,3 +72,9 @@ Reviews for:
 ## We are looking to grow our Focus Modes that are built in
 
 If you have something to add, [Create an Issue](https://github.com/ron-myers/candid/issues/new) or reach out on our Slack.
+
+## See Also
+
+- [Tone Selection](/docs/core-features/tone-selection) — control review directness alongside focus
+- [Candid Loop](/docs/core-features/candid-loop) — run focused reviews repeatedly until issues clear
+- [Candid Ship](/docs/core-features/candid-ship) — focus modes apply during Candid Ship's review step

--- a/docs/app/docs/core-features/re-review/page.mdx
+++ b/docs/app/docs/core-features/re-review/page.mdx
@@ -40,3 +40,9 @@ The review state is saved at `.candid/last-review.json`. You can:
 - Commit it to track review history
 - Delete it to reset the baseline
 - Ignore it in `.gitignore` for personal tracking
+
+## See Also
+
+- [Candid Loop](/docs/core-features/candid-loop) — run review repeatedly until all issues are resolved
+- [Auto Commit](/docs/core-features/auto-commit) — commit fixes automatically, then re-review
+- [Focus Modes](/docs/core-features/focus-modes) — scope re-review to specific categories

--- a/docs/app/docs/core-features/slash-commands/page.mdx
+++ b/docs/app/docs/core-features/slash-commands/page.mdx
@@ -231,3 +231,10 @@ Check your Technical.md for issues.
 - 🌫️ Vague rules without clear criteria
 - 📏 Missing thresholds or limits
 - 🔧 Rules that overlap with linters
+
+## See Also
+
+- [Candid Ship](/docs/core-features/candid-ship) — the most complete slash command in the toolkit
+- [Candid Loop](/docs/core-features/candid-loop) — run review slash commands repeatedly
+- [Candid Chrome QA](/docs/core-features/candid-chrome-qa) — browser QA slash command
+- [Focus Modes](/docs/core-features/focus-modes) — flags that modify what most slash commands review

--- a/docs/app/docs/core-features/technical-md/page.mdx
+++ b/docs/app/docs/core-features/technical-md/page.mdx
@@ -58,3 +58,9 @@ The most important rule: **every rule should be actionable and verifiable.**
 ## Learn More
 
 - [Creating custom standards](/docs/how-to-guides/custom-standards) — Write effective rules
+
+## See Also
+
+- [Candid Ship](/docs/core-features/candid-ship) — applies your Technical.md rules during the review step
+- [Context Optimization](/docs/core-features/context-optimization) — reduce how many tokens Technical.md consumes
+- [Focus Modes](/docs/core-features/focus-modes) — run only a subset of your Technical.md rules per pass

--- a/docs/app/docs/core-features/tone-selection/page.mdx
+++ b/docs/app/docs/core-features/tone-selection/page.mdx
@@ -45,3 +45,9 @@ Or for user-wide default at `~/.candid/config.json`.
 2. Project config (`.candid/config.json`)
 3. User config (`~/.candid/config.json`)
 4. Interactive prompt (fallback)
+
+## See Also
+
+- [Candid Ship](/docs/core-features/candid-ship) — the review step in Candid Ship uses your configured tone
+- [Candid Loop](/docs/core-features/candid-loop) — tone applies to every loop iteration
+- [Focus Modes](/docs/core-features/focus-modes) — combine with tone to narrow what gets reviewed

--- a/docs/app/docs/layout.jsx
+++ b/docs/app/docs/layout.jsx
@@ -3,6 +3,7 @@ import { getPageMap } from 'nextra/page-map'
 import 'nextra-theme-docs/style.css'
 import Logo from '../components/Logo'
 import BreadcrumbSchema from '../components/schema/BreadcrumbSchema'
+import ThemeButtonA11y from '../components/ThemeButtonA11y'
 
 export default async function DocsLayout({ children }) {
   const pageMap = await getPageMap()
@@ -37,6 +38,7 @@ export default async function DocsLayout({ children }) {
       }
     >
       <BreadcrumbSchema />
+      <ThemeButtonA11y />
       {children}
     </Layout>
   )


### PR DESCRIPTION
## Summary

- Add `ThemeButtonA11y` client component that patches `aria-label="Switch theme"` onto the unlabelled Nextra listbox button (F-1b2ced4d, P2 a11y — screen readers previously announced only "button, collapsed, has popup listbox")
- Add `## See Also` section with 3–5 sibling links to all 13 core-feature pages (F-ecae93b8, P3 ux — zero in-content paths between sibling features)
- Remove dead `/docs/core-features/candid-review` link caught during review

## Verification

- Review: PASS (1 issue fixed — dead link removed)
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*