### PR TITLE
Homepage clarity + chrome-qa flags + ship-config recipes

### DIFF
--- a/commands/candid-chrome-qa.md
+++ b/commands/candid-chrome-qa.md
@@ -6,8 +6,29 @@ args:
   - name: url
     description: App URL to test (overrides prompted value, e.g. http://localhost:3000)
     required: false
+  - name: goal
+    description: Pre-fill the goal prompt (surface to test). Skip the interactive ask when provided.
+    required: false
+  - name: prompt
+    description: Pre-fill the QA-plan prompt (edge cases, hot spots). Skip the interactive ask when provided.
+    required: false
+  - name: routes
+    description: Comma-separated list of routes to limit the walk to (e.g. "/dashboard,/settings"). Without this, the walk follows goal+prompt.
+    required: false
+  - name: severity-floor
+    description: Persist only findings at or above this severity. One of P0|P1|P2|P3|P4|P5. Default P5 (all).
+    required: false
+  - name: viewports
+    description: Comma-separated viewports to override config defaults (e.g. "1440x900,390x844"). First = desktop, second = mobile.
+    required: false
+  - name: findings-dir
+    description: Override findings output directory. Default .context/findings.
+    required: false
   - name: mobile-only
     description: Skip desktop pass and run mobile-only (390x844). Explicit opt-in — desktop is the default and runs first otherwise.
+    required: false
+  - name: desktop-only
+    description: Skip mobile pass and run desktop-only. Counterpart to --mobile-only.
     required: false
 ---
 
@@ -17,16 +38,22 @@ Usage:
 ```
 /candid-chrome-qa                                          # Prompts for goal, prompt, and URL
 /candid-chrome-qa --url http://localhost:3000              # Skip URL prompt
-/candid-chrome-qa --mobile-only                            # Mobile pass only (rare; desktop runs first by default)
+/candid-chrome-qa --goal "Settings tabs" --prompt "Walk every tab; toggle save/cancel"
+/candid-chrome-qa --routes "/dashboard,/settings,/billing" # Limit walk to specific routes
+/candid-chrome-qa --severity-floor P2                       # Persist only P0/P1/P2 findings
+/candid-chrome-qa --viewports "1920x1080,414x896"           # Override viewport sizes
+/candid-chrome-qa --findings-dir .qa/runs                   # Custom output directory
+/candid-chrome-qa --mobile-only                             # Mobile pass only (skip desktop)
+/candid-chrome-qa --desktop-only                            # Desktop pass only (skip mobile)
 ```
 
-When invoked, you'll be asked for:
+When invoked, you'll be asked for any inputs not provided via flags:
 - **goal** — what surface to test (e.g. "Agent Config tabs, all 16")
 - **prompt** — free-form QA plan (edge cases, hot spots, recently-changed surfaces)
 - **app URL** — verified before any work begins (curl health check)
 
 Output:
-- **JSON findings file** at `.context/findings/<YYYY-MM-DD>-<slug>.json` — v2.0 schema with `context`, `findings`, and end-of-pass `summary` blocks
+- **JSON findings file** at `<findings-dir>/<YYYY-MM-DD>-<slug>.json` — v2.0 schema with `context`, `findings`, and end-of-pass `summary` blocks
 - **Stdout summary** at end of pass — severity counts, category breakdown, and titles + URLs of every P0/P1 finding
 
 Requires the `mcp__claude-in-chrome__*` tools to be available (auto-loaded via ToolSearch on first use).

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -456,7 +456,7 @@ export default function HomePage() {
         <Link
           href="/docs/reference/ship-config"
           className="btn-secondary"
-          onClick={() => trackEvent(EVENTS.LEARN_MORE_CLICK)}
+          onClick={() => trackEvent(EVENTS.SHIP_CONFIG_CTA_CLICK)}
         >
           See the full ship-config reference <span className="btn-arrow">→</span>
         </Link>

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -48,6 +48,7 @@ export default function HomePage() {
   // Refs for scroll-triggered animations
   const featuresRef = useRef(null)
   const howItWorksRef = useRef(null)
+  const configRef = useRef(null)
   const qaFlowRef = useRef(null)
   const commandsRef = useRef(null)
   const communityRef = useRef(null)
@@ -82,7 +83,7 @@ export default function HomePage() {
 
     const observer = new IntersectionObserver(observerCallback, observerOptions)
 
-    const refs = [featuresRef, howItWorksRef, qaFlowRef, commandsRef, communityRef, faqRef, ctaRef]
+    const refs = [featuresRef, howItWorksRef, configRef, qaFlowRef, commandsRef, communityRef, faqRef, ctaRef]
     refs.forEach(ref => {
       if (ref.current) {
         observer.observe(ref.current)
@@ -128,19 +129,19 @@ export default function HomePage() {
         <h1
           style={getHeroAnimationStyle(heroLoaded, 100)}
         >
-          Code Review for the AI Era
+          The full review → ship → QA → fix loop, in one plugin
         </h1>
         <p
           className="hero-subtitle"
           style={getHeroAnimationStyle(heroLoaded, 200)}
         >
-          Claude Code writes fast. Now you review faster.
+          Candid runs structured code review, ships your branch, QAs the live app in real Chrome, and turns findings into PRs — all from inside Claude Code.
         </p>
         <p
           className="hero-tagline"
           style={getHeroAnimationStyle(heroLoaded, 200)}
         >
-          And with more confidence.
+          One config. Your standards. Your tone. Your gates.
         </p>
         <div
           className="hero-cta"
@@ -151,7 +152,7 @@ export default function HomePage() {
             className="btn-primary"
             onClick={() => trackEvent(EVENTS.GET_STARTED_CLICK)}
           >
-            Get Started
+            Get Started in 5 minutes
             <svg className="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M6 3L11 8L6 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
             </svg>
@@ -182,7 +183,7 @@ export default function HomePage() {
 
       <section className="demo-section">
         <span className="section-badge">SEE IT IN ACTION</span>
-        <h2>Candid Code Review Workflow</h2>
+        <h2>What a review actually looks like</h2>
         <div className="screenshot-grid">
           {SCREENSHOTS.map((screenshot, index) => (
             <div key={index} className="screenshot-item">
@@ -283,65 +284,75 @@ export default function HomePage() {
 
       <section className="features-section scroll-animate" ref={featuresRef}>
         <h2>Features</h2>
+
+        <h3 className="feature-group-heading">Review</h3>
         <div className="card-grid">
           <Link href="/docs/core-features/technical-md" className="card-link">
             <div className="card">
               <h3>Technical.md</h3>
-              <p>Define coding standards in markdown. Run <code>/candid-init</code> to auto-generate from your codebase, or use a template.</p>
+              <p>Write your standards in markdown. <code>/candid-init</code> generates them from your codebase.</p>
             </div>
           </Link>
           <Link href="/docs/core-features/focus-modes" className="card-link">
             <div className="card">
               <h3>Focus Modes</h3>
-              <p>Target specific review areas: <code>--focus security</code>, <code>--focus performance</code>, <code>--focus architecture</code>, or <code>--focus edge-case</code>.</p>
+              <p>Review only what matters: <code>--focus security</code>, <code>performance</code>, <code>architecture</code>, <code>edge-case</code>.</p>
             </div>
           </Link>
           <Link href="/docs/core-features/tone-selection" className="card-link">
             <div className="card">
               <h3>Tone Selection</h3>
-              <p>Choose <code>--harsh</code> for brutal honesty or <code>--constructive</code> for Radical Candor-style feedback. Set defaults in config.</p>
+              <p><code>--harsh</code> says it straight. <code>--constructive</code> cares but doesn&apos;t soften. Set the default in config.</p>
             </div>
           </Link>
           <Link href="/docs/core-features/re-review" className="card-link">
             <div className="card">
               <h3>Re-Review</h3>
-              <p>Run <code>--re-review</code> to compare against your last review. See what's fixed, what's still present, and what's new.</p>
-            </div>
-          </Link>
-          <Link href="/docs/core-features/auto-commit" className="card-link">
-            <div className="card">
-              <h3>Auto-Commit</h3>
-              <p>Add <code>--auto-commit</code> to commit applied fixes with detailed messages listing each fix location and severity.</p>
-            </div>
-          </Link>
-          <Link href="/docs/reference/config-options" className="card-link">
-            <div className="card">
-              <h3>Config Hierarchy</h3>
-              <p>CLI flags override project config (<code>.candid/config.json</code>), which overrides user config (<code>~/.candid/config.json</code>).</p>
+              <p><code>--re-review</code> diffs against your last pass. See what&apos;s fixed, what&apos;s still broken, what&apos;s new.</p>
             </div>
           </Link>
           <Link href="/docs/core-features/decision-register" className="card-link">
             <div className="card">
               <h3>Decision Register</h3>
-              <p>Track questions raised during reviews and their resolutions. Prior answers are reused automatically so the same question is never asked twice.</p>
+              <p>Answers persist. The same question never asks twice — across reviews, across sessions.</p>
+            </div>
+          </Link>
+        </div>
+
+        <h3 className="feature-group-heading">Ship</h3>
+        <div className="card-grid">
+          <Link href="/docs/core-features/auto-commit" className="card-link">
+            <div className="card">
+              <h3>Auto-Commit</h3>
+              <p><code>--auto-commit</code> commits applied fixes with messages that list every change and its severity.</p>
+            </div>
+          </Link>
+          <Link href="/docs/reference/ship-config" className="card-link">
+            <div className="card">
+              <h3>Configurable Ship Pipeline</h3>
+              <p>Install, build, test, review, PR, auto-merge, deploy hook — every step is opt-in via <code>.candid/config.json</code>.</p>
             </div>
           </Link>
           <Link href="/docs/core-features/candid-ship#issue-tracker-integration" className="card-link">
             <div className="card">
-              <h3>Issue Tracker Integration</h3>
-              <p>Ship a branch and <code>/candid-ship</code> automatically moves the linked issue (Linear today, more soon) to <code>In Review</code>. Provider, state, and prompt are configurable.</p>
+              <h3>Linear Integration</h3>
+              <p><code>/candid-ship</code> moves the linked Linear issue to <code>In Review</code> on PR open. State, prompt, and team prefixes are yours.</p>
             </div>
           </Link>
+        </div>
+
+        <h3 className="feature-group-heading">QA</h3>
+        <div className="card-grid">
           <Link href="/docs/core-features/candid-chrome-qa" className="card-link">
             <div className="card">
               <h3>Chrome QA</h3>
-              <p>Drive a real Chrome session with <code>/candid-chrome-qa</code>. Walks your app like a real user across desktop and mobile, writes structured findings JSON for triage.</p>
+              <p><code>/candid-chrome-qa</code> drives real Chrome — desktop and mobile — and writes findings as structured JSON.</p>
             </div>
           </Link>
           <Link href="/docs/core-features/candid-chrome-qa-fix" className="card-link">
             <div className="card">
               <h3>Chrome QA Fix</h3>
-              <p>Pick which QA findings to fix with <code>/candid-chrome-qa-fix</code>. Batched PR, one PR per finding via Conductor, or file Linear issues — your choice.</p>
+              <p>Pick findings to fix. Batched PR, one PR per finding via Conductor, or file Linear issues — your call.</p>
             </div>
           </Link>
         </div>
@@ -349,68 +360,145 @@ export default function HomePage() {
 
       <section className="how-it-works scroll-animate" ref={howItWorksRef}>
         <span className="section-badge">HOW IT WORKS</span>
+        <h2>The loop</h2>
+        <p className="hero-tagline">
+          Install once. Then run the four commands that take a branch from review to shipped.
+        </p>
         <ol className="steps-list">
           <li>
             <div className="step-content">
-              <strong>Install Candid.</strong>
-              <span>Add Candid to Claude Code with two commands from your terminal.</span>
+              <strong>Install + init.</strong>
+              <span>Add Candid to Claude Code, then generate a <code>Technical.md</code> tuned to your codebase.</span>
               <Pre className="step-code" trackingId="step_install">
-                <code>{`npx skills add https://github.com/ron-myers/candid`}</code>
-              </Pre>
-            </div>
-          </li>
-          <li>
-            <div className="step-content">
-              <strong>Initialize your Project.</strong>
-              <span>Generate a Technical.md for your codebase.</span>
-              <Pre className="step-code" trackingId="step_init">
-                <code>/candid-init</code>
+                <code>{`npx skills add https://github.com/ron-myers/candid
+/candid-init`}</code>
               </Pre>
             </div>
           </li>
           <li>
             <div className="step-content">
               <strong>Review.</strong>
-              <span>Run the command to analyze your changes.</span>
+              <span>Tell Candid <em>what kind</em> of review you want — flags pick tone and focus, freeform text after sets the lens.</span>
               <Pre className="step-code" trackingId="step_review">
-                <code>/candid-review</code>
+                <code>{`/candid-review --harsh review this branch like a
+  skeptical CTO — what would block a launch?`}</code>
+              </Pre>
+            </div>
+          </li>
+          <li>
+            <div className="step-content">
+              <strong>Ship.</strong>
+              <span>Pipeline runs from <code>.candid/config.json</code>. Add intent for the review pass that gates the PR.</span>
+              <Pre className="step-code" trackingId="step_ship">
+                <code>{`/candid-ship double-check no secrets, no
+  console.logs, no commented-out code before opening PR`}</code>
+              </Pre>
+            </div>
+          </li>
+          <li>
+            <div className="step-content">
+              <strong>QA + fix.</strong>
+              <span>Drive real Chrome with a goal in plain English. Then pick findings to ship — batched PR, one PR per finding, or Linear issues.</span>
+              <Pre className="step-code" trackingId="step_qa">
+                <code>{`/candid-chrome-qa --goal "first-time signup flow" \\
+  --prompt "where would a new user get stuck?"
+
+/candid-chrome-qa-fix --strategy batched fix the
+  P0/P1 blockers, file the rest as Linear issues`}</code>
               </Pre>
             </div>
           </li>
         </ol>
       </section>
 
+      <section className="config-showcase scroll-animate" ref={configRef}>
+        <span className="section-badge">CONFIG</span>
+        <h2>One config file. Your whole pipeline.</h2>
+        <p className="hero-tagline">
+          Tone, focus, ship steps, fast-ship toggles, Linear — all in <code>.candid/config.json</code>. No CLI flag hunting.
+        </p>
+        <div className="config-showcase-grid">
+          <Pre className="config-snippet" trackingId="config_showcase">
+            <code>{`{
+  "tone": "harsh",
+  "focus": "security",
+  "exclude": ["*.generated.ts"],
+  "ship": {
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
+    "targetBranch": "stable",
+    "autoMerge": true,
+    "postMergeCommand": "curl -X POST $DEPLOY_HOOK",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["ENG"],
+      "state": "In Review"
+    }
+  },
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
+  }
+}`}</code>
+          </Pre>
+          <ul className="config-annotations">
+            <li><code>tone: &quot;harsh&quot;</code> — every <code>/candid-review</code> uses brutal honesty by default.</li>
+            <li><code>focus: &quot;security&quot;</code> — reviews target security unless you override per-run.</li>
+            <li><code>ship.installCommand</code> — runs before build on every <code>/candid-ship</code>.</li>
+            <li><code>ship.autoMerge: true</code> — PR auto-merges once checks pass.</li>
+            <li><code>ship.postMergeCommand</code> — deploy webhook fires after merge.</li>
+            <li><code>ship.issueTracker.enabled</code> — Linear issue moves to <code>In Review</code> on PR open.</li>
+            <li><code>fastShip.build + autoMerge</code> — <code>/candid-fast-ship</code> skips review and tests for trivial PRs.</li>
+          </ul>
+        </div>
+        <Link
+          href="/docs/reference/ship-config"
+          className="btn-secondary"
+          onClick={() => trackEvent(EVENTS.LEARN_MORE_CLICK)}
+        >
+          See the full ship-config reference <span className="btn-arrow">→</span>
+        </Link>
+      </section>
+
       <section className="how-it-works scroll-animate" ref={qaFlowRef}>
         <span className="section-badge">CHROME QA FLOW</span>
-        <h2>From bugs found to bugs fixed</h2>
+        <h2>Find the bug. Fix the bug. Ship the bug fix.</h2>
         <p className="hero-tagline">
           QA your running app, then turn findings into shipped fixes — without leaving Claude Code.
         </p>
         <ol className="steps-list">
           <li>
             <div className="step-content">
-              <strong>QA your app.</strong>
-              <span>Drive a real Chrome session, walk every target across desktop and mobile, and write structured findings to JSON.</span>
+              <strong>QA your app — as a frustrated first-time user.</strong>
+              <span>Tell Candid <em>who</em> is walking the app. The persona shapes what counts as a finding — confused user, paranoid security engineer, fussy designer.</span>
               <Pre className="step-code" trackingId="qa_step_chrome_qa">
-                <code>/candid-chrome-qa</code>
+                <code>{`/candid-chrome-qa --goal "signup → first action" \\
+  --prompt "walk this as a frustrated first-time user
+  who has never seen the product. Where do you bounce?"`}</code>
               </Pre>
             </div>
           </li>
           <li>
             <div className="step-content">
-              <strong>Pick what to fix.</strong>
-              <span>Multi-select findings by severity or category. Choose batched PR, parallel PRs via Conductor deep links, local-only, or issues-only.</span>
+              <strong>Pick what to fix — as the engineer on call.</strong>
+              <span>Filter by severity, category, or persona. Pick the strategy: batched PR, one PR per finding, local-only, or issues-only.</span>
               <Pre className="step-code" trackingId="qa_step_chrome_qa_fix">
-                <code>/candid-chrome-qa-fix</code>
+                <code>{`/candid-chrome-qa-fix --severity P0,P1 fix the
+  blockers like an engineer on call — minimal diffs,
+  no refactors, ship fast`}</code>
               </Pre>
             </div>
           </li>
           <li>
             <div className="step-content">
-              <strong>Ship it — with issues linked.</strong>
-              <span>Files one Linear issue per finding before any code change, then opens PRs that link back to the tracker. Re-runs are safe — findings are deduplicated by ID.</span>
+              <strong>Ship it — as the PM filing the backlog.</strong>
+              <span>File a Linear issue per finding before touching code, then ship the PRs that link back. Re-runs dedup by ID.</span>
               <Pre className="step-code" trackingId="qa_step_ship">
-                <code>/candid-chrome-qa-fix --create-issues --strategy batched</code>
+                <code>{`/candid-chrome-qa-fix --create-issues --strategy batched
+  triage like a PM — group related findings, write
+  user-facing titles, link back to the QA pass`}</code>
               </Pre>
             </div>
           </li>
@@ -421,24 +509,32 @@ export default function HomePage() {
         <span className="section-badge">SLASH COMMANDS</span>
         <ul className="commands-list">
           <li>
-            <code>/candid-review</code>
-            <span>Run a code review on your changes with configurable tone and focus areas.</span>
+            <code>/candid-init</code>
+            <span>Generate <code>Technical.md</code> + <code>.candid/config.json</code> from your codebase.</span>
           </li>
           <li>
-            <code>/candid-init</code>
-            <span>Generate a Technical.md file by analyzing your codebase structure.</span>
+            <code>/candid-review</code>
+            <span>Review your changes. Pick tone (<code>--harsh</code>/<code>--constructive</code>) and focus area.</span>
+          </li>
+          <li>
+            <code>/candid-ship</code>
+            <span>Run install/build/test, open the PR, optionally auto-merge and update Linear.</span>
+          </li>
+          <li>
+            <code>/candid-fast-ship</code>
+            <span>Minimal ship — only steps you opted into in <code>fastShip</code> config run.</span>
           </li>
           <li>
             <code>/candid-chrome-qa</code>
-            <span>Drive a real Chrome session against your running web app and write structured findings JSON.</span>
+            <span>Walk your running app in real Chrome (desktop + mobile). Filter by route, severity, viewport.</span>
           </li>
           <li>
             <code>/candid-chrome-qa-fix</code>
-            <span>Pick QA findings to fix and ship them — batched PR, parallel PRs via Conductor, or Linear issues only.</span>
+            <span>Pick findings to fix. Batched PR, one PR per finding via Conductor, or Linear issues only.</span>
           </li>
           <li>
             <code>/candid-validate-standards</code>
-            <span>Check your Technical.md for vague rules and linter overlaps.</span>
+            <span>Lint your <code>Technical.md</code> for vague rules and linter overlaps.</span>
           </li>
         </ul>
       </section>
@@ -466,31 +562,37 @@ export default function HomePage() {
           <div className="faq-item">
             <details>
               <summary>Does Candid work with any language?</summary>
-              <p>Yes, Candid reviews code in any language Claude Code supports. Your Technical.md standards can be language-specific or universal.</p>
+              <p>Any language Claude Code reads. Your Technical.md standards can be language-specific or universal.</p>
             </details>
           </div>
           <div className="faq-item">
             <details>
               <summary>How does Candid pay for Claude Code?</summary>
-              <p>Candid uses Claude Code however you're already logged in. If you're using an API key, Candid uses that. If you're on Claude Pro or Max, Candid uses that.</p>
+              <p>It uses whatever Claude Code is already logged into — your API key, Pro, or Max plan. No separate billing.</p>
             </details>
           </div>
           <div className="faq-item">
             <details>
-              <summary>Can I use Candid with my team?</summary>
-              <p>Yes. Share your Technical.md and candid.config.json in your repo. Everyone gets the same standards and configuration automatically.</p>
+              <summary>Can my team share a config?</summary>
+              <p>Commit <code>Technical.md</code> and <code>.candid/config.json</code> to your repo. Every teammate gets the same standards, tone, and ship pipeline automatically.</p>
             </details>
           </div>
           <div className="faq-item">
             <details>
-              <summary>What's the difference between Harsh and Constructive tone?</summary>
-              <p>Harsh mode is brutally honest—great for finding issues you might miss. Constructive mode is caring but direct, based on Radical Candor principles.</p>
+              <summary>Harsh vs. Constructive — what&apos;s the difference?</summary>
+              <p>Harsh is brutally honest — best for catching what you&apos;d defend if asked nicely. Constructive is direct but caring, based on Radical Candor principles.</p>
             </details>
           </div>
           <div className="faq-item">
             <details>
               <summary>What is Radical Candor?</summary>
-              <p>Radical Candor is a management philosophy that combines caring personally with challenging directly. It's about giving honest, direct feedback while genuinely caring about the person receiving it. Candid's Constructive tone is based on these principles.</p>
+              <p>A management philosophy that combines caring personally with challenging directly. Candid&apos;s constructive tone is based on it.</p>
+            </details>
+          </div>
+          <div className="faq-item">
+            <details>
+              <summary>What does <code>.candid/config.json</code> control?</summary>
+              <p>Tone, focus, file exclusions, the ship pipeline (install/build/test/auto-merge/post-merge hook), fast-ship toggles, and Linear integration. See the <Link href="/docs/reference/ship-config">ship-config reference</Link>.</p>
             </details>
           </div>
         </div>

--- a/docs/app/components/trackEvent.js
+++ b/docs/app/components/trackEvent.js
@@ -16,6 +16,7 @@ export const EVENTS = {
   GET_STARTED_CLICK: 'get_started_click',
   LEARN_MORE_CLICK: 'learn_more_click',
   DOCS_CTA_CLICK: 'docs_cta_click',
+  SHIP_CONFIG_CTA_CLICK: 'ship_config_cta_click',
 
   // External links
   GITHUB_CLICK: 'github_click',

--- a/docs/app/docs/core-features/candid-fast-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-fast-ship/page.mdx
@@ -7,6 +7,8 @@ export const metadata = {
 
 Ship low-risk changes with a minimal, opt-in workflow.
 
+> Looking for ready-to-paste config examples? See the [Ship Configuration Reference](/docs/reference/ship-config) — Recipe 4 covers fast-ship for trivial PRs and Recipe 5 mixes fast-ship with full ship for chores vs features.
+
 ## Quick Start
 
 ```

--- a/docs/app/docs/core-features/candid-ship/page.mdx
+++ b/docs/app/docs/core-features/candid-ship/page.mdx
@@ -7,6 +7,8 @@ export const metadata = {
 
 Ship your branch with one command — review, build, test, PR, and merge.
 
+> Looking for ready-to-paste config examples? See the [Ship Configuration Reference](/docs/reference/ship-config) — recipes for minimal ship, full pipeline, hands-off auto-merge, Linear integration, and post-merge deploy hooks.
+
 ## Quick Start
 
 ```

--- a/docs/app/docs/reference/_meta.js
+++ b/docs/app/docs/reference/_meta.js
@@ -1,6 +1,7 @@
 export default {
   index: 'Reference Overview',
   'config-options': 'Config Options',
+  'ship-config': 'Ship Configuration',
   'file-exclusions': 'File Exclusions',
   'merge-targets': 'Merge Targets',
   'workflow-examples': 'Workflow Examples',

--- a/docs/app/docs/reference/ship-config/page.mdx
+++ b/docs/app/docs/reference/ship-config/page.mdx
@@ -1,0 +1,278 @@
+# Ship Configuration
+
+Everything `/candid-ship` and `/candid-fast-ship` read, organized as recipes you can paste into `.candid/config.json`.
+
+For the bare schema (every key, every type), see [Config Options](/docs/reference/config-options). For the full skill behavior, see [Candid Ship](/docs/core-features/candid-ship) and [Candid Fast Ship](/docs/core-features/candid-fast-ship).
+
+## Quickstart: a working config in 30 seconds
+
+```json
+{
+  "tone": "harsh",
+  "ship": {
+    "buildCommand": "npm run build",
+    "testCommand": "npm test",
+    "targetBranch": "main"
+  }
+}
+```
+
+What this unlocks:
+
+- `/candid-review` defaults to harsh tone — no per-run flag needed.
+- `/candid-ship` runs `npm run build`, then `npm test`, then opens a PR against `main`.
+- `/candid-fast-ship` is available but does nothing extra until you opt in via the `fastShip` block (see Recipe 4).
+
+## Recipes
+
+Each recipe is a real `.candid/config.json` snippet, when to use it, and what runs when you invoke `/candid-ship` (or `/candid-fast-ship`) with it.
+
+### 1. Minimal — just create the PR
+
+**Use when:** you want Candid to open the PR but skip every check (CI handles them).
+
+```json
+{
+  "ship": {
+    "targetBranch": "main"
+  }
+}
+```
+
+**What `/candid-ship` runs:**
+1. Detects target branch (`main`).
+2. Commits any pending changes.
+3. Opens the PR via `gh pr create`.
+
+No install, build, test, review, auto-merge, or post-merge — they're all unconfigured and skipped.
+
+### 2. Full pipeline — install → build → test → review → ship
+
+**Use when:** you want every gate before code lands. Best for solo work or pre-CI environments.
+
+```json
+{
+  "tone": "constructive",
+  "ship": {
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
+    "additionalPrompt": "Pay extra attention to error handling in async code paths.",
+    "targetBranch": "main"
+  }
+}
+```
+
+**What `/candid-ship` runs:**
+1. `/candid-loop` review using constructive tone, with the additionalPrompt appended.
+2. `pnpm install`.
+3. `pnpm build`.
+4. `pnpm test`.
+5. Commit any review fixes.
+6. Open the PR against `main`.
+
+If any step fails, ship stops and surfaces the failure. The PR is not created.
+
+### 3. Hands-off — review + auto-merge + Linear update
+
+**Use when:** the branch is named after a Linear issue (e.g. `eng/ENG-123-fix-login`) and you want fully automated landing once review passes.
+
+```json
+{
+  "tone": "harsh",
+  "ship": {
+    "buildCommand": "npm run build",
+    "testCommand": "npm test",
+    "targetBranch": "main",
+    "autoMerge": true,
+    "postMergeCommand": "curl -X POST $DEPLOY_HOOK",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["ENG"],
+      "state": "In Review"
+    }
+  }
+}
+```
+
+**What `/candid-ship` runs:**
+1. Review (harsh).
+2. Build + test.
+3. Open the PR against `main`.
+4. Move Linear issue `ENG-123` from current state → `In Review`.
+5. Mark PR with `gh pr merge --squash --auto`.
+6. After auto-merge succeeds, fire the deploy webhook.
+
+If the branch name doesn't match a `teamPrefixes` entry, the Linear step skips silently — the rest still runs.
+
+### 4. Fast-ship for trivial PRs (config-driven, no review)
+
+**Use when:** typo fixes, dependency bumps, doc tweaks. You want a build check and PR creation but no review and no tests.
+
+```json
+{
+  "ship": {
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
+    "targetBranch": "main"
+  },
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
+  }
+}
+```
+
+**What `/candid-fast-ship` runs:**
+1. `pnpm build` (because `fastShip.build: true`).
+2. Open the PR.
+3. Auto-merge once checks pass.
+
+Notice: `install`, `tests`, `review`, `issueTracker`, and `postMergeCommand` are all `false`/unset in `fastShip`, so they don't run — even though the `ship` block has commands for them. **`fastShip` is opt-in for every step.**
+
+### 5. Mixed — full ship for features, fast-ship for chores
+
+**Use when:** one repo, two velocities. Features get the full gauntlet; chores fly through.
+
+```json
+{
+  "tone": "harsh",
+  "ship": {
+    "installCommand": "pnpm install",
+    "buildCommand": "pnpm build",
+    "testCommand": "pnpm test",
+    "targetBranch": "main",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["ENG"],
+      "state": "In Review"
+    }
+  },
+  "fastShip": {
+    "build": true,
+    "autoMerge": true
+  }
+}
+```
+
+**Workflow:**
+- Feature branch → `/candid-ship` → review + install + build + test + Linear → PR.
+- Chore branch (`chore/bump-typescript`) → `/candid-fast-ship` → build only → PR → auto-merge.
+
+Same config. Two commands. Two paces.
+
+### 6. Linear integration only
+
+**Use when:** you already have CI handling install/build/test, but want Candid to touch Linear on PR open.
+
+```json
+{
+  "ship": {
+    "targetBranch": "main",
+    "issueTracker": {
+      "provider": "linear",
+      "enabled": true,
+      "teamPrefixes": ["ENG", "DESIGN"],
+      "state": "Code Review",
+      "prompt": "Update issue {issueId}: set its state to \"{state}\". Update only this one issue and only its state — do not modify any other issues, fields, or properties. If the issue is already in \"{state}\", report success without action. If the issue is missing or inaccessible, report the error and stop."
+    }
+  }
+}
+```
+
+**What `/candid-ship` runs:**
+1. Open the PR.
+2. Match branch prefix (`ENG-` or `DESIGN-`) to extract issue ID.
+3. Move the issue to `Code Review` (the state name in your tracker — case-sensitive).
+
+Custom `prompt` overrides the default. **Must keep the four single-issue invariants** (single issue, single field, idempotent, no fallback search) or `/candid-ship` will reject it.
+
+### 7. Post-merge deploy hook
+
+**Use when:** auto-merge is enabled and you want a deploy command to fire automatically after the PR lands.
+
+```json
+{
+  "ship": {
+    "buildCommand": "npm run build",
+    "testCommand": "npm test",
+    "targetBranch": "main",
+    "autoMerge": true,
+    "postMergeCommand": "fly deploy --remote-only --app my-app"
+  }
+}
+```
+
+**What `/candid-ship` runs:**
+1. Build + test.
+2. PR + auto-merge.
+3. After merge succeeds: `fly deploy --remote-only --app my-app`.
+
+If `autoMerge` is `false` or the merge fails, the post-merge command **does not run**. If the post-merge command fails, ship warns but doesn't roll back the merge.
+
+---
+
+## All `ship.*` keys
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `installCommand` | string | — | Shell command to install dependencies before build. Skipped if not set. |
+| `buildCommand` | string | — | Shell command for build verification before PR. Skipped if not set. |
+| `testCommand` | string | — | Shell command for tests before PR. Skipped if not set. |
+| `targetBranch` | string | first `mergeTargetBranches` or `"main"` | PR target branch. |
+| `autoMerge` | boolean | `false` | Auto-merge PR via `gh pr merge --squash --auto`. |
+| `additionalPrompt` | string | — | Extra context appended to the review step. |
+| `postMergeCommand` | string | — | Shell command after auto-merge succeeds. Skipped if `autoMerge` is `false` or merge failed. |
+| `issueTracker` | object | — | See [issueTracker block](#shipissuetracker). |
+
+See [Candid Ship](/docs/core-features/candid-ship) for behavior details.
+
+### `ship.issueTracker`
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `provider` | string | `"linear"` | Issue tracker. Only `"linear"` today. |
+| `enabled` | boolean | `false` | Opt-in toggle. |
+| `teamPrefixes` | string[] | `["DIS", "ENG", "DISC"]` | Branch-name prefixes to match for issue ID extraction. **Edit to your team keys.** |
+| `state` | string | `"In Review"` | State name to transition to. Case-sensitive. |
+| `prompt` | string | (default with 4 invariants) | Customizable MCP prompt. Must restrict the action to a single issue. |
+
+See [Candid Ship — Issue Tracker Integration](/docs/core-features/candid-ship#issue-tracker-integration) for setup.
+
+## All `fastShip.*` keys
+
+Every key is a boolean toggle (default `false`) — except `targetBranch` (string). Commands and provider config come from the `ship` block.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `review` | boolean | `false` | Run candid-loop review. |
+| `install` | boolean | `false` | Run `ship.installCommand`. |
+| `build` | boolean | `false` | Run `ship.buildCommand`. |
+| `tests` | boolean | `false` | Run `ship.testCommand`. |
+| `issueTracker` | boolean | `false` | Update issue tracker per `ship.issueTracker`. |
+| `autoMerge` | boolean | `false` | Auto-merge PR. |
+| `postMergeCommand` | boolean | `false` | Run `ship.postMergeCommand` after auto-merge. |
+| `targetBranch` | string | inherits from `ship.targetBranch` | Override PR target branch. |
+
+A toggle is silently skipped if its dependency is missing — `fastShip.build: true` with no `ship.buildCommand` does nothing, no error.
+
+See [Candid Fast Ship](/docs/core-features/candid-fast-ship) for behavior details.
+
+## Precedence
+
+When the same setting appears in multiple places, this is the order (first wins):
+
+1. CLI flags (e.g. `--auto-merge`, `--no-auto-merge`)
+2. Project config (`.candid/config.json`)
+3. User config (`~/.candid/config.json`)
+4. Built-in defaults
+
+## See also
+
+- [Config Options](/docs/reference/config-options) — full schema for every Candid key.
+- [Candid Ship](/docs/core-features/candid-ship) — full skill behavior.
+- [Candid Fast Ship](/docs/core-features/candid-fast-ship) — fast-ship behavior + use cases.
+- [Workflow Examples](/docs/reference/workflow-examples) — git-flow / github-flow / trunk-based variants.

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -762,7 +762,8 @@ header a:has(.logo):hover {
   padding: 0.75rem 2.5rem 0.75rem 1rem;
   border-radius: 0.5rem;
   font-size: 0.85rem;
-  white-space: pre-line;
+  white-space: pre;
+  overflow-x: auto;
   margin: 0;
 }
 

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -770,6 +770,111 @@ header a:has(.logo):hover {
   background: transparent;
 }
 
+/* ===== Config Showcase Section ===== */
+.config-showcase {
+  padding: var(--spacing-section) 0;
+  max-width: 72rem;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.config-showcase h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-section);
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 1rem;
+  letter-spacing: -0.02em;
+}
+
+.config-showcase .hero-tagline {
+  margin: 0 auto 3rem auto;
+  max-width: 48rem;
+}
+
+.config-showcase-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: start;
+  text-align: left;
+  margin-bottom: 2.5rem;
+}
+
+.config-snippet {
+  margin: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: var(--shadow-elevated);
+}
+
+.config-snippet pre {
+  margin: 0;
+  background: #1a1a1a;
+  color: #e5e5e5;
+  padding: 1.5rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  overflow-x: auto;
+}
+
+.config-snippet code {
+  background: transparent;
+  font-family: var(--font-mono);
+}
+
+.config-annotations {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.config-annotations li {
+  background: var(--surface-light);
+  border: 2px solid var(--border-light);
+  border-radius: 10px;
+  padding: 0.875rem 1rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.55;
+  box-shadow: var(--shadow-subtle);
+}
+
+.config-annotations li code {
+  font-family: var(--font-mono);
+  font-size: 0.825rem;
+  background: #f0f0f0;
+  color: var(--text-primary);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .config-showcase-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+}
+
+/* ===== Feature group headings (Review / Ship / QA) ===== */
+.feature-group-heading {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  margin: 2.5rem 0 1rem 0;
+  text-align: center;
+}
+
+.feature-group-heading:first-of-type {
+  margin-top: 0;
+}
+
 /* ===== Commands Section ===== */
 .commands-section {
   padding: var(--spacing-section) 0;
@@ -1241,6 +1346,29 @@ html.dark .install-command {
 
 html.dark .cta-section {
   background: linear-gradient(to bottom, rgba(212, 162, 127, 0.08) 0%, rgba(212, 162, 127, 0.03) 100%);
+}
+
+html.dark .config-showcase h2 {
+  color: var(--text-primary-dark);
+}
+
+html.dark .config-showcase .hero-tagline {
+  color: var(--text-secondary-dark);
+}
+
+html.dark .config-annotations li {
+  background: var(--surface-dark);
+  border-color: var(--border-light-dark);
+  color: var(--text-secondary-dark);
+}
+
+html.dark .config-annotations li code {
+  background: #2a2a2a;
+  color: var(--text-primary-dark);
+}
+
+html.dark .feature-group-heading {
+  color: var(--text-secondary-dark);
 }
 
 html.dark .commands-list li {

--- a/skills/candid-chrome-qa/SKILL.md
+++ b/skills/candid-chrome-qa/SKILL.md
@@ -12,13 +12,25 @@ This is a **technique skill**. Follow the order. The schema is non-negotiable.
 ## Inputs
 
 When invoked, the user provides (or you confirm):
-- **goal** — surface to test, e.g. "Agent Config / AI Setup, all 16 tabs"
-- **prompt** — free-form QA plan (what to exercise, edge cases, hot spots)
+- **goal** — surface to test, e.g. "Agent Config / AI Setup, all 16 tabs". Skipped if `--goal "<text>"` is passed.
+- **prompt** — free-form QA plan (what to exercise, edge cases, hot spots). Skipped if `--prompt "<text>"` is passed.
 - **app URL** — usually `http://localhost:<port>`. Verify before you start. Skipped if the user passes `--url` or `chromeQA.defaultUrl` is set in `.candid/config.json`.
 
-CLI flags:
-- `--url <url>` — provide the app URL up front, skipping the prompt.
-- `--mobile-only` — explicit opt-out from the desktop pass. Runs **only** the mobile pass (390x844). Documented exception to Hard Rule 6.
+CLI flags (full set):
+
+| Flag | Purpose |
+|---|---|
+| `--url <url>` | Provide the app URL up front, skipping the prompt. |
+| `--goal "<text>"` | Pre-fill the goal prompt. Skip the interactive ask. |
+| `--prompt "<text>"` | Pre-fill the QA-plan prompt. Skip the interactive ask. |
+| `--routes "/p1,/p2"` | Comma-separated list of routes to walk. Each becomes one target, bypassing goal-derived target inference. |
+| `--severity-floor P3` | Persist only findings at or above this severity (`P0` highest, `P5` lowest). Default `P5` (all). Findings below the floor are still walked and counted toward the `summary` block — they're just not appended to the file. |
+| `--viewports "1440x900,390x844"` | Override `chromeQA.desktopViewport` / `chromeQA.mobileViewport` from config. First value = desktop, second = mobile. |
+| `--findings-dir <path>` | Override findings output directory (default `.context/findings`). The directory is `mkdir -p`'d on each pass. |
+| `--mobile-only` | Explicit opt-out from the desktop pass. Runs **only** the mobile pass. Documented exception to Hard Rule 6. |
+| `--desktop-only` | Explicit opt-out from the mobile pass. Runs **only** the desktop pass. Second documented exception to Hard Rule 6. |
+
+`--mobile-only` and `--desktop-only` are mutually exclusive — if both are passed, error out and ask the user which one they meant.
 
 If any required input is missing after flags + config, ask. Don't guess.
 
@@ -61,6 +73,8 @@ ToolSearch query: "select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in
 
   All fields optional. Defaults: URL prompted, `apiPathPattern: "/api/"`, viewports as shown.
 
+  **Precedence:** `--viewports` CLI flag > `chromeQA.desktopViewport`/`chromeQA.mobileViewport` config > built-in defaults. `--findings-dir` CLI flag overrides the built-in `.context/findings` path. Record the resolved viewports and output directory in `context.environment` of the findings file so re-runs are reproducible.
+
 ### 2. Verify the dev server
 
 `curl -s -o /dev/null -w "%{http_code}" <url>`. Anything other than 2xx/3xx → ask the user to start it. The HTTP code is the source of truth — don't run `lsof` or process probes.
@@ -100,14 +114,18 @@ If the goal touches lists/details that need seeded data and the account is empty
 
 ### 9. Open the findings file
 
-1. **Make the directory:** `mkdir -p .context/findings`
+1. **Resolve the output directory:** `--findings-dir <path>` if passed, else `.context/findings`. **Make the directory:** `mkdir -p <dir>`.
 2. **Generate the slug** from `goal`: lowercase the first 4 words, replace non-alphanumerics with `-`, collapse repeated `-`, trim trailing `-`, truncate to 40 chars. Example: goal `"Agent Config / AI Setup, all 16 tabs"` → `agent-config-ai-setup`.
-3. **Choose the filename:** `.context/findings/<YYYY-MM-DD>-<slug>.json`. If that file already exists, switch to `<YYYY-MM-DD>-<HHmm>-<slug>.json` (current local time, 24h). Never overwrite a prior pass.
+3. **Choose the filename:** `<dir>/<YYYY-MM-DD>-<slug>.json`. If that file already exists, switch to `<YYYY-MM-DD>-<HHmm>-<slug>.json` (current local time, 24h). Never overwrite a prior pass.
 4. **Write the initial schema** with `findings: []`, the `context` block populated, and `summary` omitted (it's added at end-of-pass). Append findings to disk after each one — never batch-write at the end.
 
 ## Per-target loop (one route or one tab at a time)
 
-For each target identified in `goal` + `prompt`, use the **flush-capture cycle** so each step's telemetry is clean:
+**Target selection:**
+- If `--routes "/p1,/p2,/p3"` was passed, the target list is exactly those routes (each one a target). Bypasses goal-derived routing.
+- Otherwise, derive targets from `goal` + `prompt` as today (sidebar nav inferred from `read_page interactive` plus user-named surfaces).
+
+For each target, use the **flush-capture cycle** so each step's telemetry is clean:
 
 1. **Navigate / click into target.** Use sidebar buttons rather than direct URL when the app has client-side routing.
 2. **Flush telemetry.** `read_network_requests({clear: true})` and `read_console_messages({pattern: ".", clear: true})` — discard prior chatter.
@@ -118,7 +136,7 @@ For each target identified in `goal` + `prompt`, use the **flush-capture cycle**
    - `read_console_messages({pattern: "error|warn|fail|hydration|nested|aria|deprecat|key"})` — apply console triage table below.
    - `read_network_requests({urlPattern: "<chromeQA.apiPathPattern>"})` (default `/api/`; or `supabase`, or whatever Technical.md / config indicates) — apply network health thresholds below.
    - **Fallback if entries are redacted** (`[BLOCKED: Cookie/query string data]`): run `javascript_tool` with `performance.getEntriesByType('resource').filter(r => r.responseStatus >= 400 || r.responseStatus === 0).map(r => ({url: r.name, status: r.responseStatus, type: r.initiatorType}))` to recover full URLs from inside the page.
-7. **Append findings.** Each finding written to disk immediately, not buffered.
+7. **Append findings.** Each finding written to disk immediately, not buffered. **Severity floor:** if `--severity-floor <P>` was passed (default `P5` = all), drop findings whose severity is **below** the floor at this step. Severity order, highest first: `P0` > `P1` > `P2` > `P3` > `P4` > `P5`. Findings dropped at this step are still counted in the end-of-pass `summary` block — they just don't land in the `findings` array. This keeps the summary honest about what was walked.
 8. **Reset state** if you mutated something that affects subsequent targets (escape dirty-form modals via Discard, etc.).
 
 If a target produces no findings, append a single `confidence: "definite"`, `severity: "P5"`, `title: "✓ no issues — probes ran clean"` finding so coverage is provable.
@@ -198,6 +216,10 @@ After desktop pass:
 **Resize ceiling fallback:** Chrome may enforce a minimum content width of ~1075 px on the active tab depending on UI chrome. If `resize_window` to 390 wide doesn't take effect, try the smallest you can reach (often ~500 px) — the mobile breakpoint still triggers, the desktop sidebar still hides, and the hamburger drawer still appears. Note the actual width reached in the finding's `evidence`.
 
 **`--mobile-only` flag** inverts the default: skip the desktop pass entirely and run only the mobile sequence above. This is an **explicit opt-out** of Hard Rule 6 (which forbids running mobile without desktop). Use sparingly — most QA passes need both.
+
+**`--desktop-only` flag** skips the mobile pass entirely. Use when the surface is admin-only, internal tooling, or otherwise has no mobile contract to honor. Like `--mobile-only`, it's an explicit opt-out — without the flag, mobile is required.
+
+**`--mobile-only` + `--desktop-only` are mutually exclusive.** If both are passed, error and ask the user which one they meant. Don't silently pick one.
 
 ## Hot-spot stress — when the user provides recent commits or known weak points
 
@@ -346,7 +368,7 @@ The JSON file is always the source of truth — stdout is a courtesy for users w
 3. **Never invent the schema.** Use the v2.0 schema above byte-for-byte. Downstream consumers depend on it.
 4. **Never batch-write findings at the end.** Append per-finding. Context can exhaust mid-pass.
 5. **Never claim "no issues" without running the cross-cutting probes.** A `✓ no issues — probes ran clean` finding is fine; skipping the probes is not.
-6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute. **Exception:** the `--mobile-only` flag explicitly opts out of this rule — when the flag is passed, skip the desktop pass entirely.
+6. **Never resize to mobile without first finishing desktop.** Mobile is additive, not a substitute. **Exceptions:** `--mobile-only` skips the desktop pass entirely; `--desktop-only` skips the mobile pass entirely. Both are explicit opt-outs — without one, run both. Passing both flags is an error — ask the user which they meant.
 7. **Never use a stale tab.** Always `tabs_context_mcp` first. If reusing a tab, confirm with the user.
 8. **Never proceed without verifying Claude in Chrome is loaded** (Pre-flight step 0). Without it, every subsequent tool call fails opaquely.
 
@@ -378,6 +400,9 @@ If you hit a hard blocker (server down mid-pass, dirty-state trap, unrecoverable
 | "I'll skip the stdout summary, the JSON has the data" | The summary is the pass's headline. Users without a triage tool need it. |
 | "I'll use `'P0\|P1\|P2'` as the severity since the schema example showed it" | The schema example shows real values like `"P0"`. Pipe-delimited strings are TypeScript-style enum docs, not JSON values. Use one exact string. |
 | "I don't need `mkdir -p` — the directory probably exists" | It probably doesn't. Make it explicitly. |
+| "User passed `--severity-floor P0` so I'll skip walking the lower-severity stuff" | Wrong layer. Walk everything; drop only at the persist step (#7). The `summary` block must reflect the full walk, otherwise `Top issues: none` becomes a lie when there were P3s you skipped. |
+| "I'll silently override `--viewports` if the second value won't fit" | Use the resize-ceiling fallback (mobile-pass section) and record the actual width reached in the finding's `evidence`. Never silently change user-provided viewports. |
+| "User passed `--routes` so I'll skip the cross-cutting probes" | Cross-cutting probes still run once per pass. `--routes` narrows the per-target loop, not the probes. |
 
 ## Red flags — STOP and re-read this skill
 


### PR DESCRIPTION
## Summary

- **Homepage rewrite** — workflow-loop framing (review→ship→QA→fix), persona-led example commands, new CONFIG showcase section, feature cards regrouped under Review · Ship · QA
- **`/candid-chrome-qa` control surface** — 7 new flags exposed: `--goal`, `--prompt`, `--routes`, `--severity-floor`, `--viewports`, `--findings-dir`, `--desktop-only`. Skill body wires each flag into pre-flight, per-target loop, mobile pass, output; Hard Rule 6 updated; new Common Rationalization entries
- **New `/docs/reference/ship-config` page** — 7 paste-able recipes (minimal, full pipeline, hands-off auto-merge, fast-ship trivial, mixed velocity, Linear-only, post-merge deploy) plus full `ship.*` and `fastShip.*` reference tables. Cross-linked from candid-ship + candid-fast-ship

## Verification

- Review: PASS — 2 iterations, 2 issues fixed
- Build: PASS (`npm run build` clean — 43 pages, new `/docs/reference/ship-config` prerendered)
- Tests: SKIPPED (not configured in `.candid/config.json`)
- Install: SKIPPED (not configured)

### Fixes from review pass

- Analytics event collision: added `EVENTS.SHIP_CONFIG_CTA_CLICK` so the new ship-config CTA doesn't share `learn_more_click` with the hero
- `.step-code` switched from `white-space: pre-line` to `pre` + `overflow-x: auto` so multi-line shell examples render with intended indentation

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*