### PR TITLE
Add candid-improve-implementation skill (v1.18.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Candid review state (user-specific)
 .candid/last-review.json
+.candid/last-improve.json
 .candid/register
 
 # macOS metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-04-30
+
+### Added
+
+- **Candid Improve Implementation** (`/candid-improve-implementation`): A new skill that runs an improvement-lens pass on the current implementation — distinct from `candid-review`'s defect hunt. Where `/candid-review` asks *"what's wrong or risky?"*, this skill asks *"the code works — what would the next version look like if we built it again with what we know now?"*
+  - **Three signal categories** with explicit checklists: 🧭 **Approach** (existing util/pattern reuse, simpler decomposition, premature/missing abstractions, data-shape changes), 🔍 **Clarity** (misleading names, control flow hiding intent, mixed abstraction levels, comments that should be code or deleted), ✨ **Quality** (idiomatic fit, dead code, leftover scaffolding, testability friction, cheap perf wins that don't trade clarity)
+  - **Optional 🐛 Bugs section** — if the reviewer happens to spot real defects while scanning, they're surfaced as one-liners with a pointer to `/candid-review`. Capped at 3. Suppress entirely with `--no-bugs`
+  - **Quality over quantity**: ranks all candidates and caps the final list at 7 high-signal opportunities (configurable via `improve.maxOpportunities`). Drops low-impact suggestions even if technically valid — a 4-item review the user actually applies beats a 12-item review the user skims
+  - **Per-opportunity structured format**: `Current` snippet, `Suggested` before/after, `Why it's better` (specific property gained), `Tradeoff` (what's given up, or "None — strictly better"), and `Confidence` level (Safe ✓ / Verify ⚡ / Careful ⚠️)
+  - **Scope ladder**: unstaged changes first; if none, branch diff vs configured merge target. Skips the staged-only check that `candid-review` starts with — improvement passes target work-in-progress or branch-level deltas, not commits about to be made
+  - **Three-phase fix selection** (mirrors `candid-review` Step 8): bulk action choice (apply all / apply Safe ✓ only / review individually / track as todos) → optional per-item review → confirmation summary. Mandatory step — never auto-applies without explicit user confirmation
+  - **Tone preference** mirrors `candid-review`'s harsh/constructive split with the same precedence loader (CLI flag → project config → user config → interactive prompt)
+  - **Flags**: `--harsh` / `--constructive` (tone), `--focus approach|clarity|quality` (single-category mode), `--exclude <pattern>` (skip files), `--no-bugs` (suppress bugs section), `--auto-commit` (commit applied suggestions)
+  - **Config block** under `improve.*` in `.candid/config.json`: `improve.focus` (default focus area), `improve.noBugs` (default suppress bugs), `improve.maxOpportunities` (cap, default 7). Shared fields (`tone`, `exclude`, `mergeTargetBranches`, `autoCommit`) coexist with `candid-review`'s top-level keys without interference — `focus: "security"` applies to `/candid-review` while `improve.focus: "clarity"` applies to `/candid-improve-implementation`
+  - **State persistence**: writes `.candid/last-improve.json` (separate from `.candid/last-review.json`) for future comparisons
+  - **Explicit non-overlap clause** at the top of the skill: not a defect hunter, not a feature suggester, not a linter. If multiple findings would belong in `/candid-review`, surface them briefly under 🐛 Bugs and route the user there for proper triage
+  - **Comprehensive docs**: dedicated `/docs/core-features/candid-improve-implementation` page with categories, flags table, examples, and a full diff-vs-`candid-review` table
+  - **Homepage**: new "Improve" step inserted between Review and Ship in the marketing-page workflow list
+
 ## [1.16.0] - 2026-04-25
 
 ### Added

--- a/commands/candid-improve-implementation.md
+++ b/commands/candid-improve-implementation.md
@@ -1,0 +1,49 @@
+---
+command: candid-improve-implementation
+description: Review the implementation for approach/clarity/quality improvements - "the code works, what would the next version look like?"
+skill: candid-improve-implementation
+args:
+  - name: harsh
+    description: Use harsh/brutal tone (skips tone prompt)
+    required: false
+  - name: constructive
+    description: Use constructive/supportive tone (skips tone prompt)
+    required: false
+  - name: focus
+    description: Focus on a single area (approach, clarity, quality)
+    required: false
+  - name: exclude
+    description: Exclude files matching pattern (can be repeated)
+    required: false
+  - name: no-bugs
+    description: Suppress the "Bugs" section (defects route to /candid-review)
+    required: false
+  - name: auto-commit
+    description: Automatically create a git commit after applying suggestions
+    required: false
+---
+
+Review the current implementation through the **improvement** lens — what would the next version of this code look like if we built it again with what we know now?
+
+Distinct from `/candid-review` (which hunts defects, security holes, edge cases). This skill surfaces opportunities to improve approach, clarity, and quality.
+
+Usage:
+```
+/candid-improve-implementation                          # Interactive tone selection
+/candid-improve-implementation --harsh                  # Brutal honesty
+/candid-improve-implementation --constructive           # Supportive
+/candid-improve-implementation --focus approach         # Design / decomposition only
+/candid-improve-implementation --focus clarity          # Naming, control flow, abstraction
+/candid-improve-implementation --focus quality          # Idioms, dead code, testability
+/candid-improve-implementation --no-bugs                # Suppress bug section
+/candid-improve-implementation --exclude "*.generated.ts"
+/candid-improve-implementation --auto-commit            # Commit applied suggestions
+```
+
+The skill will:
+1. Detect changes (unstaged → branch diff vs merge target)
+2. Load Technical.md standards (if present)
+3. Read full files for context (not just the diff)
+4. Surface opportunities ranked by impact (cap at 7)
+5. Let you choose which to apply via three-phase selection
+6. Save state for future comparisons

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -362,7 +362,7 @@ export default function HomePage() {
         <span className="section-badge">HOW IT WORKS</span>
         <h2>The loop</h2>
         <p className="hero-tagline">
-          Install once. Then run the four commands that take a branch from review to shipped.
+          Install once. Then run the five commands that take a branch from review to shipped.
         </p>
         <ol className="steps-list">
           <li>
@@ -382,6 +382,17 @@ export default function HomePage() {
               <Pre className="step-code" trackingId="step_review">
                 <code>{`/candid-review --harsh review this branch like a
   skeptical CTO — what would block a launch?`}</code>
+              </Pre>
+            </div>
+          </li>
+          <li>
+            <div className="step-content">
+              <strong>Improve.</strong>
+              <span>Where <code>/candid-review</code> asks <em>&quot;what&apos;s wrong or risky?&quot;</em>, this asks <em>&quot;the code works — what would the next version look like if we built it again with what we know now?&quot;</em></span>
+              <Pre className="step-code" trackingId="step_improve">
+                <code>{`/candid-improve-implementation --focus clarity
+  rename anything ambiguous, collapse the helpers
+  that are only used once`}</code>
               </Pre>
             </div>
           </li>

--- a/docs/app/docs/core-features/candid-improve-implementation/page.mdx
+++ b/docs/app/docs/core-features/candid-improve-implementation/page.mdx
@@ -1,0 +1,139 @@
+export const metadata = {
+  title: 'Candid Improve Implementation - The Next Version of Working Code',
+  description: 'Use candid-improve-implementation to surface opportunities to improve approach, clarity, and quality - distinct from candid-review\'s defect hunt. Concrete before/after, why it\'s better, and what\'s traded off.',
+}
+
+# Candid Improve Implementation
+
+Where `/candid-review` asks *"what's wrong or risky?"*, this skill asks *"the code works — what would the next version look like if we built it again with what we know now?"*
+
+## Quick Start
+
+```
+/candid-improve-implementation
+```
+
+Runs an improvement-lens pass on your unstaged changes (or branch diff if no unstaged). Surfaces a ranked list — capped at 7 — of opportunities to improve approach, clarity, and quality. Each opportunity comes with a concrete before/after, why it's better, what's traded off, and a confidence level.
+
+## When to Use It
+
+- After a feature works but before `/candid-ship` — a quality second pass on shipping code
+- During a cleanup PR or a refactor branch
+- When you're returning to code you wrote a month ago and want a sharper version
+- After a `/candid-review` cleanup — once defects are gone, this surfaces what's left
+
+Not the right tool for: defect hunting (use `/candid-review`), feature design (use planning skills), or style nits a linter would catch.
+
+## Categories
+
+Three signal categories. Mixed by default; isolate one with `--focus`.
+
+### 🧭 Approach / design
+
+- Existing utility/pattern in this codebase the new code should reuse
+- A meaningfully simpler structure or different decomposition
+- Premature abstraction to collapse, or a missing one to introduce
+- Data-shape changes that simplify multiple consumers
+
+### 🔍 Clarity
+
+- Names that mislead or under-describe
+- Control flow hiding intent (deep nesting, flag arguments, mixed abstraction levels)
+- Comments that should be code, code that should be a comment, comments that should be deleted
+
+### ✨ Quality
+
+- Idiomatic fit — language/framework features being re-implemented
+- Dead code, unused branches, leftover scaffolding
+- Testability friction (hard-to-mock seams, hidden dependencies)
+- Cheap performance wins that don't trade off clarity
+
+### 🐛 Bugs (optional)
+
+If the reviewer happens to spot real bugs while scanning, they're surfaced as one-liners with a pointer to `/candid-review`. Capped at 3. Suppress entirely with `--no-bugs`.
+
+## Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--harsh` | Brutal honesty, no hedging | Interactive prompt |
+| `--constructive` | Same honesty, more scaffolding | Interactive prompt |
+| `--focus <area>` | Limit to one category: `approach`, `clarity`, `quality` | All three |
+| `--exclude <pattern>` | Skip files matching glob (repeatable) | None |
+| `--no-bugs` | Suppress the 🐛 Bugs section entirely | Bugs included |
+| `--auto-commit` | Commit applied suggestions automatically | Off |
+
+## How It Works
+
+1. **Detect changes** — unstaged first; if none, branch diff vs merge target. (No staged-only check — that's `/candid-review`'s lane.)
+2. **Load standards** — reads `Technical.md` if present; cites alignment or contradiction in suggestions.
+3. **Read full files** — improvement signal needs surrounding context, not just the diff.
+4. **Identify opportunities** — walks Approach / Clarity / Quality checklists.
+5. **Rank and cap at 7** — drops low-impact items even if technically valid. Quality over quantity.
+6. **Present each opportunity** — with `Current` snippet, `Suggested` before/after, `Why it's better`, `Tradeoff`, and `Confidence` (Safe ✓ / Verify ⚡ / Careful ⚠️).
+7. **Three-phase fix selection** — apply all / apply Safe ✓ only / review individually / track as todos.
+8. **Apply or todo** — Edits files for selected items; TodoWrite for the rest.
+9. **Optional commit** — `--auto-commit` creates a single commit listing every applied item.
+10. **Save state** — writes `.candid/last-improve.json` for future comparisons.
+
+## Difference vs `/candid-review`
+
+| Lens | `/candid-review` | `/candid-improve-implementation` |
+|------|------------------|----------------------------------|
+| Question asked | "What's wrong or risky?" | "What would the next version look like?" |
+| Targets | Defects, security, edge cases, smells | Approach, clarity, quality |
+| Scope ladder | Staged → unstaged → branch diff | Unstaged → branch diff |
+| Output | Issues with severity (🔥 ⚠️ 📜 etc.) | Opportunities with confidence (✓ ⚡ ⚠️) |
+| Cap | None — every issue surfaces | 7 (configurable via `improve.maxOpportunities`) |
+| Bugs | Primary purpose | Side-effect, capped at 3, opt-out via `--no-bugs` |
+| When to run | Pre-commit, pre-PR, defect hunt | Post-feature-works, cleanup PRs, refactor |
+
+Run them together: `/candid-review` first to clean defects, then `/candid-improve-implementation` to sharpen what's left. Or use both lenses on the same diff in either order — they don't conflict.
+
+## Examples
+
+```bash
+# Default: interactive tone, all three categories, bugs included
+/candid-improve-implementation
+
+# Harsh tone, focus only on approach (design / decomposition)
+/candid-improve-implementation --harsh --focus approach
+
+# Quick clarity-only pass, ignore generated files
+/candid-improve-implementation --focus clarity --exclude "*.generated.ts"
+
+# Suppress the bugs section (you've already run candid-review)
+/candid-improve-implementation --no-bugs
+
+# Apply automatically with a commit
+/candid-improve-implementation --auto-commit
+```
+
+## Configuration
+
+Add to `.candid/config.json`:
+
+```json
+{
+  "tone": "constructive",
+  "improve": {
+    "focus": "approach",
+    "noBugs": false,
+    "maxOpportunities": 7
+  }
+}
+```
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `improve.focus` | `"approach" \| "clarity" \| "quality"` | Default focus area | None (all three) |
+| `improve.noBugs` | boolean | Suppress 🐛 Bugs section | `false` |
+| `improve.maxOpportunities` | integer (1-50) | Cap on opportunities surfaced | `7` |
+
+`tone`, `exclude`, `mergeTargetBranches`, and `autoCommit` are shared with `/candid-review`. See the [Candid Review docs](/docs/core-features/candid-review) or the full config reference for those.
+
+## See Also
+
+- [Candid Review](/docs/core-features/candid-review) — defect / risk / security review (run first)
+- [Candid Loop](/docs/core-features/candid-loop) — fix-review-fix until clean
+- [Candid Ship](/docs/core-features/candid-ship) — full shipping workflow once code is sharp

--- a/skills/candid-improve-implementation/CONFIG.md
+++ b/skills/candid-improve-implementation/CONFIG.md
@@ -1,0 +1,220 @@
+# Config File Handling for Candid Improve Implementation
+
+## Config File Locations
+
+- **User config:** `~/.candid/config.json`
+- **Project config:** `.candid/config.json` (in project root)
+
+`candid-improve-implementation` reads the same config file as `candid-review` and the rest of the candid suite. This file documents the fields **specific to or shared with** the improve-implementation skill. For ship/fastShip blocks, see `skills/candid-review/CONFIG.md` (canonical reference).
+
+## Schema Specification
+
+```json
+{
+  "version": 1,
+  "tone": "harsh" | "constructive",
+  "exclude": ["*.generated.ts", "vendor/*"],
+  "mergeTargetBranches": ["main", "stable", "master"],
+  "autoCommit": true | false,
+  "improve": {
+    "focus": "approach" | "clarity" | "quality",
+    "noBugs": true | false,
+    "maxOpportunities": 7
+  }
+}
+```
+
+**Field descriptions:**
+
+- `version` (optional): Config schema version. Defaults to `1`.
+- `tone` (optional): Review tone preference. Must be exactly `"harsh"` or `"constructive"`. Shared with `candid-review`. Same precedence loader.
+- `exclude` (optional): Array of glob patterns for files to skip. Shared with `candid-review`. Merged with CLI `--exclude` flags.
+- `mergeTargetBranches` (optional): Array of branches to compare against for branch-diff fallback. Defaults to `["main", "stable", "master"]`. Shared with `candid-review`.
+- `autoCommit` (optional): If `true`, automatically commits after applying suggestions (equivalent to always passing `--auto-commit`). Defaults to `false`. Shared with `candid-review`.
+- `improve` (optional): Settings specific to `candid-improve-implementation`. If absent, all defaults apply.
+  - `improve.focus` (optional): Default focus area. Must be exactly `"approach"`, `"clarity"`, or `"quality"`. CLI `--focus` flag overrides. **Note:** `improve.focus` values are different from `candid-review`'s top-level `focus` (which uses `security|performance|architecture|edge-case`) — keep them separate to avoid cross-contamination.
+  - `improve.noBugs` (optional): If `true`, suppress the 🐛 Bugs section by default. CLI `--no-bugs` overrides toward suppression. Defaults to `false` (bugs section included).
+  - `improve.maxOpportunities` (optional): Cap on the number of opportunities surfaced. Must be a positive integer. Defaults to `7`. Lower values force tighter ranking.
+
+## Validation Rules
+
+1. **File must be valid JSON** — must parse without errors
+2. **Tone field validation** — if `tone` is present, must be exactly `"harsh"` or `"constructive"` (case-sensitive)
+3. **Exclude field validation** — if present, must be an array of non-empty strings
+4. **mergeTargetBranches field validation** — if present, must be an array of non-empty strings; empty arrays show warning and are ignored
+5. **AutoCommit field validation** — if present, must be a boolean
+6. **Improve field validation** — if `improve` is present, must be an object
+   - `improve.focus`: if present, must be exactly `"approach"`, `"clarity"`, or `"quality"` (case-sensitive). Invalid values show warning and are ignored.
+   - `improve.noBugs`: if present, must be a boolean. Invalid values show warning and are ignored.
+   - `improve.maxOpportunities`: if present, must be a positive integer (1-50). Out-of-range or non-integer values show warning and are ignored (defaults to 7).
+7. **Unknown fields ignored** — forward compatibility
+8. **Empty object is valid** — `{}` is a valid config; system continues to next source
+
+## Config Validation Procedure
+
+Same reusable procedure as `candid-review`. See `skills/candid-review/CONFIG.md` → "Config Validation Procedure" for the canonical text.
+
+The only difference for this skill: when extracting the focus value, the field is `improve.focus` (nested under the `improve` block), not the top-level `focus` field.
+
+```bash
+jq -r '.improve.focus // "none"' [config_path]
+```
+
+Validation: must be `"approach"`, `"clarity"`, or `"quality"`.
+
+## Error Handling
+
+### Invalid JSON
+- **Error message:** `"malformed JSON"`
+- **Action:** Show warning, continue to next precedence level
+
+### Invalid `improve.focus` Value
+- **Error message:** `'invalid improve.focus "[value]" (must be "approach", "clarity", or "quality")'`
+- **Action:** Show warning, continue to next precedence level
+
+### Invalid `improve.maxOpportunities` Value
+- **Error message:** `'invalid improve.maxOpportunities "[value]" (must be positive integer 1-50)'`
+- **Action:** Show warning, use default (7)
+
+### Invalid `improve.noBugs` Value
+- **Error message:** `'invalid improve.noBugs "[value]" (must be boolean)'`
+- **Action:** Show warning, use default (false)
+
+## Warning Message Template
+
+```
+⚠️  Invalid config at [path]: [specific error]. Falling back to [next source].
+```
+
+### Examples
+
+**Invalid focus:**
+```
+⚠️  Invalid config at .candid/config.json: invalid improve.focus "design" (must be "approach", "clarity", or "quality"). Falling back to user config.
+```
+
+**Invalid maxOpportunities:**
+```
+⚠️  Invalid config at ~/.candid/config.json: invalid improve.maxOpportunities "100" (must be positive integer 1-50). Using default (7).
+```
+
+## Success Message Template
+
+When valid preferences are loaded:
+
+```
+Using [tone] tone (from [source])
+Focusing improvement review on: [focus] (from [source])
+Bugs section: suppressed (from [source])
+Capping opportunities at [N] (from [source])
+```
+
+### Source Values
+
+- `"CLI flag"` — when `--harsh`, `--constructive`, `--focus`, `--no-bugs`, or `--auto-commit` is provided
+- `"project config"` — when loaded from `.candid/config.json`
+- `"user config"` — when loaded from `~/.candid/config.json`
+- `"default"` — when no source set the value
+
+## Config File Examples
+
+### Valid Configs
+
+**Minimal (use defaults):**
+```json
+{
+  "tone": "constructive"
+}
+```
+
+**Improvement-focused defaults:**
+```json
+{
+  "tone": "harsh",
+  "improve": {
+    "focus": "approach",
+    "noBugs": true
+  }
+}
+```
+
+**Tight cap on opportunities:**
+```json
+{
+  "tone": "constructive",
+  "improve": {
+    "maxOpportunities": 3
+  }
+}
+```
+
+**With exclusions:**
+```json
+{
+  "tone": "harsh",
+  "exclude": ["*.generated.ts", "vendor/*", "**/*.min.js"],
+  "improve": {
+    "focus": "clarity"
+  }
+}
+```
+
+**Full config (improve + shared fields):**
+```json
+{
+  "version": 1,
+  "tone": "harsh",
+  "exclude": ["*.generated.ts"],
+  "mergeTargetBranches": ["stable", "main"],
+  "autoCommit": false,
+  "improve": {
+    "focus": "approach",
+    "noBugs": false,
+    "maxOpportunities": 7
+  }
+}
+```
+
+**Coexisting with candid-review config:**
+```json
+{
+  "version": 1,
+  "tone": "harsh",
+  "focus": "security",
+  "exclude": ["*.generated.ts"],
+  "improve": {
+    "focus": "clarity",
+    "maxOpportunities": 5
+  }
+}
+```
+Here `focus: "security"` applies to `/candid-review`; `improve.focus: "clarity"` applies to `/candid-improve-implementation`. They do not interfere.
+
+### Invalid Configs
+
+**Invalid focus value:**
+```json
+{
+  "improve": {
+    "focus": "design"
+  }
+}
+```
+
+**Wrong type for noBugs:**
+```json
+{
+  "improve": {
+    "noBugs": "yes"
+  }
+}
+```
+
+**Out-of-range maxOpportunities:**
+```json
+{
+  "improve": {
+    "maxOpportunities": 200
+  }
+}
+```

--- a/skills/candid-improve-implementation/SKILL.md
+++ b/skills/candid-improve-implementation/SKILL.md
@@ -1,0 +1,465 @@
+---
+name: candid-improve-implementation
+description: Use when the code works and you want a focused pass on opportunities to improve approach, clarity, and quality - distinct from candid-review's defect hunt. Surfaces simpler structures, clearer names, idiomatic alternatives, dead weight to remove, and abstractions to collapse or introduce. Each suggestion comes with a concrete before/after, why it's better, what's traded off, and confidence level. Three-phase fix selection mirrors candid-review.
+---
+
+# Improvement Lens — candid-improve-implementation
+
+You are a senior engineer doing a **second pass** on code that already works. Your job is not to find bugs. Your job is to ask: *"the code works — what would the next version look like if we built it again with what we know now?"*
+
+## Non-Overlap Clause (read this first)
+
+This skill is **not a defect hunter.** That is `/candid-review`'s job.
+
+- Do not enumerate edge cases, security holes, or null/undefined risks.
+- Do not list every code smell a linter would catch.
+- Do not flag style preferences a formatter would normalize.
+- Do not invent missing features ("you should also add X") — scope expansion is not improvement.
+
+If, while reading, you happen to see one or two real bugs, surface them in a brief **🐛 Bugs (route to /candid-review)** section — one line each, then stop. The user can rerun under candid-review for proper triage. The `--no-bugs` flag suppresses this section entirely.
+
+The signal you ARE hunting:
+
+1. **🧭 Approach / design** — A meaningfully simpler structure, a different decomposition, a utility/pattern already in this codebase that should be reused, a premature abstraction to collapse, or a missing one to introduce.
+2. **🔍 Clarity** — Names that mislead or under-describe. Control flow that hides intent (deep nesting, flag arguments, mixed levels of abstraction). Comments that should be code, code that should be a comment, and comments that should be deleted.
+3. **✨ Quality** — Idiomatic fit with the language/framework. Dead code, unused branches, leftover scaffolding. Testability friction (hard-to-mock seams, hidden dependencies). Cheap performance wins that don't trade off clarity.
+
+Quality over quantity. Cap output at **7 high-signal opportunities**. Drop low-impact suggestions even if technically valid.
+
+---
+
+## Workflow
+
+### Step 1: Load Project Standards
+
+Check for Technical.md (project-specific standards):
+
+```
+1. Read ./Technical.md (project root)
+2. If not found, read ./.candid/Technical.md
+3. If found, use these standards to inform your review
+4. If not found, proceed without project-specific standards
+```
+
+When Technical.md exists, cite the relevant section when an opportunity aligns with or contradicts a standard.
+
+### Step 2: Detect Changes
+
+Get the code to review. **Note:** unlike `candid-review`, this skill skips the staged-only check. Improvement reviews target unstaged work-in-progress or full-branch deltas, not commits about to be made.
+
+**1. Verify git repository:**
+```bash
+git rev-parse --git-dir 2>/dev/null
+```
+If this fails, inform user: "This directory is not a git repository. I need a git repo to detect changes."
+
+**2. Check for changes in priority order:**
+```bash
+# First: unstaged changes (working tree vs index)
+git diff --stat
+
+# If no unstaged changes, fall back to branch diff vs configured merge targets
+# (built dynamically from mergeTargetBranches in Step 2.5)
+# Example for ["stable", "main"]: git diff stable...HEAD --stat 2>/dev/null || git diff main...HEAD --stat 2>/dev/null
+```
+
+**3. Decide what to review:**
+- If unstaged changes exist → review with `git diff`
+- Else if branch differs from merge target → review with `git diff <branch>...HEAD` (using first successful branch from `mergeTargetBranches`)
+- Else → inform user: "No unstaged or branch changes detected. This skill reviews work-in-progress or branch-level deltas. To review staged changes specifically, use `/candid-review`."
+
+**4. Handle special cases:**
+- Skip binary files
+- For diffs over 500 lines, ask the user which directories or files to prioritize — improvement passes need depth, not surface
+
+### Step 2.5: Load Merge Target Branches
+
+Determine which branches to compare against, following config precedence.
+
+**Precedence (highest to lowest):**
+1. CLI flags (`--merge-target <branch>`, repeatable)
+2. Project config (`.candid/config.json` → `mergeTargetBranches`)
+3. User config (`~/.candid/config.json` → `mergeTargetBranches`)
+4. Default (`["main", "stable", "master"]`)
+
+For each branch in `mergeTargetBranches`, try `git diff <branch>...HEAD --stat 2>/dev/null` and use the first that succeeds. If all fail: `Could not find merge target branch. Tried: [list]`.
+
+### Step 3: Parse Options
+
+Check CLI arguments for review options.
+
+#### Focus Mode (`--focus`)
+
+**Focus Precedence (highest to lowest):**
+1. CLI flag (`--focus approach`)
+2. Project config (`.candid/config.json` → `focus` field)
+3. User config (`~/.candid/config.json` → `focus` field)
+4. No focus (review all three categories)
+
+| Focus Area | Categories Surfaced |
+|------------|---------------------|
+| `approach` | 🧭 Approach / design only |
+| `clarity` | 🔍 Clarity only |
+| `quality` | ✨ Quality only |
+
+When focus is set: `Focusing review on: [area]`
+
+#### File Exclusions (`--exclude`)
+
+Same behavior as `candid-review`: merge CLI exclusions with config exclusions, apply to file list in Step 2. Common patterns: `*.generated.ts`, `vendor/*`, `**/node_modules/**`.
+
+#### Bugs Section (`--no-bugs`)
+
+If `--no-bugs` is provided OR config sets `noBugs: true`, suppress the 🐛 Bugs section entirely. Do not flag any defects. Default = include bugs section (one-line each, route to candid-review).
+
+#### Auto-Commit (`--auto-commit`)
+
+If `--auto-commit` is provided OR config sets `autoCommit: true`, automatically create a git commit after applying suggestions. Same behavior as candid-review's auto-commit (see Step 10.5 below).
+
+### Step 4: Load Tone Preference
+
+Mirror `candid-review`'s tone loader exactly. See `CONFIG.md` for the full procedure.
+
+**Precedence:**
+1. CLI flags (`--harsh` / `--constructive`)
+2. Project config (`.candid/config.json` → `tone`)
+3. User config (`~/.candid/config.json` → `tone`)
+4. Interactive prompt
+
+If falling through to interactive, use AskUserQuestion:
+
+**Question:** "Choose your improvement-pass style"
+
+**Options:**
+1. **Harsh** — No sugar coating. I'll tell you which design choices were lazy and which names are quietly misleading. Direct, no hedging.
+2. **Constructive** — Same honesty, more scaffolding. I'll explain *why* the suggested version is sharper and what tradeoffs you'd be accepting.
+
+Output: `Using [tone] tone (from [source])`.
+
+### Step 5: Gather Context
+
+Before suggesting anything, understand the code:
+
+1. **Read changed files in full** — improvements depend on surrounding structure
+2. **Find imports/exports** — is there a utility already in this codebase that the new code re-implements?
+3. **Look for related tests** — testability friction is a quality category
+4. **Check recent history** — `git log -3 --oneline -- <changed-files>` — was an abstraction recently introduced and not yet stabilized?
+5. **Search for sibling patterns** — when proposing a new abstraction or naming, confirm it's consistent with how this codebase already does it
+
+This is what enables genuine improvement signal vs. drive-by opinions.
+
+### Step 6: Identify Opportunities
+
+For each changed file, walk all three categories. Use the checklists below as prompts — not as boxes to fill. Skip a category for a file if nothing rises above the noise floor.
+
+#### 🧭 Approach / design
+
+- Is there an **existing utility, hook, helper, or pattern** in this codebase that re-implements what the new code does? Cite the file path.
+- Is the **decomposition** right — could this collapse into one function, or split cleanly into two with different responsibilities?
+- Is there a **premature abstraction** here (one caller, single configuration path, speculative parameters)?
+- Is there a **missing abstraction** (the same shape repeated 3+ times in the diff)?
+- Could a **data-shape change** simplify three downstream consumers? (e.g., normalize once, ditch the repeated transforms.)
+- Does the structure **fight the framework** (e.g., manual state machine where the framework gives you one)?
+
+#### 🔍 Clarity
+
+- **Names** — does the identifier describe what it *does* or what it *is for*? Are there names that mislead (Boolean named like a noun, function named like a query but causing side effects)?
+- **Control flow** — early returns vs. nested else; guard clauses vs. pyramids; flag arguments that mean the function does two things.
+- **Levels of abstraction** — does a single function mix high-level orchestration with low-level string manipulation? Split into named layers.
+- **Comments** — comments that re-state the code (delete), comments that explain *what* (rename instead), comments that explain *why* and capture a non-obvious constraint (keep).
+- **Magic values** — numeric or string constants that appear multiple times without a name.
+
+#### ✨ Quality
+
+- **Idiomatic fit** — language/framework features being re-implemented (e.g., manual loops where `.map`/`.filter` reads cleaner; `useEffect` where derived state would be simpler).
+- **Dead code** — unreachable branches, parameters never read, exported names never imported, fallback paths for cases that can't happen.
+- **Leftover scaffolding** — `console.log`, commented-out code, TODOs older than the change itself, debug-only flags.
+- **Testability** — implicit dependencies (clocks, randomness, network) baked into the unit being changed. Could you inject them and gain testability with no clarity loss?
+- **Cheap performance** — N memoizations vs. one (or none). Recomputed values that could move outside a hot path. Allocations in tight loops. **Only if it doesn't trade clarity.**
+
+#### 🐛 Bugs (optional, suppressed by `--no-bugs`)
+
+If you genuinely see a real defect (not edge-case speculation), surface it as one line:
+- File:line — one-sentence problem.
+- Cap at 3. If you're listing more than 3 bugs, you're doing candid-review's job — stop and tell the user to run `/candid-review` for proper triage.
+
+### Step 7: Rank & Cap
+
+Across all three categories, you may have surfaced 10-20 candidates. **Cap the final list at 7 opportunities.** Selection criteria, in order:
+
+1. **Highest leverage** — fixes a structural choice that propagates through the rest of the file
+2. **Highest reuse signal** — opportunities that cite an existing util/pattern in the codebase (Approach category)
+3. **Lowest cost-to-apply** — Safe ✓ items that strictly improve clarity with no behavior change
+4. **Drop everything else.** A 4-item review the user actually applies beats a 12-item review the user skims.
+
+If the diff is small enough that 7 is overkill, surface fewer. Truth-telling matters more than checklist completeness.
+
+### Step 8: Present Opportunities
+
+For each opportunity, use this structured format:
+
+```markdown
+### [Icon] [Title]
+**File:** path/to/file.ts:42-58
+**Category:** Approach | Clarity | Quality
+**Confidence:** [Safe ✓ | Verify ⚡ | Careful ⚠️]
+
+**Current:**
+```[language]
+// snippet of the code as-is
+```
+
+**Suggested:**
+```[language]
+// concrete before/after
+```
+
+**Why it's better:** Specific property gained — "uses existing `formatCurrency` helper at lib/format.ts:14 instead of re-implementing", or "removes flag parameter, splits into two named call sites", or "moves transform out of render loop, allocates once".
+
+**Tradeoff:** What's given up. If genuinely none, write "None — strictly better."
+```
+
+#### Confidence Levels
+
+| Level | Icon | When to Use | Example |
+|-------|------|-------------|---------|
+| Safe | ✓ | Mechanical, no behavior change | Rename, delete dead code, replace duplicate with existing util |
+| Verify | ⚡ | Logic shift, needs a test pass | Restructure control flow, change data shape |
+| Careful | ⚠️ | Architectural / cross-file | Collapse abstraction, change module boundary |
+
+#### Tone Variations
+
+*Harsh tone example:*
+> ### 🔍 `processData` does three things, named for none of them
+> **File:** src/orders.ts:42-58
+> **Category:** Clarity
+> **Confidence:** Safe ✓
+>
+> **Current:**
+> ```ts
+> function processData(order: Order, refresh: boolean) {
+>   if (refresh) cache.invalidate(order.id);
+>   const enriched = enrich(order);
+>   db.save(enriched);
+>   return enriched;
+> }
+> ```
+>
+> **Suggested:** Split. `enrichOrder` returns the enriched value (no side effects). `saveEnrichedOrder` writes. The cache invalidation moves to the call site that actually owns refresh semantics.
+>
+> **Why it's better:** Right now nothing about the name suggests this writes to a database or invalidates a cache. The `refresh` flag means the function does two different things and you have to read the body to know which. Two named functions read themselves.
+>
+> **Tradeoff:** One more import at the call site. Worth it.
+
+*Constructive tone example:*
+> ### 🧭 `formatPrice` already exists in lib/format.ts — reuse it
+> **File:** src/checkout/Cart.tsx:88
+> **Category:** Approach
+> **Confidence:** Safe ✓
+>
+> **Current:**
+> ```tsx
+> const display = `$${(amount / 100).toFixed(2)}`;
+> ```
+>
+> **Suggested:**
+> ```tsx
+> import { formatPrice } from '@/lib/format';
+> const display = formatPrice(amount);
+> ```
+>
+> **Why it's better:** `formatPrice` at `lib/format.ts:14` handles the cents-to-dollars conversion plus locale-aware formatting (commas for thousands), which the inline version misses. Two other components in `src/checkout/` already use it — staying consistent makes the next refactor easier.
+>
+> **Tradeoff:** None — strictly better.
+
+### Step 9: Fix Selection (MANDATORY)
+
+**⚠️ CRITICAL: This step is MANDATORY when opportunities exist. Never skip.**
+
+**Pre-condition:** If Step 7 left zero opportunities, skip to a summary stating "No high-signal improvements found — the code reads cleanly as-is" and end. Otherwise, proceed.
+
+#### Phase 9a: Bulk Action Choice
+
+Before the prompt, remind: "Scroll up to review the detailed before/after for each opportunity."
+
+Use AskUserQuestion:
+
+**Question:** "How would you like to handle these suggestions?"
+
+**Options:**
+1. "Apply all" — Apply every suggested change
+2. "Apply Safe ✓ only" — Only the mechanical, no-behavior-change ones
+3. "Review each individually" — Per-item Yes/No (proceeds to Phase 9b)
+4. "None (track as todos)" — Don't apply anything; add all to todos
+
+Store choice and route accordingly:
+- "Apply all" → Add all to `selectedFixes`, skip to 9c
+- "Apply Safe ✓ only" → Add only Safe-confidence items, skip to 9c
+- "Review each individually" → Phase 9b
+- "None" → Empty `selectedFixes`, jump to Step 10
+
+#### Phase 9b: Individual Review
+
+Loop through opportunities. For each:
+
+1. Show issue number `[1/N]`, icon, title, file location, brief problem
+2. AskUserQuestion:
+   - **Question:** "Apply this suggestion?"
+   - **Options:** "Yes, apply", "No, skip"
+3. If Yes → add to `selectedFixes`. If No → continue.
+
+After loop, proceed to 9c.
+
+#### Phase 9c: Confirmation
+
+Display summary: count + list (number, icon, short title, file:line).
+
+AskUserQuestion:
+- **Question:** "Apply these suggestions?"
+- **Options:** "Yes, apply all selected", "No, let me review again" (returns to 9a)
+
+Do not proceed to Step 10 without explicit confirmation.
+
+### Step 10: Apply or Track
+
+**If `selectedFixes` is non-empty:**
+
+1. TodoWrite the selected items as `pending` with format `[Icon] Improve: [title] at [file:line]`
+2. Initialize `modifiedFiles` set
+3. For each: mark `in_progress`, apply via Edit, add file to `modifiedFiles`, mark `completed`
+4. Summarize: count applied + list of modified files
+
+**If `selectedFixes` is empty (user chose "None"):**
+
+TodoWrite all opportunities from Step 7 as pending todos. Confirm count to user.
+
+### Step 10.5: Auto-Commit (Optional)
+
+**Pre-condition:** `commitEnabled = true` AND `selectedFixes` non-empty AND git repo available.
+
+**1. Verify changes:**
+```bash
+git diff --stat
+```
+If empty: `No file changes detected, skipping commit`. Skip to Step 11.
+
+**2. Stage modified files:**
+```bash
+git add <file1> <file2> ...
+```
+Use files from `modifiedFiles` set.
+
+**3. Commit message format:**
+```
+Apply candid-improve-implementation suggestions ([N] items)
+
+Improvements:
+- [icon] [title] in [path]:[line]
+- [icon] [title] in [path]:[line]
+[...]
+
+Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+Truncate at 10 entries with `- ... and [M] more`.
+
+**4. Create commit:**
+```bash
+git commit -m "$(cat <<'EOF'
+[generated message]
+EOF
+)"
+```
+
+Success: `✅ Created commit: "Apply candid-improve-implementation suggestions ([N] items)"`.
+
+Failure never aborts the workflow — fixes stay applied; user commits manually.
+
+### Step 11: Save State
+
+Save review state for future comparisons.
+
+**1. Create `.candid` if needed:**
+```bash
+mkdir -p .candid
+```
+
+**2. Generate state JSON:**
+
+```json
+{
+  "timestamp": "ISO timestamp",
+  "commit": "git rev-parse HEAD output",
+  "branch": "git branch --show-current output",
+  "skill": "candid-improve-implementation",
+  "opportunities": [
+    {
+      "id": "first 12 chars of SHA256 of `${path}:${line}:${category}:${title}`",
+      "file": "src/orders.ts",
+      "line": 42,
+      "category": "clarity",
+      "confidence": "safe",
+      "title": "processData does three things"
+    }
+  ]
+}
+```
+
+**3. Write to `.candid/last-improve.json`** (separate from `.candid/last-review.json`).
+
+**4. Output:**
+```
+Improvement state saved to .candid/last-improve.json
+```
+
+**Note:** `.candid/last-improve.json` should be in `.gitignore` (user-specific state).
+
+---
+
+## Output Structure
+
+Present in this order:
+
+1. **Summary** — one paragraph: what was reviewed, overall density of opportunities (e.g., "tight code; 3 worth surfacing" vs. "several reusable utils being re-implemented; 7 opportunities, all Safe").
+2. **🧭 Approach / design** (if any)
+3. **🔍 Clarity** (if any)
+4. **✨ Quality** (if any)
+5. **🐛 Bugs (route to /candid-review)** — if any, suppressed by `--no-bugs`
+6. **✅ What's good** — keep brief, one or two lines acknowledging where the code already reads well
+7. **Fix selection prompt** (Step 9)
+8. **Commit summary** — if `--auto-commit` ran successfully
+
+---
+
+## Your Character
+
+**Core traits:**
+- **Curious** — you ask "what's the simplest version of this?" before "what's wrong?"
+- **Specific** — every suggestion has a `file:line` and a concrete before/after
+- **Honest about cost** — every Tradeoff line is filled in; "None — strictly better" only when truly so
+- **Restrained** — you'd rather surface 4 great opportunities than 12 mediocre ones
+
+**Harsh mode adds:**
+- Direct, no hedging
+- Calls out lazy design choices and quietly misleading names by name
+- "This name is doing PR for the function" energy
+
+**Constructive mode adds:**
+- Explains the *why* in full
+- Acknowledges where the existing approach was a reasonable first cut
+- Multiple alternative phrasings when the call is close
+
+---
+
+## Remember
+
+The goal is **the next version of this code** — not the perfect version, not the version with every feature, just the version someone returning to it in 3 months will thank the past author for.
+
+Every opportunity:
+1. Names a specific file:line
+2. Shows a concrete before/after (not just prose)
+3. Says what's gained
+4. Says what's traded off
+5. Can be applied or tracked
+
+If you can't fill in all five, the opportunity isn't ready. Drop it.

--- a/skills/candid-improve-implementation/SKILL.md
+++ b/skills/candid-improve-implementation/SKILL.md
@@ -24,7 +24,7 @@ The signal you ARE hunting:
 2. **🔍 Clarity** — Names that mislead or under-describe. Control flow that hides intent (deep nesting, flag arguments, mixed levels of abstraction). Comments that should be code, code that should be a comment, and comments that should be deleted.
 3. **✨ Quality** — Idiomatic fit with the language/framework. Dead code, unused branches, leftover scaffolding. Testability friction (hard-to-mock seams, hidden dependencies). Cheap performance wins that don't trade off clarity.
 
-Quality over quantity. Cap output at **7 high-signal opportunities**. Drop low-impact suggestions even if technically valid.
+Quality over quantity. Cap output at **`maxOpportunities` high-signal opportunities** (default 7, configurable via `improve.maxOpportunities` — see Step 3). Drop low-impact suggestions even if technically valid.
 
 ---
 
@@ -92,9 +92,13 @@ Check CLI arguments for review options.
 
 **Focus Precedence (highest to lowest):**
 1. CLI flag (`--focus approach`)
-2. Project config (`.candid/config.json` → `focus` field)
-3. User config (`~/.candid/config.json` → `focus` field)
+2. Project config (`.candid/config.json` → `improve.focus` field — extract via `jq -r '.improve.focus // "none"'`)
+3. User config (`~/.candid/config.json` → `improve.focus` field — same path)
 4. No focus (review all three categories)
+
+**Important:** the path is `improve.focus` (nested), not the top-level `focus` field. Top-level `focus` belongs to `candid-review` and uses different valid values (`security|performance|architecture|edge-case`). Reading the wrong field cross-contaminates the two skills.
+
+Valid values for `improve.focus`: `"approach"`, `"clarity"`, or `"quality"` (case-sensitive). Invalid values show a warning and are ignored.
 
 | Focus Area | Categories Surfaced |
 |------------|---------------------|
@@ -110,7 +114,22 @@ Same behavior as `candid-review`: merge CLI exclusions with config exclusions, a
 
 #### Bugs Section (`--no-bugs`)
 
-If `--no-bugs` is provided OR config sets `noBugs: true`, suppress the 🐛 Bugs section entirely. Do not flag any defects. Default = include bugs section (one-line each, route to candid-review).
+**Precedence (highest to lowest):**
+1. CLI flag `--no-bugs` (suppress)
+2. Project config (`.candid/config.json` → `improve.noBugs` boolean — extract via `jq -r '.improve.noBugs // null'`)
+3. User config (`~/.candid/config.json` → `improve.noBugs` boolean — same path)
+4. Default `false` (bugs section included)
+
+If suppression is active from any source, do not flag any defects in the 🐛 Bugs section. Otherwise emit one-line each, route to `/candid-review`. Invalid (non-boolean) config values show a warning and fall through to the next source.
+
+#### Max Opportunities (`improve.maxOpportunities`)
+
+**Precedence (highest to lowest):**
+1. Project config (`.candid/config.json` → `improve.maxOpportunities` integer — extract via `jq -r '.improve.maxOpportunities // null'`)
+2. User config (`~/.candid/config.json` → `improve.maxOpportunities` integer — same path)
+3. Default `7`
+
+Validate: must be a positive integer in range 1-50. Out-of-range or non-integer values show a warning and fall through. Store the resolved value as `maxOpportunities` and use it in Step 7's cap (do not use the literal `7`).
 
 #### Auto-Commit (`--auto-commit`)
 
@@ -185,14 +204,14 @@ If you genuinely see a real defect (not edge-case speculation), surface it as on
 
 ### Step 7: Rank & Cap
 
-Across all three categories, you may have surfaced 10-20 candidates. **Cap the final list at 7 opportunities.** Selection criteria, in order:
+Across all three categories, you may have surfaced 10-20 candidates. **Cap the final list at `maxOpportunities` opportunities** (the value loaded in Step 3 — default 7). Selection criteria, in order:
 
 1. **Highest leverage** — fixes a structural choice that propagates through the rest of the file
 2. **Highest reuse signal** — opportunities that cite an existing util/pattern in the codebase (Approach category)
 3. **Lowest cost-to-apply** — Safe ✓ items that strictly improve clarity with no behavior change
 4. **Drop everything else.** A 4-item review the user actually applies beats a 12-item review the user skims.
 
-If the diff is small enough that 7 is overkill, surface fewer. Truth-telling matters more than checklist completeness.
+If the diff is small enough that `maxOpportunities` is overkill, surface fewer. Truth-telling matters more than checklist completeness.
 
 ### Step 8: Present Opportunities
 


### PR DESCRIPTION
## Summary
- Add `/candid-improve-implementation` skill (v1.18.0): improvement-lens pass — distinct from candid-review's defect hunt. Surfaces opportunities across approach / clarity / quality with concrete before/after, why-it's-better, and tradeoff per item. Capped at `improve.maxOpportunities` (default 7). Mirrors candid-review's tone loader and three-phase fix selection.
- New homepage step "Improve" inserted between Review and Ship in the marketing-page workflow list.
- Dedicated docs page at `/docs/core-features/candid-improve-implementation` with categories, flags, examples, and a full diff-vs-candid-review table.
- Apply candid-review fixes (4 issues) — patched internal contract violations where SKILL.md hardcoded behavior that CONFIG.md / docs page promised was configurable: `improve.maxOpportunities`, `improve.focus` config path, `improve.noBugs` config loader, and `.candid/last-improve.json` gitignore entry.

## Verification
- Install: SKIPPED
- Review: PASS — 1 iteration, 4 issues fixed
- Build: SKIPPED
- Tests: SKIPPED

Note: docs site has pre-existing prerender failures on `/docs/quickstart/react` and `/docs/core-features/slash-commands` that reproduce on `origin/stable` with this branch's changes stashed — not a regression from this branch. The new MDX page on this branch compiles cleanly.

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*