### PR TITLE
Fix 10 docs site a11y/UX issues from chrome-qa pass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/docs/app/(marketing)/brand/BrandPageClient.jsx
+++ b/docs/app/(marketing)/brand/BrandPageClient.jsx
@@ -272,7 +272,11 @@ export default function BrandPageClient() {
             </div>
             <span className="brand-variation-label">Full Logo</span>
             <span className="brand-variation-usage">Primary usage</span>
-            <button className="brand-download-btn" onClick={() => downloadSVG('full')}>
+            <button
+              className="brand-download-btn"
+              onClick={() => downloadSVG('full')}
+              aria-label="Download full logo SVG"
+            >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
                 <polyline points="7 10 12 15 17 10"/>
@@ -289,7 +293,11 @@ export default function BrandPageClient() {
             </div>
             <span className="brand-variation-label">Icon Only</span>
             <span className="brand-variation-usage">Favicons, small spaces</span>
-            <button className="brand-download-btn" onClick={() => downloadSVG('icon')}>
+            <button
+              className="brand-download-btn"
+              onClick={() => downloadSVG('icon')}
+              aria-label="Download icon-only logo SVG"
+            >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
                 <polyline points="7 10 12 15 17 10"/>
@@ -304,7 +312,11 @@ export default function BrandPageClient() {
             </div>
             <span className="brand-variation-label">Wordmark</span>
             <span className="brand-variation-usage">Text-heavy contexts</span>
-            <button className="brand-download-btn" onClick={() => downloadSVG('wordmark')}>
+            <button
+              className="brand-download-btn"
+              onClick={() => downloadSVG('wordmark')}
+              aria-label="Download wordmark SVG"
+            >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
                 <polyline points="7 10 12 15 17 10"/>

--- a/docs/app/(marketing)/brand/page.jsx
+++ b/docs/app/(marketing)/brand/page.jsx
@@ -1,7 +1,7 @@
 import BrandPageClient from './BrandPageClient'
 
 export const metadata = {
-  title: 'Brand Guidelines | Candid',
+  title: 'Brand Guidelines',
   description: 'Official brand guidelines for Candid - logos, colors, typography, and voice.',
   robots: {
     index: false,

--- a/docs/app/(marketing)/layout.jsx
+++ b/docs/app/(marketing)/layout.jsx
@@ -97,7 +97,7 @@ export default function MarketingLayout({ children }) {
       </main>
       <footer className="marketing-footer">
         <p>
-          MIT {new Date().getFullYear()} ©{' '}
+          MIT © {new Date().getFullYear()}{' '}·{' '}
           <a
             href="https://www.fritterfactory.com"
             target="_blank"

--- a/docs/app/(marketing)/privacy/page.jsx
+++ b/docs/app/(marketing)/privacy/page.jsx
@@ -1,6 +1,18 @@
 export const metadata = {
-  title: 'Privacy | Candid',
+  title: 'Privacy',
   description: 'Privacy policy for candid.tools — what data is collected and how.',
+  openGraph: {
+    title: 'Privacy | Candid',
+    description: 'Privacy policy for candid.tools — what data is collected and how.',
+    url: 'https://www.candid.tools/privacy',
+    siteName: 'Candid',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Privacy | Candid',
+    description: 'Privacy policy for candid.tools — what data is collected and how.',
+  },
 }
 
 export default function PrivacyPage() {

--- a/docs/app/components/Pre.jsx
+++ b/docs/app/components/Pre.jsx
@@ -1,21 +1,34 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { trackEvent } from './trackEvent'
 
 export default function Pre({ children, trackingId, ...props }) {
   const [copied, setCopied] = useState(false)
+  const [snippet, setSnippet] = useState('')
   const preRef = useRef(null)
+
+  useEffect(() => {
+    const code = preRef.current?.textContent || ''
+    const firstLine = code.split('\n').find(l => l.trim()) || ''
+    setSnippet(firstLine.trim().slice(0, 40))
+  }, [])
 
   const handleCopy = async () => {
     const code = preRef.current?.textContent || ''
     await navigator.clipboard.writeText(code)
     setCopied(true)
-    // Use trackingId if provided, otherwise use first 30 chars of code
     const identifier = trackingId || code.slice(0, 30).replace(/\s+/g, '_').replace(/[^a-zA-Z0-9_]/g, '')
     trackEvent(`code_copy_${identifier}`)
     setTimeout(() => setCopied(false), 2000)
   }
+
+  const labelHint = trackingId || snippet
+  const ariaLabel = copied
+    ? 'Copied!'
+    : labelHint
+      ? `Copy code: ${labelHint}`
+      : 'Copy code'
 
   return (
     <div className="code-block-wrapper">
@@ -25,7 +38,7 @@ export default function Pre({ children, trackingId, ...props }) {
       <button
         className="copy-button"
         onClick={handleCopy}
-        aria-label={copied ? 'Copied!' : 'Copy code'}
+        aria-label={ariaLabel}
       >
         {copied ? (
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/docs/app/components/ThemeButtonA11y.jsx
+++ b/docs/app/components/ThemeButtonA11y.jsx
@@ -4,12 +4,22 @@ import { useEffect } from 'react'
 export default function ThemeButtonA11y() {
   useEffect(() => {
     function patch() {
-      const btn = document.querySelector('button[aria-haspopup="listbox"]:not([aria-label])')
-      if (btn) {
-        btn.setAttribute('aria-label', 'Switch theme')
-        observer.disconnect()
-      }
+      document
+        .querySelectorAll('button[aria-haspopup="listbox"]:not([aria-label])')
+        .forEach(btn => {
+          const title = btn.getAttribute('title')
+          if (title === 'Change theme') {
+            btn.setAttribute('aria-label', 'Switch theme')
+          } else {
+            btn.setAttribute('aria-label', 'Select copy format')
+          }
+        })
+
+      document
+        .querySelectorAll('nav a[href*="slack.com"]:not([aria-label])')
+        .forEach(a => a.setAttribute('aria-label', 'Join Candid on Slack'))
     }
+
     const observer = new MutationObserver(patch)
     observer.observe(document.body, { childList: true, subtree: true })
     patch()

--- a/docs/app/components/ThemeButtonA11y.jsx
+++ b/docs/app/components/ThemeButtonA11y.jsx
@@ -10,7 +10,7 @@ export default function ThemeButtonA11y() {
           const title = btn.getAttribute('title')
           if (title === 'Change theme') {
             btn.setAttribute('aria-label', 'Switch theme')
-          } else {
+          } else if (btn.parentElement?.textContent?.includes('Copy page')) {
             btn.setAttribute('aria-label', 'Select copy format')
           }
         })

--- a/docs/app/docs/core-features/_meta.js
+++ b/docs/app/docs/core-features/_meta.js
@@ -1,5 +1,5 @@
 export default {
-  index: 'Overview',
+  index: 'Core Features Overview',
   'tone-selection': 'Tone Selection',
   'focus-modes': 'Focus Modes',
   'technical-md': 'Technical.md',

--- a/docs/app/docs/how-to-guides/_meta.js
+++ b/docs/app/docs/how-to-guides/_meta.js
@@ -1,5 +1,5 @@
 export default {
-  index: 'Overview',
+  index: 'How-to Guides Overview',
   'team-setup': 'Setting Up for Your Team',
   conductor: 'Using with Conductor',
   'custom-standards': 'Creating Custom Standards',

--- a/docs/app/docs/layout.jsx
+++ b/docs/app/docs/layout.jsx
@@ -28,7 +28,7 @@ export default async function DocsLayout({ children }) {
       docsRepositoryBase="https://github.com/ron-myers/candid/tree/main/docs"
       footer={
         <Footer>
-          MIT {new Date().getFullYear()} ©{' '}
+          MIT © {new Date().getFullYear()}{' '}·{' '}
           <a href="https://www.fritterfactory.com" target="_blank" rel="noopener noreferrer">
             Fritter Factory
           </a>

--- a/docs/app/docs/quickstart/_meta.js
+++ b/docs/app/docs/quickstart/_meta.js
@@ -1,5 +1,5 @@
 export default {
-  index: 'Overview',
+  index: 'Quickstart Overview',
   nextjs: 'Next.js',
   react: 'React',
   python: 'Python',

--- a/docs/app/docs/reference/_meta.js
+++ b/docs/app/docs/reference/_meta.js
@@ -1,5 +1,5 @@
 export default {
-  index: 'Overview',
+  index: 'Reference Overview',
   'config-options': 'Config Options',
   'file-exclusions': 'File Exclusions',
   'merge-targets': 'Merge Targets',

--- a/docs/app/docs/resources/_meta.js
+++ b/docs/app/docs/resources/_meta.js
@@ -1,5 +1,5 @@
 export default {
-  index: 'Overview',
+  index: 'Resources Overview',
   changelog: 'Changelog',
   examples: 'Example Reviews',
 }

--- a/docs/app/docs/tips-troubleshooting/_meta.js
+++ b/docs/app/docs/tips-troubleshooting/_meta.js
@@ -1,4 +1,4 @@
 export default {
-  index: 'Overview',
+  index: 'Tips & Troubleshooting Overview',
   faq: 'FAQ & Known Issues',
 }

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -995,6 +995,12 @@ header a:has(.logo):hover {
   opacity: 1;
 }
 
+@media (hover: none) {
+  .copy-button {
+    opacity: 1;
+  }
+}
+
 .copy-button:hover {
   background: rgba(255, 255, 255, 0.2);
   color: #1a1612;


### PR DESCRIPTION
## Summary
- Apply candid-review fixes (1 issue)
- Fix 10 docs site issues from chrome-qa pass (a11y, copy, ux)

## Findings addressed (from `.context/findings/2026-04-25-candid-tools-docs-qa.json`)

| Finding | Sev | What |
|---|---|---|
| F-0551a81d | P1 | Copy-page format-selector dropdown gets aria-label "Select copy format" |
| F-28dc1c69 | P1 | Slack icon link gets aria-label "Join Candid on Slack" |
| F-7f944950 | P2 | Copy buttons visible on touch devices via `@media (hover: none)` |
| F-b17c468d | P2 | Pre.jsx aria-label includes first line of code so each button is distinct |
| F-816b8a3d | P2 | ThemeButtonA11y now patches all theme toggle instances (querySelectorAll, no premature disconnect) |
| F-5dd088a8 | P2 | Section index pages renamed "Overview" → "{Section} Overview" |
| F-bf71d4c0 | P2 | Brand SVG download buttons get distinct aria-labels per variant |
| F-2f7fe585 | P3 | Privacy & Brand titles drop redundant `\| Candid` suffix |
| F-80d395f9 | P3 | Privacy page gains OpenGraph + Twitter metadata blocks |
| F-f25f0c21 | P4 | Footer copyright fixed: "MIT 2026 ©" → "MIT © 2026 ·" |

Plus: synced `marketplace.json` from 1.16.0 → 1.17.0 (was lagging plugin.json).

## Verification
- Install: SKIPPED (not configured)
- Review: PASS — 2 iterations, 1 issue fixed (ThemeButtonA11y else branch narrowed to require "Copy page" parent context)
- Build: SKIPPED (not configured) — Vercel CI will validate
- Tests: SKIPPED (not configured)

## Test plan
- [ ] CI build succeeds on Vercel
- [ ] Verify on candid.tools after deploy: theme toggle in sidebar gets `aria-label="Switch theme"`
- [ ] Verify copy-page chevron gets `aria-label="Select copy format"`
- [ ] Verify Slack icon link in docs navbar gets `aria-label="Join Candid on Slack"`
- [ ] Verify copy buttons are visible on a touch device
- [ ] Verify each copy button reads a distinct line in screen reader
- [ ] Verify section sidebar links read "Core Features Overview" / "Reference Overview" etc.
- [ ] Verify Brand page download buttons read "Download full logo SVG" / "icon-only logo SVG" / "wordmark SVG"
- [ ] Verify privacy page title reads "Privacy | Candid" (single suffix) and OG card renders correctly
- [ ] Verify footer reads "MIT © 2026 · Fritter Factory · LinkedIn · Privacy"

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*