### PR TITLE
Add Remotion workflow animation to homepage hero

### DIFF
--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -174,6 +174,7 @@ export default function HomePage() {
         <div
           className="hero-animation"
           style={getHeroAnimationStyle(heroLoaded, 500)}
+          aria-hidden="true"
         >
           <WorkflowAnimation />
         </div>

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import { trackEvent, EVENTS } from '../components/trackEvent'
 import Pre from '../components/Pre'
 import SoftwareApplicationSchema from '../components/schema/SoftwareApplicationSchema'
+import WorkflowAnimation from '../components/WorkflowAnimation'
 import pluginJson from '../../data/plugin.json'
 
 const SCREENSHOTS = [
@@ -170,6 +171,12 @@ export default function HomePage() {
         >
           <code>{`npx skills add https://github.com/ron-myers/candid`}</code>
         </Pre>
+        <div
+          className="hero-animation"
+          style={getHeroAnimationStyle(heroLoaded, 500)}
+        >
+          <WorkflowAnimation />
+        </div>
       </section>
 
       <section className="demo-section">

--- a/docs/app/components/WorkflowAnimation/WorkflowComposition.jsx
+++ b/docs/app/components/WorkflowAnimation/WorkflowComposition.jsx
@@ -1,0 +1,377 @@
+'use client'
+
+import { AbsoluteFill, Sequence, useCurrentFrame, interpolate, spring, Easing } from 'remotion'
+
+const C = {
+  bg: '#0d1117',
+  surface: '#161b22',
+  border: '#30363d',
+  text: '#e6edf3',
+  muted: '#7d8590',
+  accent: '#d4a27f',
+  green: '#3fb950',
+  red: '#f85149',
+  yellow: '#d29922',
+  blue: '#58a6ff',
+}
+
+const MONO = '"JetBrains Mono", "Consolas", "Courier New", monospace'
+const SANS = 'Inter, system-ui, -apple-system, sans-serif'
+
+function clamp(v) {
+  return { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: v }
+}
+
+const EASE_OUT = Easing.out(Easing.cubic)
+
+function fade(frame, inStart, outStart, duration = 10) {
+  return interpolate(
+    frame,
+    [inStart, inStart + duration, outStart, outStart + duration],
+    [0, 1, 1, 0],
+    { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' }
+  )
+}
+
+function TerminalChrome({ title = 'Terminal' }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 7,
+      padding: '10px 16px',
+      background: '#1c2128',
+      borderBottom: `1px solid ${C.border}`,
+    }}>
+      <div style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff5f57' }} />
+      <div style={{ width: 12, height: 12, borderRadius: '50%', background: '#febc2e' }} />
+      <div style={{ width: 12, height: 12, borderRadius: '50%', background: '#28c840' }} />
+      <span style={{ color: C.muted, fontSize: 12, fontFamily: MONO, marginLeft: 'auto', marginRight: 'auto' }}>
+        {title}
+      </span>
+    </div>
+  )
+}
+
+function Typewriter({ text, startFrame, endFrame }) {
+  const frame = useCurrentFrame()
+  const count = Math.floor(
+    interpolate(frame, [startFrame, endFrame], [0, text.length], {
+      extrapolateLeft: 'clamp', extrapolateRight: 'clamp',
+    })
+  )
+  const showCursor = frame < endFrame + 8 && Math.floor(frame / 7) % 2 === 0
+  return (
+    <span>
+      {text.slice(0, count)}
+      <span style={{ opacity: showCursor ? 1 : 0 }}>█</span>
+    </span>
+  )
+}
+
+// Scene 1: git push (frames 0–70)
+function Scene1GitPush() {
+  const frame = useCurrentFrame()
+  const opacity = fade(frame, 0, 58, 10)
+  const responseOpacity = interpolate(frame, [36, 48], [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+  const responseY = interpolate(frame, [36, 48], [10, 0], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: EASE_OUT })
+
+  return (
+    <AbsoluteFill style={{ opacity, padding: 36, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      <div style={{ background: C.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 660, margin: '0 auto', width: '100%' }}>
+        <TerminalChrome />
+        <div style={{ padding: '20px 22px', minHeight: 160 }}>
+          <div style={{ color: C.green, fontFamily: MONO, fontSize: 13.5 }}>
+            <Typewriter text="$ git push origin feature/user-auth" startFrame={6} endFrame={30} />
+          </div>
+          <div style={{ marginTop: 14, opacity: responseOpacity, transform: `translateY(${responseY}px)` }}>
+            <div style={{ color: C.muted, fontFamily: MONO, fontSize: 12.5, lineHeight: 1.85 }}>
+              <div>Enumerating objects: 15, done.</div>
+              <div>Counting objects: 100% (15/15), done.</div>
+              <div>Writing objects: 100% (9/9), 2.41 KiB, done.</div>
+            </div>
+            <div style={{ marginTop: 10, color: C.green, fontFamily: MONO, fontSize: 13.5, fontWeight: 'bold' }}>
+              ✓  Pushed 3 commits to feature/user-auth
+            </div>
+          </div>
+        </div>
+      </div>
+    </AbsoluteFill>
+  )
+}
+
+// Scene 2: /candid-review (frames 60–140)
+function Scene2CandidReview() {
+  const frame = useCurrentFrame()
+  const opacity = fade(frame, 0, 65, 10)
+  const analysisOpacity = interpolate(frame, [25, 36], [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+  const progressWidth = interpolate(frame, [35, 65], [0, 100], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+  const dotPhase = Math.floor((frame - 25) / 7) % 3
+
+  return (
+    <AbsoluteFill style={{ opacity, padding: 36, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      <div style={{ background: C.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 660, margin: '0 auto', width: '100%' }}>
+        <TerminalChrome title="Claude Code" />
+        <div style={{ padding: '20px 22px', minHeight: 160 }}>
+          <div style={{ color: C.accent, fontFamily: MONO, fontSize: 13.5 }}>
+            <Typewriter text="> /candid-review" startFrame={4} endFrame={20} />
+          </div>
+
+          <div style={{ marginTop: 18, opacity: analysisOpacity }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
+              {[0, 1, 2].map(i => (
+                <span key={i} style={{ color: dotPhase === i ? C.accent : C.border, fontSize: 20, lineHeight: 1 }}>●</span>
+              ))}
+              <span style={{ color: C.muted, fontFamily: MONO, fontSize: 12.5, marginLeft: 4 }}>
+                Analyzing 847 lines across 12 files…
+              </span>
+            </div>
+
+            <div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+                <span style={{ color: C.muted, fontFamily: MONO, fontSize: 11.5 }}>Deep review in progress</span>
+                <span style={{ color: C.accent, fontFamily: MONO, fontSize: 11.5 }}>{Math.round(progressWidth)}%</span>
+              </div>
+              <div style={{ height: 4, background: C.border, borderRadius: 2 }}>
+                <div style={{ height: '100%', width: `${progressWidth}%`, background: C.accent, borderRadius: 2 }} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AbsoluteFill>
+  )
+}
+
+// Scene 3: Review results (frames 130–225)
+function Scene3ReviewResults() {
+  const frame = useCurrentFrame()
+  const opacity = fade(frame, 0, 80, 10)
+
+  const panelX = interpolate(frame, [5, 22], [50, 0], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: EASE_OUT })
+  const panelOpacity = interpolate(frame, [5, 22], [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+
+  const comments = [
+    { label: 'Security',    line: 23, msg: 'SQL injection — user input not sanitized', color: C.red,    in: [22, 33] },
+    { label: 'Type Error',  line: 25, msg: 'user.posts may be undefined',               color: C.yellow, in: [35, 46] },
+    { label: 'Performance', line: 27, msg: 'N+1 query in loop — batch fetch instead',   color: C.blue,   in: [48, 59] },
+  ]
+
+  const code = [
+    { n: 21, text: 'async function getUser(req, res) {',         hl: null },
+    { n: 22, text: '  const id = req.params.id',                 hl: null },
+    { n: 23, text: '  const q = `SELECT * WHERE id=${id}`',      hl: C.red },
+    { n: 24, text: '  const user = await db.raw(q)',             hl: null },
+    { n: 25, text: '  const posts = user.posts.map(p => p)',     hl: C.yellow },
+    { n: 26, text: '  for (const tag of user.tags) {',          hl: null },
+    { n: 27, text: '    await db.query(`SELECT...`, [tag])',     hl: C.blue },
+    { n: 28, text: '  }',                                        hl: null },
+    { n: 29, text: '  res.json({ user, posts })',                hl: null },
+    { n: 30, text: '}',                                          hl: null },
+  ]
+
+  return (
+    <AbsoluteFill style={{ opacity, padding: 22 }}>
+      <div style={{ display: 'flex', gap: 14, height: '100%', alignItems: 'center', maxWidth: 760, margin: '0 auto', width: '100%' }}>
+        <div style={{
+          flex: '0 0 320px',
+          background: C.surface,
+          borderRadius: 10,
+          border: `1px solid ${C.border}`,
+          overflow: 'hidden',
+          transform: `translateX(${panelX}px)`,
+          opacity: panelOpacity,
+        }}>
+          <TerminalChrome title="user-auth.js" />
+          <div style={{ padding: '10px 0' }}>
+            {code.map(line => (
+              <div key={line.n} style={{
+                display: 'flex',
+                padding: '2.5px 0',
+                background: line.hl ? `${line.hl}18` : 'transparent',
+                borderLeft: line.hl ? `3px solid ${line.hl}` : '3px solid transparent',
+              }}>
+                <span style={{ color: C.border, fontFamily: MONO, fontSize: 10.5, width: 28, textAlign: 'right', paddingRight: 10, flexShrink: 0 }}>
+                  {line.n}
+                </span>
+                <span style={{ color: line.hl ?? C.text, fontFamily: MONO, fontSize: 10.5, opacity: line.hl ? 1 : 0.8 }}>
+                  {line.text}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <div style={{ color: C.text, fontFamily: SANS, fontSize: 14, fontWeight: 600, marginBottom: 2 }}>
+            3 issues found
+          </div>
+          {comments.map(c => {
+            const op = interpolate(frame, c.in, [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+            const ty = interpolate(frame, c.in, [10, 0], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: EASE_OUT })
+            return (
+              <div key={c.line} style={{
+                opacity: op, transform: `translateY(${ty}px)`,
+                background: C.surface,
+                border: `1px solid ${c.color}40`,
+                borderLeft: `3px solid ${c.color}`,
+                borderRadius: 8,
+                padding: '10px 12px',
+              }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                  <span style={{ background: `${c.color}22`, color: c.color, fontFamily: MONO, fontSize: 10, padding: '2px 6px', borderRadius: 4 }}>
+                    {c.label}
+                  </span>
+                  <span style={{ color: C.muted, fontFamily: MONO, fontSize: 10.5 }}>Line {c.line}</span>
+                </div>
+                <div style={{ color: C.text, fontFamily: SANS, fontSize: 12.5, lineHeight: 1.4 }}>{c.msg}</div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </AbsoluteFill>
+  )
+}
+
+// Scene 4: Apply fixes (frames 220–305)
+function Scene4ApplyFixes() {
+  const frame = useCurrentFrame()
+  const opacity = fade(frame, 0, 70, 10)
+
+  const fixes = [
+    { label: 'Security',    msg: 'Parameterize SQL query',          color: C.red,    range: [10, 32] },
+    { label: 'Type Error',  msg: 'Add optional chaining ?.map()',   color: C.yellow, range: [28, 50] },
+    { label: 'Performance', msg: 'Replace loop with batchGetTags()', color: C.blue,   range: [46, 66] },
+  ]
+
+  const labelOpacity = interpolate(frame, [4, 14], [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+
+  return (
+    <AbsoluteFill style={{ opacity, padding: 40, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
+      <div style={{ maxWidth: 540, width: '100%' }}>
+        <div style={{ color: C.accent, fontFamily: MONO, fontSize: 13, marginBottom: 20, opacity: labelOpacity }}>
+          Applying fixes…
+        </div>
+
+        {fixes.map((fix, i) => {
+          const progress = interpolate(frame, fix.range, [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+          const done = progress >= 1
+          return (
+            <div key={i} style={{
+              background: C.surface,
+              border: `1px solid ${C.border}`,
+              borderRadius: 8,
+              padding: '13px 16px',
+              marginBottom: 10,
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ background: `${fix.color}22`, color: fix.color, fontFamily: MONO, fontSize: 10, padding: '2px 6px', borderRadius: 4 }}>
+                    {fix.label}
+                  </span>
+                  <span style={{ color: C.text, fontFamily: SANS, fontSize: 13 }}>{fix.msg}</span>
+                </div>
+                <div style={{
+                  width: 20, height: 20, borderRadius: '50%',
+                  background: done ? C.green : C.border,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  flexShrink: 0,
+                }}>
+                  {done && (
+                    <svg width="11" height="11" viewBox="0 0 11 11" fill="none">
+                      <path d="M2 5.5L4.5 8L9 3" stroke="#0d1117" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </div>
+              </div>
+              <div style={{ height: 3, background: C.border, borderRadius: 2 }}>
+                <div style={{ height: '100%', width: `${progress * 100}%`, background: done ? C.green : fix.color, borderRadius: 2 }} />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </AbsoluteFill>
+  )
+}
+
+// Scene 5: Ship (frames 300–390)
+function Scene5Ship() {
+  const frame = useCurrentFrame()
+  const opacity = fade(frame, 0, 78, 10)
+
+  const successOpacity = interpolate(frame, [34, 48], [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
+  const successScale = spring({ fps: 30, frame: Math.max(0, frame - 34), config: { damping: 14, stiffness: 180 } })
+
+  const tags = ['Security', 'Type Error', 'Performance']
+
+  return (
+    <AbsoluteFill style={{ opacity, padding: 40, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
+      <div style={{ background: C.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 540, width: '100%' }}>
+        <TerminalChrome title="Claude Code" />
+        <div style={{ padding: '22px 24px' }}>
+          <div style={{ color: C.accent, fontFamily: MONO, fontSize: 13.5, marginBottom: 22 }}>
+            <Typewriter text="> /candid-ship" startFrame={6} endFrame={24} />
+          </div>
+
+          <div style={{ opacity: successOpacity, transform: `scale(${successScale})`, textAlign: 'center' }}>
+            <div style={{
+              width: 56, height: 56, borderRadius: '50%',
+              background: `${C.green}1a`,
+              border: `2px solid ${C.green}`,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              margin: '0 auto 16px',
+            }}>
+              <svg width="26" height="26" viewBox="0 0 26 26" fill="none">
+                <path d="M4 13L10 19L22 7" stroke={C.green} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </div>
+
+            <div style={{ color: C.text, fontFamily: SANS, fontSize: 17, fontWeight: 700, marginBottom: 6 }}>
+              All issues resolved
+            </div>
+            <div style={{ color: C.muted, fontFamily: SANS, fontSize: 13.5, marginBottom: 18 }}>
+              Shipped with confidence ✓
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+              {tags.map(tag => (
+                <span key={tag} style={{
+                  background: `${C.green}1a`,
+                  color: C.green,
+                  fontFamily: MONO,
+                  fontSize: 11,
+                  padding: '3px 9px',
+                  borderRadius: 4,
+                }}>
+                  ✓ {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </AbsoluteFill>
+  )
+}
+
+export default function WorkflowComposition() {
+  return (
+    <AbsoluteFill style={{ background: C.bg }}>
+      <Sequence from={0} durationInFrames={70}>
+        <Scene1GitPush />
+      </Sequence>
+      <Sequence from={60} durationInFrames={80}>
+        <Scene2CandidReview />
+      </Sequence>
+      <Sequence from={130} durationInFrames={95}>
+        <Scene3ReviewResults />
+      </Sequence>
+      <Sequence from={220} durationInFrames={85}>
+        <Scene4ApplyFixes />
+      </Sequence>
+      <Sequence from={300} durationInFrames={90}>
+        <Scene5Ship />
+      </Sequence>
+    </AbsoluteFill>
+  )
+}

--- a/docs/app/components/WorkflowAnimation/WorkflowComposition.jsx
+++ b/docs/app/components/WorkflowAnimation/WorkflowComposition.jsx
@@ -2,7 +2,7 @@
 
 import { AbsoluteFill, Sequence, useCurrentFrame, interpolate, spring, Easing } from 'remotion'
 
-const C = {
+const COLORS = {
   bg: '#0d1117',
   surface: '#161b22',
   border: '#30363d',
@@ -17,10 +17,6 @@ const C = {
 
 const MONO = '"JetBrains Mono", "Consolas", "Courier New", monospace'
 const SANS = 'Inter, system-ui, -apple-system, sans-serif'
-
-function clamp(v) {
-  return { extrapolateLeft: 'clamp', extrapolateRight: 'clamp', easing: v }
-}
 
 const EASE_OUT = Easing.out(Easing.cubic)
 
@@ -44,7 +40,7 @@ function TerminalChrome({ title = 'Terminal' }) {
       <div style={{ width: 12, height: 12, borderRadius: '50%', background: '#ff5f57' }} />
       <div style={{ width: 12, height: 12, borderRadius: '50%', background: '#febc2e' }} />
       <div style={{ width: 12, height: 12, borderRadius: '50%', background: '#28c840' }} />
-      <span style={{ color: C.muted, fontSize: 12, fontFamily: MONO, marginLeft: 'auto', marginRight: 'auto' }}>
+      <span style={{ color: COLORS.muted, fontSize: 12, fontFamily: MONO, marginLeft: 'auto', marginRight: 'auto' }}>
         {title}
       </span>
     </div>
@@ -76,19 +72,19 @@ function Scene1GitPush() {
 
   return (
     <AbsoluteFill style={{ opacity, padding: 36, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-      <div style={{ background: C.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 660, margin: '0 auto', width: '100%' }}>
+      <div style={{ background: COLORS.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 660, margin: '0 auto', width: '100%' }}>
         <TerminalChrome />
         <div style={{ padding: '20px 22px', minHeight: 160 }}>
-          <div style={{ color: C.green, fontFamily: MONO, fontSize: 13.5 }}>
+          <div style={{ color: COLORS.green, fontFamily: MONO, fontSize: 13.5 }}>
             <Typewriter text="$ git push origin feature/user-auth" startFrame={6} endFrame={30} />
           </div>
           <div style={{ marginTop: 14, opacity: responseOpacity, transform: `translateY(${responseY}px)` }}>
-            <div style={{ color: C.muted, fontFamily: MONO, fontSize: 12.5, lineHeight: 1.85 }}>
+            <div style={{ color: COLORS.muted, fontFamily: MONO, fontSize: 12.5, lineHeight: 1.85 }}>
               <div>Enumerating objects: 15, done.</div>
               <div>Counting objects: 100% (15/15), done.</div>
               <div>Writing objects: 100% (9/9), 2.41 KiB, done.</div>
             </div>
-            <div style={{ marginTop: 10, color: C.green, fontFamily: MONO, fontSize: 13.5, fontWeight: 'bold' }}>
+            <div style={{ marginTop: 10, color: COLORS.green, fontFamily: MONO, fontSize: 13.5, fontWeight: 'bold' }}>
               ✓  Pushed 3 commits to feature/user-auth
             </div>
           </div>
@@ -108,30 +104,30 @@ function Scene2CandidReview() {
 
   return (
     <AbsoluteFill style={{ opacity, padding: 36, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-      <div style={{ background: C.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 660, margin: '0 auto', width: '100%' }}>
+      <div style={{ background: COLORS.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 660, margin: '0 auto', width: '100%' }}>
         <TerminalChrome title="Claude Code" />
         <div style={{ padding: '20px 22px', minHeight: 160 }}>
-          <div style={{ color: C.accent, fontFamily: MONO, fontSize: 13.5 }}>
+          <div style={{ color: COLORS.accent, fontFamily: MONO, fontSize: 13.5 }}>
             <Typewriter text="> /candid-review" startFrame={4} endFrame={20} />
           </div>
 
           <div style={{ marginTop: 18, opacity: analysisOpacity }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
               {[0, 1, 2].map(i => (
-                <span key={i} style={{ color: dotPhase === i ? C.accent : C.border, fontSize: 20, lineHeight: 1 }}>●</span>
+                <span key={i} style={{ color: dotPhase === i ? COLORS.accent : COLORS.border, fontSize: 20, lineHeight: 1 }}>●</span>
               ))}
-              <span style={{ color: C.muted, fontFamily: MONO, fontSize: 12.5, marginLeft: 4 }}>
+              <span style={{ color: COLORS.muted, fontFamily: MONO, fontSize: 12.5, marginLeft: 4 }}>
                 Analyzing 847 lines across 12 files…
               </span>
             </div>
 
             <div>
               <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
-                <span style={{ color: C.muted, fontFamily: MONO, fontSize: 11.5 }}>Deep review in progress</span>
-                <span style={{ color: C.accent, fontFamily: MONO, fontSize: 11.5 }}>{Math.round(progressWidth)}%</span>
+                <span style={{ color: COLORS.muted, fontFamily: MONO, fontSize: 11.5 }}>Deep review in progress</span>
+                <span style={{ color: COLORS.accent, fontFamily: MONO, fontSize: 11.5 }}>{Math.round(progressWidth)}%</span>
               </div>
-              <div style={{ height: 4, background: C.border, borderRadius: 2 }}>
-                <div style={{ height: '100%', width: `${progressWidth}%`, background: C.accent, borderRadius: 2 }} />
+              <div style={{ height: 4, background: COLORS.border, borderRadius: 2 }}>
+                <div style={{ height: '100%', width: `${progressWidth}%`, background: COLORS.accent, borderRadius: 2 }} />
               </div>
             </div>
           </div>
@@ -150,19 +146,19 @@ function Scene3ReviewResults() {
   const panelOpacity = interpolate(frame, [5, 22], [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
 
   const comments = [
-    { label: 'Security',    line: 23, msg: 'SQL injection — user input not sanitized', color: C.red,    in: [22, 33] },
-    { label: 'Type Error',  line: 25, msg: 'user.posts may be undefined',               color: C.yellow, in: [35, 46] },
-    { label: 'Performance', line: 27, msg: 'N+1 query in loop — batch fetch instead',   color: C.blue,   in: [48, 59] },
+    { label: 'Security',    line: 23, msg: 'SQL injection — user input not sanitized', color: COLORS.red,    in: [22, 33] },
+    { label: 'Type Error',  line: 25, msg: 'user.posts may be undefined',               color: COLORS.yellow, in: [35, 46] },
+    { label: 'Performance', line: 27, msg: 'N+1 query in loop — batch fetch instead',   color: COLORS.blue,   in: [48, 59] },
   ]
 
   const code = [
     { n: 21, text: 'async function getUser(req, res) {',         hl: null },
     { n: 22, text: '  const id = req.params.id',                 hl: null },
-    { n: 23, text: '  const q = `SELECT * WHERE id=${id}`',      hl: C.red },
+    { n: 23, text: '  const q = `SELECT * WHERE id=${id}`',      hl: COLORS.red },
     { n: 24, text: '  const user = await db.raw(q)',             hl: null },
-    { n: 25, text: '  const posts = user.posts.map(p => p)',     hl: C.yellow },
+    { n: 25, text: '  const posts = user.posts.map(p => p)',     hl: COLORS.yellow },
     { n: 26, text: '  for (const tag of user.tags) {',          hl: null },
-    { n: 27, text: '    await db.query(`SELECT...`, [tag])',     hl: C.blue },
+    { n: 27, text: '    await db.query(`SELECT...`, [tag])',     hl: COLORS.blue },
     { n: 28, text: '  }',                                        hl: null },
     { n: 29, text: '  res.json({ user, posts })',                hl: null },
     { n: 30, text: '}',                                          hl: null },
@@ -173,7 +169,7 @@ function Scene3ReviewResults() {
       <div style={{ display: 'flex', gap: 14, height: '100%', alignItems: 'center', maxWidth: 760, margin: '0 auto', width: '100%' }}>
         <div style={{
           flex: '0 0 320px',
-          background: C.surface,
+          background: COLORS.surface,
           borderRadius: 10,
           border: `1px solid ${C.border}`,
           overflow: 'hidden',
@@ -189,10 +185,10 @@ function Scene3ReviewResults() {
                 background: line.hl ? `${line.hl}18` : 'transparent',
                 borderLeft: line.hl ? `3px solid ${line.hl}` : '3px solid transparent',
               }}>
-                <span style={{ color: C.border, fontFamily: MONO, fontSize: 10.5, width: 28, textAlign: 'right', paddingRight: 10, flexShrink: 0 }}>
+                <span style={{ color: COLORS.border, fontFamily: MONO, fontSize: 10.5, width: 28, textAlign: 'right', paddingRight: 10, flexShrink: 0 }}>
                   {line.n}
                 </span>
-                <span style={{ color: line.hl ?? C.text, fontFamily: MONO, fontSize: 10.5, opacity: line.hl ? 1 : 0.8 }}>
+                <span style={{ color: line.hl ?? COLORS.text, fontFamily: MONO, fontSize: 10.5, opacity: line.hl ? 1 : 0.8 }}>
                   {line.text}
                 </span>
               </div>
@@ -201,7 +197,7 @@ function Scene3ReviewResults() {
         </div>
 
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 10 }}>
-          <div style={{ color: C.text, fontFamily: SANS, fontSize: 14, fontWeight: 600, marginBottom: 2 }}>
+          <div style={{ color: COLORS.text, fontFamily: SANS, fontSize: 14, fontWeight: 600, marginBottom: 2 }}>
             3 issues found
           </div>
           {comments.map(c => {
@@ -210,7 +206,7 @@ function Scene3ReviewResults() {
             return (
               <div key={c.line} style={{
                 opacity: op, transform: `translateY(${ty}px)`,
-                background: C.surface,
+                background: COLORS.surface,
                 border: `1px solid ${c.color}40`,
                 borderLeft: `3px solid ${c.color}`,
                 borderRadius: 8,
@@ -220,9 +216,9 @@ function Scene3ReviewResults() {
                   <span style={{ background: `${c.color}22`, color: c.color, fontFamily: MONO, fontSize: 10, padding: '2px 6px', borderRadius: 4 }}>
                     {c.label}
                   </span>
-                  <span style={{ color: C.muted, fontFamily: MONO, fontSize: 10.5 }}>Line {c.line}</span>
+                  <span style={{ color: COLORS.muted, fontFamily: MONO, fontSize: 10.5 }}>Line {c.line}</span>
                 </div>
-                <div style={{ color: C.text, fontFamily: SANS, fontSize: 12.5, lineHeight: 1.4 }}>{c.msg}</div>
+                <div style={{ color: COLORS.text, fontFamily: SANS, fontSize: 12.5, lineHeight: 1.4 }}>{c.msg}</div>
               </div>
             )
           })}
@@ -238,9 +234,9 @@ function Scene4ApplyFixes() {
   const opacity = fade(frame, 0, 70, 10)
 
   const fixes = [
-    { label: 'Security',    msg: 'Parameterize SQL query',          color: C.red,    range: [10, 32] },
-    { label: 'Type Error',  msg: 'Add optional chaining ?.map()',   color: C.yellow, range: [28, 50] },
-    { label: 'Performance', msg: 'Replace loop with batchGetTags()', color: C.blue,   range: [46, 66] },
+    { label: 'Security',    msg: 'Parameterize SQL query',          color: COLORS.red,    range: [10, 32] },
+    { label: 'Type Error',  msg: 'Add optional chaining ?.map()',   color: COLORS.yellow, range: [28, 50] },
+    { label: 'Performance', msg: 'Replace loop with batchGetTags()', color: COLORS.blue,   range: [46, 66] },
   ]
 
   const labelOpacity = interpolate(frame, [4, 14], [0, 1], { extrapolateLeft: 'clamp', extrapolateRight: 'clamp' })
@@ -248,7 +244,7 @@ function Scene4ApplyFixes() {
   return (
     <AbsoluteFill style={{ opacity, padding: 40, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
       <div style={{ maxWidth: 540, width: '100%' }}>
-        <div style={{ color: C.accent, fontFamily: MONO, fontSize: 13, marginBottom: 20, opacity: labelOpacity }}>
+        <div style={{ color: COLORS.accent, fontFamily: MONO, fontSize: 13, marginBottom: 20, opacity: labelOpacity }}>
           Applying fixes…
         </div>
 
@@ -257,7 +253,7 @@ function Scene4ApplyFixes() {
           const done = progress >= 1
           return (
             <div key={i} style={{
-              background: C.surface,
+              background: COLORS.surface,
               border: `1px solid ${C.border}`,
               borderRadius: 8,
               padding: '13px 16px',
@@ -268,11 +264,11 @@ function Scene4ApplyFixes() {
                   <span style={{ background: `${fix.color}22`, color: fix.color, fontFamily: MONO, fontSize: 10, padding: '2px 6px', borderRadius: 4 }}>
                     {fix.label}
                   </span>
-                  <span style={{ color: C.text, fontFamily: SANS, fontSize: 13 }}>{fix.msg}</span>
+                  <span style={{ color: COLORS.text, fontFamily: SANS, fontSize: 13 }}>{fix.msg}</span>
                 </div>
                 <div style={{
                   width: 20, height: 20, borderRadius: '50%',
-                  background: done ? C.green : C.border,
+                  background: done ? COLORS.green : COLORS.border,
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                   flexShrink: 0,
                 }}>
@@ -283,8 +279,8 @@ function Scene4ApplyFixes() {
                   )}
                 </div>
               </div>
-              <div style={{ height: 3, background: C.border, borderRadius: 2 }}>
-                <div style={{ height: '100%', width: `${progress * 100}%`, background: done ? C.green : fix.color, borderRadius: 2 }} />
+              <div style={{ height: 3, background: COLORS.border, borderRadius: 2 }}>
+                <div style={{ height: '100%', width: `${progress * 100}%`, background: done ? COLORS.green : fix.color, borderRadius: 2 }} />
               </div>
             </div>
           )
@@ -306,10 +302,10 @@ function Scene5Ship() {
 
   return (
     <AbsoluteFill style={{ opacity, padding: 40, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
-      <div style={{ background: C.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 540, width: '100%' }}>
+      <div style={{ background: COLORS.surface, borderRadius: 10, border: `1px solid ${C.border}`, overflow: 'hidden', maxWidth: 540, width: '100%' }}>
         <TerminalChrome title="Claude Code" />
         <div style={{ padding: '22px 24px' }}>
-          <div style={{ color: C.accent, fontFamily: MONO, fontSize: 13.5, marginBottom: 22 }}>
+          <div style={{ color: COLORS.accent, fontFamily: MONO, fontSize: 13.5, marginBottom: 22 }}>
             <Typewriter text="> /candid-ship" startFrame={6} endFrame={24} />
           </div>
 
@@ -326,10 +322,10 @@ function Scene5Ship() {
               </svg>
             </div>
 
-            <div style={{ color: C.text, fontFamily: SANS, fontSize: 17, fontWeight: 700, marginBottom: 6 }}>
+            <div style={{ color: COLORS.text, fontFamily: SANS, fontSize: 17, fontWeight: 700, marginBottom: 6 }}>
               All issues resolved
             </div>
-            <div style={{ color: C.muted, fontFamily: SANS, fontSize: 13.5, marginBottom: 18 }}>
+            <div style={{ color: COLORS.muted, fontFamily: SANS, fontSize: 13.5, marginBottom: 18 }}>
               Shipped with confidence ✓
             </div>
 
@@ -337,7 +333,7 @@ function Scene5Ship() {
               {tags.map(tag => (
                 <span key={tag} style={{
                   background: `${C.green}1a`,
-                  color: C.green,
+                  color: COLORS.green,
                   fontFamily: MONO,
                   fontSize: 11,
                   padding: '3px 9px',
@@ -356,7 +352,7 @@ function Scene5Ship() {
 
 export default function WorkflowComposition() {
   return (
-    <AbsoluteFill style={{ background: C.bg }}>
+    <AbsoluteFill style={{ background: COLORS.bg }}>
       <Sequence from={0} durationInFrames={70}>
         <Scene1GitPush />
       </Sequence>

--- a/docs/app/components/WorkflowAnimation/WorkflowPlayer.jsx
+++ b/docs/app/components/WorkflowAnimation/WorkflowPlayer.jsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Player } from '@remotion/player'
+import WorkflowComposition from './WorkflowComposition'
+
+export default function WorkflowPlayer() {
+  return (
+    <Player
+      component={WorkflowComposition}
+      durationInFrames={390}
+      compositionWidth={800}
+      compositionHeight={450}
+      fps={30}
+      autoPlay
+      loop
+      style={{ width: '100%', aspectRatio: '16 / 9' }}
+    />
+  )
+}

--- a/docs/app/components/WorkflowAnimation/index.jsx
+++ b/docs/app/components/WorkflowAnimation/index.jsx
@@ -1,0 +1,9 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const WorkflowPlayer = dynamic(() => import('./WorkflowPlayer'), { ssr: false })
+
+export default function WorkflowAnimation() {
+  return <WorkflowPlayer />
+}

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -611,6 +611,28 @@ header a:has(.logo):hover {
   background: transparent;
 }
 
+.hero-animation {
+  width: 100%;
+  max-width: 800px;
+  margin: 2.5rem auto 0;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: var(--shadow-elevated);
+  border: 1px solid var(--border-color);
+}
+
+@media (max-width: 768px) {
+  .hero-animation {
+    border-radius: 8px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-animation {
+    display: none;
+  }
+}
+
 /* ===== Features Section ===== */
 .features-section {
   padding: var(--spacing-section) 0;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "candid-docs",
       "version": "1.0.0",
       "dependencies": {
+        "@remotion/player": "^4.0.451",
         "fathom-client": "^3.7.2",
         "next": "^16.1.3",
         "next-mdx-remote": "^6.0.0",
@@ -15,7 +16,8 @@
         "nextra-theme-docs": "^4.6.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
-        "react-github-btn": "^1.4.0"
+        "react-github-btn": "^1.4.0",
+        "remotion": "^4.0.451"
       },
       "devDependencies": {
         "pagefind": "^1.4.0"
@@ -1387,6 +1389,19 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@remotion/player": {
+      "version": "4.0.451",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.451.tgz",
+      "integrity": "sha512-mJSaWHsMQuDXVVVh6UVBySBzzzqeSI+MHUuS+6hk/CrqZwBz1CQnsrtFZcjcnBpY40ao+ZqMA6uTEgs9n34YlQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.451"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@shikijs/core": {
@@ -5838,6 +5853,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remotion": {
+      "version": "4.0.451",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.451.tgz",
+      "integrity": "sha512-uTku1RmytCk50ZtPEoTdmB/4Erb+nH85vT3jkCLWQCaG9qWXxp2XAJ+eL7EfsCUyast2umZm4vdrdKXVxbeDMQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/retext": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@remotion/player": "^4.0.451",
     "fathom-client": "^3.7.2",
     "next": "^16.1.3",
     "next-mdx-remote": "^6.0.0",
@@ -21,7 +22,8 @@
     "nextra-theme-docs": "^4.6.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "react-github-btn": "^1.4.0"
+    "react-github-btn": "^1.4.0",
+    "remotion": "^4.0.451"
   },
   "devDependencies": {
     "pagefind": "^1.4.0"


### PR DESCRIPTION
## Summary
- Add a 13-second looping Remotion animation to the homepage hero showing the full Candid workflow (git push → /candid-review → review results → apply fixes → /candid-ship)
- Uses `@remotion/player` with `dynamic(() => import(...), { ssr: false })` to avoid SSR issues
- Animation respects `prefers-reduced-motion` (hidden via CSS) and is `aria-hidden` for screen readers

## Verification
- Install: SKIPPED
- Review: PASS — 1 iteration, 3 issues fixed
- Build: SKIPPED
- Tests: SKIPPED

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*