### PR TITLE
Skill token-efficiency pass — 75 edits, ~1,770 lines cut (v1.19.1)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "name": "candid",
       "source": "./.codex-plugin",
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.1] - 2026-07-04
+
+### Changed
+
+- **Token-efficiency pass across all 10 skills** (~1,770 lines removed from always-loaded context, zero behavior change):
+  - **Progressive disclosure**: `candid-init`'s 10 agent-prompt templates moved verbatim to `skills/candid-init/reference/` (loaded only in thorough mode); `candid-review`'s 75-line edge-case checklist moved to `skills/candid-review/EDGE-CASE.md` (loaded only with `--focus edge-case`)
+  - **Config example galleries trimmed**: `candid-review/CONFIG.md` and `candid-improve-implementation/CONFIG.md` reduced from ~18 examples each to the 2–4 that add information beyond the schema
+  - **Boilerplate dedupe**: the CLI → project config → user config → default precedence ladder now stated once per skill instead of once per field; duplicate `--auto-commit` spec, repeated summary/banner templates, and identity mappings removed
+  - **Command files now delegate**: `commands/*.md` recaps of workflow/output/config deleted — they double-loaded with SKILL.md on every invocation
+  - **Shared templates**: ship/fast-ship plan boxes unified in `candid-ship/WORKFLOW.md`; chrome-qa-fix's three identical unsupported-provider warnings merged into one
+  - All review criteria, severity/category definitions, checklists, output strings, and defaults preserved verbatim
+
 ## [1.19.0] - 2026-05-12
 
 ### Added

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -114,17 +114,7 @@ Return findings as structured JSON for the main skill to format:
 
 ## Tone Application
 
-**Harsh mode:**
-- Be direct and blunt
-- Use "This will break" not "This might cause issues"
-- Express appropriate frustration at obvious mistakes
-- Keep it technical, not personal
-
-**Constructive mode:**
-- Explain the reasoning thoroughly
-- Acknowledge complexity when present
-- Offer alternative approaches
-- Connect issues to learning opportunities
+Harsh: direct, blunt, "this will break" phrasing. Constructive: explain reasoning, acknowledge complexity, offer alternatives.
 
 ## Quality Checklist
 
@@ -137,39 +127,6 @@ Before returning, verify you've checked:
 - [ ] Each issue has file:line reference
 - [ ] Each issue has concrete fix
 - [ ] No false positives (verified issues are real)
-
-## Example Output
-
-```json
-{
-  "summary": "Reviewed 3 files in authentication module. Found 2 critical security issues and 3 code smells.",
-  "issues": [
-    {
-      "category": "critical",
-      "title": "JWT secret in source code",
-      "file": "src/auth/jwt.ts",
-      "line": 15,
-      "problem": "JWT_SECRET hardcoded as string literal",
-      "impact": "Anyone with repo access can forge tokens. Security breach.",
-      "fix": "const JWT_SECRET = process.env.JWT_SECRET;\nif (!JWT_SECRET) throw new Error('JWT_SECRET required');"
-    },
-    {
-      "category": "standards",
-      "title": "Missing input validation",
-      "file": "src/auth/login.ts",
-      "line": 22,
-      "problem": "Email and password used without validation",
-      "impact": "Violates security standards, potential injection",
-      "fix": "import { validateEmail, validatePassword } from '../validators';\nif (!validateEmail(email)) throw new ValidationError('Invalid email');",
-      "standard": "Security: All user input must be validated"
-    }
-  ],
-  "good_practices": [
-    "Proper use of bcrypt for password hashing",
-    "Token expiration correctly implemented"
-  ]
-}
-```
 
 ## Remember
 

--- a/commands/candid-chrome-qa-fix.md
+++ b/commands/candid-chrome-qa-fix.md
@@ -48,25 +48,4 @@ Usage:
 /candid-chrome-qa-fix --file .context/findings/2026-04-25-foo.json --strategy local
 ```
 
-Workflow:
-
-1. **Resolve findings file** — `--file` or latest in `.context/findings/`.
-2. **Validate v2.0 schema** — abort on mismatch.
-3. **Filter & summarize** — drop `✓ no issues` markers; apply `--severity` / `--category`.
-4. **Multi-select** — native checkbox UX for ≤15 findings; bulk presets + custom indices for more.
-5. **Strategy** — batched / per-finding (Conductor) / local / issues-only.
-6. **Issue tracker** — optional Linear issue creation, with dedup probe and single-issue invariant.
-7. **Execute** — apply fixes, create PR, or dispatch deep links.
-8. **Summary** — per-finding status + PR/issue links.
-
-Output:
-
-- **Batched mode**: one PR with all selected fixes; Linear issues linked in PR title + body if enabled.
-- **Per-finding mode**: N `conductor://` deep links, each spawning a fresh Conductor workspace that fixes one finding and ships its own PR.
-- **Local mode**: edits applied to the working tree, no PR.
-- **Issues-only mode**: Linear issues created from each finding; no code changes.
-- **Sidecar log**: `.context/findings/<base>.fixes.md` records every fix applied (timestamp, finding ID, files changed).
-
-Configuration: see `skills/candid-chrome-qa-fix/SKILL.md` → `## Configuration`. Provider details: see `skills/candid-chrome-qa-fix/WORKFLOW.md`.
-
-Requires `mcp__claude_ai_Linear__save_issue` + `mcp__claude_ai_Linear__list_issues` to be available when issue creation is enabled. macOS for `open`-launched Conductor deep links (per-finding mode falls back to `--print-links` on other platforms).
+Full workflow, output format, and configuration: the candid-chrome-qa-fix skill.

--- a/commands/candid-chrome-qa.md
+++ b/commands/candid-chrome-qa.md
@@ -47,13 +47,4 @@ Usage:
 /candid-chrome-qa --desktop-only                            # Desktop pass only (skip mobile)
 ```
 
-When invoked, you'll be asked for any inputs not provided via flags:
-- **goal** — what surface to test (e.g. "Agent Config tabs, all 16")
-- **prompt** — free-form QA plan (edge cases, hot spots, recently-changed surfaces)
-- **app URL** — verified before any work begins (curl health check)
-
-Output:
-- **JSON findings file** at `<findings-dir>/<YYYY-MM-DD>-<slug>.json` — v2.0 schema with `context`, `findings`, and end-of-pass `summary` blocks
-- **Stdout summary** at end of pass — severity counts, category breakdown, and titles + URLs of every P0/P1 finding
-
-Requires the `mcp__claude-in-chrome__*` tools to be available (auto-loaded via ToolSearch on first use).
+Full workflow, output format, and configuration: the candid-chrome-qa skill.

--- a/commands/candid-fast-ship.md
+++ b/commands/candid-fast-ship.md
@@ -24,21 +24,6 @@ Usage:
 /candid-fast-ship --dry-run         # Show plan without executing
 ```
 
-Configure which steps run in `.candid/config.json`:
-```json
-{
-  "fastShip": {
-    "review": false,
-    "install": false,
-    "build": false,
-    "tests": false,
-    "issueTracker": false,
-    "autoMerge": false,
-    "postMergeCommand": false
-  }
-}
-```
-
-Command values (buildCommand, testCommand, etc.) are inherited from the `ship` block.
+Enable steps via the `fastShip` block in `.candid/config.json` — see the candid-fast-ship skill for keys.
 
 For a full ship with all steps, use `/candid-ship` instead.

--- a/commands/candid-improve-implementation.md
+++ b/commands/candid-improve-implementation.md
@@ -40,10 +40,4 @@ Usage:
 /candid-improve-implementation --auto-commit            # Commit applied suggestions
 ```
 
-The skill will:
-1. Detect changes (unstaged → branch diff vs merge target)
-2. Load Technical.md standards (if present)
-3. Read full files for context (not just the diff)
-4. Surface opportunities ranked by impact (cap at 7)
-5. Let you choose which to apply via three-phase selection
-6. Save state for future comparisons
+Full workflow, output format, and configuration: the candid-improve-implementation skill.

--- a/commands/candid-optimize.md
+++ b/commands/candid-optimize.md
@@ -27,9 +27,4 @@ Usage:
 /candid-optimize --section config         # Only analyze config tuning
 ```
 
-The audit covers:
-1. **Token budget estimation** — breakdown of what consumes context during reviews
-2. **Technical.md efficiency** — verbose rules, near-duplicates, low-signal rules
-3. **Exclude patterns** — generated files, build output, lock files missing from exclusions
-4. **Decision register** — size, mode optimization, pruning old entries
-5. **Config tuning** — missing config, branch targets, focus mode suggestions
+Full workflow, output format, and configuration: the candid-optimize skill.

--- a/commands/candid-review.md
+++ b/commands/candid-review.md
@@ -36,10 +36,4 @@ Usage:
 /candid-review --re-review               # Compare to previous review
 ```
 
-The review will:
-1. Detect your changes (staged > unstaged > branch diff)
-2. Load Technical.md standards (if present)
-3. Analyze with architectural context
-4. Present categorized issues with fixes
-5. Let you choose which fixes to apply
-6. Save review state for future comparisons
+Full workflow, output format, and configuration: the candid-review skill.

--- a/commands/candid-ship.md
+++ b/commands/candid-ship.md
@@ -40,12 +40,4 @@ Usage:
 /candid-ship --dry-run              # Show plan without executing
 ```
 
-The workflow:
-1. Pre-flight checks (gh CLI, git repo, branch validation)
-2. Run candid-loop to review and fix code issues
-3. Install dependencies (when ship.installCommand is configured)
-4. Execute configured build command
-5. Execute configured test command
-6. Create pull request via gh CLI
-7. Optionally update issue tracker (Linear) via MCP
-8. Optionally auto-merge via gh pr merge --squash --auto
+Full workflow, output format, and configuration: the candid-ship skill.

--- a/commands/candid-validate-standards.md
+++ b/commands/candid-validate-standards.md
@@ -20,8 +20,4 @@ Usage:
 /candid-validate-standards --fix        # Include suggested rewrites
 ```
 
-Checks for:
-- Vague rules that can't be verified ("write clean code")
-- Rules that duplicate what linters already check
-- Rules without clear boundaries or thresholds
-- Overly complex rules that span multiple concerns
+Full workflow, output format, and configuration: the candid-validate-standards skill.

--- a/skills/candid-chrome-qa-fix/SKILL.md
+++ b/skills/candid-chrome-qa-fix/SKILL.md
@@ -205,7 +205,7 @@ For supported providers, iterate the issue-creation list (selected, unselected, 
 3. Else, build the payload (see WORKFLOW.md → `Linear Payload`) and call `mcp__claude_ai_Linear__save_issue`.
 4. Capture `{ findingId, issueId, url, status: "created" | "reused" | "failed" | "skipped-ambiguous" }` into the **issue map**.
 
-Pre-create confirmation: if creating ≥ 5 new issues, show the list and ask `"Create N issues in <provider>:<teamKey>? (Y/n)"` via `AskUserQuestion`.
+Pre-create confirmation: if creating ≥ 5 new issues, follow WORKFLOW.md → Pre-fan-out Confirmation before the first create call.
 
 After the loop, print:
 
@@ -345,10 +345,8 @@ Issues filed:  <I> created, <R> reused, <F> failed   (omit row if tracker disabl
 
 Per finding:
   ✓ F-a3f29b71 [P0] Save button does nothing — PR: https://github.com/.../pull/123 | Issue: TEAM-1234
-  ✓ F-7c29f912 [P1] Icon button missing label — applied locally | Issue: reused TEAM-1180
   ✗ F-2bff1004 [P1] Stale state on org switch — failed (test failure: <line>) | Issue: TEAM-1235
-  ◦ F-9af00103 [P2] Touch target too small — issues-only | Issue: TEAM-1236
-  → F-1c00abcd [P1] Settings save loop — Conductor: ron-myers/qa-fix-settings-save-loop
+  …
 ```
 
 Glyph legend: `✓` = fixed + shipped (or applied), `✗` = fix failed, `◦` = issues-only / no fix attempted, `→` = dispatched to Conductor (per-finding mode).
@@ -359,34 +357,9 @@ Omit the `Issue:` column entirely if `issueTracker.enabled === false` or `provid
 
 ## Configuration
 
-### Config File Schema
-
-Add to `.candid/config.json`:
-
-```json
-{
-  "version": 1,
-  "chromeQAFix": {
-    "defaultStrategy": "batched",
-    "maxParallel": 4,
-    "testCommand": "npm test",
-    "branchPrefix": "ron-myers",
-    "conductorRepoPath": "candid-v1",
-    "issueTracker": {
-      "enabled": false,
-      "provider": "linear",
-      "teamKey": "ENG",
-      "state": "Backlog",
-      "labels": ["qa-finding", "chrome-qa"],
-      "priorityMap": { "P0": 1, "P1": 2, "P2": 3, "P3": 3, "P4": 4, "P5": 0 },
-      "dedupe": true,
-      "prompt": "Create one Linear issue from this single QA finding only — this issue only. Do not create issues for any other findings. Do not search for or update any other Linear issues. Use the structured payload exactly."
-    }
-  }
-}
-```
-
 ### Field Reference
+
+Add under `chromeQAFix` in `.candid/config.json`:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -400,9 +373,9 @@ Add to `.candid/config.json`:
 | `issueTracker.teamKey` | string | none | **Required** when `provider === "linear"` and `enabled === true`. Linear team key (e.g. `"ENG"`). |
 | `issueTracker.state` | string | `"Backlog"` | Initial state for new issues. |
 | `issueTracker.labels` | array | `["qa-finding", "chrome-qa"]` | Base labels. The finding's `category` is appended at create time. |
-| `issueTracker.priorityMap` | object | see schema | Map from finding severity to Linear priority (0=No-priority…4=Low; 1=Urgent). |
+| `issueTracker.priorityMap` | object | `{"P0":1,"P1":2,"P2":3,"P3":3,"P4":4,"P5":0}` | Map from finding severity to Linear priority (0=No-priority…4=Low; 1=Urgent). |
 | `issueTracker.dedupe` | boolean | `true` | If true, search for existing issues with the same `F-id` before creating. |
-| `issueTracker.prompt` | string | see schema | Encodes the **single-issue invariant**. Custom prompts must contain one of `"only this one issue"`, `"only this single issue"`, `"only one issue"`, `"this issue only"`. |
+| `issueTracker.prompt` | string | `"Create one Linear issue from this single QA finding only — this issue only. Do not create issues for any other findings. Do not search for or update any other Linear issues. Use the structured payload exactly."` | Encodes the **single-issue invariant**. Custom prompts must contain one of `"only this one issue"`, `"only this single issue"`, `"only one issue"`, `"this issue only"`. |
 
 ### Examples
 
@@ -424,40 +397,9 @@ Add to `.candid/config.json`:
   }
 }
 ```
-
-**Force local-only by default with issues filed (review then ship manually):**
-```json
-{
-  "chromeQAFix": {
-    "defaultStrategy": "local",
-    "issueTracker": { "enabled": true, "provider": "linear", "teamKey": "ENG" }
-  }
-}
-```
-
-## CLI Examples
-
-```bash
-# Resolve latest findings file, prompt for selection and strategy
-/candid-chrome-qa-fix
-
-# Specific file, only P0 + P1 findings
-/candid-chrome-qa-fix --file .context/findings/2026-04-25-agent-config-ai-setup.json --severity P0,P1
-
-# Per-finding mode — emit deep links but don't open them (dry run)
-/candid-chrome-qa-fix --strategy per-finding --print-links
-
-# File-only mode (no fixes) — file every fixable finding into Linear
-/candid-chrome-qa-fix --strategy issues-only
-
-# Batched + Linear issues + override team
-/candid-chrome-qa-fix --strategy batched --create-issues --tracker-team DIS
-
-# Force-disable tracker even if config has it on
-/candid-chrome-qa-fix --no-create-issues
-```
-
 ## CLI Flags
+
+e.g. `/candid-chrome-qa-fix --file <path> --severity P0,P1 --strategy batched --create-issues`
 
 | Flag | Description |
 |---|---|

--- a/skills/candid-chrome-qa-fix/WORKFLOW.md
+++ b/skills/candid-chrome-qa-fix/WORKFLOW.md
@@ -164,47 +164,21 @@ Proceed?
 
 For `N < 5`, no confirmation needed — proceed.
 
-## Create Issue From Finding (GitHub)
+## Unsupported providers (github, jira, asana)
 
-**Not yet implemented.** When invoked, output:
+Not yet implemented. Output (substitute the provider name):
 
 ```
-⚠️  Issue tracker provider "github" is not yet supported.
+⚠️  Issue tracker provider "<provider>" is not yet supported.
 Request support at: https://github.com/ron-myers/candid/issues
 Skipping tracker step. Code fixes will still proceed.
 ```
 
-When implementing in a future PR, the contract surface is:
+Future contract notes:
 
-- Map finding to GitHub issue title + body
-- Map severity to GitHub label (e.g., `priority:p0` … `priority:p5`)
-- Use `gh issue create --repo <owner/repo> --title <title> --body <body> --label <labels>` via Bash (no GitHub MCP required)
-- Dedup probe: `gh issue list --search "F-<id> in:body" --state all --json number,url,title`
-- Output `{ id: "<owner>/<repo>#<number>", url, status }`
-
-## Create Issue From Finding (Jira)
-
-**Not yet implemented.** When invoked, output:
-
-```
-⚠️  Issue tracker provider "jira" is not yet supported.
-Request support at: https://github.com/ron-myers/candid/issues
-Skipping tracker step. Code fixes will still proceed.
-```
-
-Future contract: REST API via `JIRA_TOKEN` env var, project key from config, severity mapped to priority field, F-id stored in `customfield_xxxxx` for dedup.
-
-## Create Issue From Finding (Asana)
-
-**Not yet implemented.** When invoked, output:
-
-```
-⚠️  Issue tracker provider "asana" is not yet supported.
-Request support at: https://github.com/ron-myers/candid/issues
-Skipping tracker step. Code fixes will still proceed.
-```
-
-Future contract: Asana API via `ASANA_TOKEN`, project GID from config, severity mapped to custom field, F-id in description for dedup.
+- **GitHub**: map finding to issue title + body; map severity to `priority:pN` labels; create via `gh issue create --repo <owner/repo> --title --body --label` (no MCP); dedup via `gh issue list --search "F-<id> in:body" --state all --json number,url,title`; output `{ id: "<owner>/<repo>#<number>", url, status }`.
+- **Jira**: REST API via `JIRA_TOKEN`, project key from config, severity→priority field, F-id in a custom field for dedup.
+- **Asana**: API via `ASANA_TOKEN`, project GID from config, severity→custom field, F-id in description for dedup.
 
 ## Provider: "none"
 

--- a/skills/candid-chrome-qa/SKILL.md
+++ b/skills/candid-chrome-qa/SKILL.md
@@ -24,7 +24,7 @@ CLI flags (full set):
 | `--goal "<text>"` | Pre-fill the goal prompt. Skip the interactive ask. |
 | `--prompt "<text>"` | Pre-fill the QA-plan prompt. Skip the interactive ask. |
 | `--routes "/p1,/p2"` | Comma-separated list of routes to walk. Each becomes one target, bypassing goal-derived target inference. |
-| `--severity-floor P3` | Persist only findings at or above this severity (`P0` highest, `P5` lowest). Default `P5` (all). Findings below the floor are still walked and counted toward the `summary` block — they're just not appended to the file. |
+| `--severity-floor P3` | Persist only findings at or above this severity (`P0` highest, `P5` lowest). Default `P5` (all). Below-floor findings are still walked — see per-target loop step 7. |
 | `--viewports "1440x900,390x844"` | Override `chromeQA.desktopViewport` / `chromeQA.mobileViewport` from config. First value = desktop, second = mobile. |
 | `--findings-dir <path>` | Override findings output directory (default `.context/findings`). The directory is `mkdir -p`'d on each pass. |
 | `--mobile-only` | Explicit opt-out from the desktop pass. Runs **only** the mobile pass. Documented exception to Hard Rule 6. |
@@ -215,12 +215,6 @@ After desktop pass:
 
 **Resize ceiling fallback:** Chrome may enforce a minimum content width of ~1075 px on the active tab depending on UI chrome. If `resize_window` to 390 wide doesn't take effect, try the smallest you can reach (often ~500 px) — the mobile breakpoint still triggers, the desktop sidebar still hides, and the hamburger drawer still appears. Note the actual width reached in the finding's `evidence`.
 
-**`--mobile-only` flag** inverts the default: skip the desktop pass entirely and run only the mobile sequence above. This is an **explicit opt-out** of Hard Rule 6 (which forbids running mobile without desktop). Use sparingly — most QA passes need both.
-
-**`--desktop-only` flag** skips the mobile pass entirely. Use when the surface is admin-only, internal tooling, or otherwise has no mobile contract to honor. Like `--mobile-only`, it's an explicit opt-out — without the flag, mobile is required.
-
-**`--mobile-only` + `--desktop-only` are mutually exclusive.** If both are passed, error and ask the user which one they meant. Don't silently pick one.
-
 ## Hot-spot stress — when the user provides recent commits or known weak points
 
 For each: drive the recently-changed surface harder. Resize to 700px tall to stress sidebar/scroll fixes; switch orgs mid-edit to stress org-scope; trigger validation; double-click save.
@@ -387,13 +381,12 @@ If you hit a hard blocker (server down mid-pass, dirty-state trap, unrecoverable
 
 ## Common rationalizations — STOP if you catch yourself
 
+If you catch yourself about to do any of these, stop and re-read the relevant section.
+
 | Excuse | Reality |
 |--------|---------|
 | "I'll write the schema my way, it's clearer" | Downstream consumers target `schemaVersion: "2.0"` — your custom fields get dropped, and missing v2-required fields break triage. |
-| "Source review is fine since data is missing" | Silent downgrade. Ask first. |
-| "I'll batch findings at the end for cleanliness" | Context exhausts. Findings lost. Append per-finding. |
 | "Mobile is similar to desktop, skip it" | Found mobile-only bugs ~30% of pass. Don't skip unless `--mobile-only` was passed. |
-| "Console looks clean, skip the probe" | Probes catch DOM-level a11y issues clicks miss. Run them. |
 | "Click-tested ~all interactions, no need for edge cases" | Edge cases (empty/invalid/rapid-double-click) are where the bugs live. Run at least one per target. |
 | "User said skip the pre-flight" | They didn't. Ask before skipping. |
 | "I'll add `body` back, it's cleaner for humans" | v2 dropped `body` deliberately — pure derivation. Render at consumption time. |
@@ -403,16 +396,3 @@ If you hit a hard blocker (server down mid-pass, dirty-state trap, unrecoverable
 | "User passed `--severity-floor P0` so I'll skip walking the lower-severity stuff" | Wrong layer. Walk everything; drop only at the persist step (#7). The `summary` block must reflect the full walk, otherwise `Top issues: none` becomes a lie when there were P3s you skipped. |
 | "I'll silently override `--viewports` if the second value won't fit" | Use the resize-ceiling fallback (mobile-pass section) and record the actual width reached in the finding's `evidence`. Never silently change user-provided viewports. |
 | "User passed `--routes` so I'll skip the cross-cutting probes" | Cross-cutting probes still run once per pass. `--routes` narrows the per-target loop, not the probes. |
-
-## Red flags — STOP and re-read this skill
-
-- About to write findings without `repro/expected/actual` structure
-- About to skip the desktop pass without `--mobile-only` having been passed
-- About to invent a new top-level field in the JSON
-- About to click "Delete" / "Disconnect" / "Force" without asking
-- About to silently use a stale tab from a prior session
-- About to skip the final summary (JSON `summary` block + stdout block)
-- About to call `mcp__claude-in-chrome__*` without having run Pre-flight step 0
-- About to write `"P0|P1|P2|P3|P4|P5"` as the value of a `severity` field
-
-All of these mean: stop, re-read the relevant section, follow the protocol.

--- a/skills/candid-fast-ship/SKILL.md
+++ b/skills/candid-fast-ship/SKILL.md
@@ -55,23 +55,7 @@ A step is **enabled** only when its `fastShip` toggle is `true` AND the underlyi
 
 Calculate `totalSteps` = 1 (PR creation) + count of enabled steps. Renumber displayed step rows so disabled steps don't take a number.
 
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Candid Fast Ship Plan
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Branch: [currentBranch] → [targetBranch]
-
-Steps (numbers assigned dynamically — only enabled+configured steps get a number):
-  [N]. 🔍 Review code (candid-loop)           [ENABLED | SKIPPED — not enabled]
-  [N]. 🛠️  Install: [installCommand]          [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  [N]. 🔨 Build: [buildCommand]               [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  [N]. 🧪 Tests: [testCommand]                [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  [N]. 📋 Create pull request
-  [N]. 🎯 Update issue tracker ([provider])   [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-  [N]. 🔀 Auto-merge                          [ENABLED | SKIPPED — not enabled]
-  [N]. 🚀 Post-merge: [postMergeCommand]      [ENABLED | SKIPPED — not enabled | SKIPPED — not configured]
-```
+Render the plan per skills/candid-ship/WORKFLOW.md → "Display Plan": header `Candid Fast Ship Plan`, statuses `[ENABLED | SKIPPED — not enabled | SKIPPED — not configured]`.
 
 If all optional steps are disabled, append `(All optional steps disabled — only PR creation will run)`.
 
@@ -83,17 +67,9 @@ If all optional steps are disabled, append `(All optional steps disabled — onl
 
 **Skip if** `fastShip.review` is `false` → `Skipping review (not enabled in fastShip config)`. Otherwise execute WORKFLOW.md → "Run Review (candid-loop)". Use `ship.additionalPrompt` if set.
 
-### Step 5: Install Dependencies
+### Steps 5-7: Install, Build, Tests
 
-**Skip if** `fastShip.install` is `false` → `Skipping install (not enabled in fastShip config)`. Skip if `fastShip.install` is `true` but `ship.installCommand` is not set → `Skipping install (installCommand not configured in ship)`. Otherwise execute WORKFLOW.md → "Install Dependencies".
-
-### Step 6: Run Build
-
-**Skip if** `fastShip.build` is `false` → `Skipping build (not enabled in fastShip config)`. Skip if `fastShip.build` is `true` but `ship.buildCommand` is not set → `Skipping build (buildCommand not configured in ship)`. Otherwise execute WORKFLOW.md → "Run Build".
-
-### Step 7: Run Tests
-
-**Skip if** `fastShip.tests` is `false` → `Skipping tests (not enabled in fastShip config)`. Skip if `fastShip.tests` is `true` but `ship.testCommand` is not set → `Skipping tests (testCommand not configured in ship)`. Otherwise execute WORKFLOW.md → "Run Tests".
+For each of install/build/tests: skip if its `fastShip.[step]` toggle is `false` → `Skipping [step] (not enabled in fastShip config)`; skip if the toggle is `true` but the corresponding `ship` command (`installCommand`/`buildCommand`/`testCommand`) is unset → `Skipping [step] ([commandField] not configured in ship)`; otherwise execute the matching WORKFLOW.md section ("Install Dependencies", "Run Build", "Run Tests").
 
 ### Step 8: Create Pull Request
 
@@ -151,11 +127,6 @@ For full validation rules see `skills/candid-review/CONFIG.md` (the `fastShip` s
 { "fastShip": {} }
 ```
 
-**Build check + PR only:**
-```json
-{ "fastShip": { "build": true } }
-```
-
 **Install + build + auto-merge:**
 ```json
 {
@@ -169,11 +140,6 @@ For full validation rules see `skills/candid-review/CONFIG.md` (the `fastShip` s
     "autoMerge": true
   }
 }
-```
-
-**Docs change — just PR and issue tracker update:**
-```json
-{ "fastShip": { "issueTracker": true, "autoMerge": true } }
 ```
 
 ## CLI Examples

--- a/skills/candid-improve-implementation/CONFIG.md
+++ b/skills/candid-improve-implementation/CONFIG.md
@@ -64,39 +64,7 @@ Validation: must be `"approach"`, `"clarity"`, or `"quality"`.
 
 ## Error Handling
 
-### Invalid JSON
-- **Error message:** `"malformed JSON"`
-- **Action:** Show warning, continue to next precedence level
-
-### Invalid `improve.focus` Value
-- **Error message:** `'invalid improve.focus "[value]" (must be "approach", "clarity", or "quality")'`
-- **Action:** Show warning, continue to next precedence level
-
-### Invalid `improve.maxOpportunities` Value
-- **Error message:** `'invalid improve.maxOpportunities "[value]" (must be positive integer 1-50)'`
-- **Action:** Show warning, use default (7)
-
-### Invalid `improve.noBugs` Value
-- **Error message:** `'invalid improve.noBugs "[value]" (must be boolean)'`
-- **Action:** Show warning, use default (false)
-
-## Warning Message Template
-
-```
-⚠️  Invalid config at [path]: [specific error]. Falling back to [next source].
-```
-
-### Examples
-
-**Invalid focus:**
-```
-⚠️  Invalid config at .candid/config.json: invalid improve.focus "design" (must be "approach", "clarity", or "quality"). Falling back to user config.
-```
-
-**Invalid maxOpportunities:**
-```
-⚠️  Invalid config at ~/.candid/config.json: invalid improve.maxOpportunities "100" (must be positive integer 1-50). Using default (7).
-```
+On any invalid value, show `⚠️  Invalid config at [path]: [specific error]. Falling back to [next source].` and continue to the next precedence level (or the default for maxOpportunities/noBugs). Specific errors: `malformed JSON`; `invalid improve.focus "[value]" (must be "approach", "clarity", or "quality")`; `invalid improve.maxOpportunities "[value]" (must be positive integer 1-50)`; `invalid improve.noBugs "[value]" (must be boolean)`.
 
 ## Success Message Template
 
@@ -119,45 +87,6 @@ Capping opportunities at [N] (from [source])
 ## Config File Examples
 
 ### Valid Configs
-
-**Minimal (use defaults):**
-```json
-{
-  "tone": "constructive"
-}
-```
-
-**Improvement-focused defaults:**
-```json
-{
-  "tone": "harsh",
-  "improve": {
-    "focus": "approach",
-    "noBugs": true
-  }
-}
-```
-
-**Tight cap on opportunities:**
-```json
-{
-  "tone": "constructive",
-  "improve": {
-    "maxOpportunities": 3
-  }
-}
-```
-
-**With exclusions:**
-```json
-{
-  "tone": "harsh",
-  "exclude": ["*.generated.ts", "vendor/*", "**/*.min.js"],
-  "improve": {
-    "focus": "clarity"
-  }
-}
-```
 
 **Full config (improve + shared fields):**
 ```json
@@ -190,31 +119,4 @@ Capping opportunities at [N] (from [source])
 ```
 Here `focus: "security"` applies to `/candid-review`; `improve.focus: "clarity"` applies to `/candid-improve-implementation`. They do not interfere.
 
-### Invalid Configs
-
-**Invalid focus value:**
-```json
-{
-  "improve": {
-    "focus": "design"
-  }
-}
-```
-
-**Wrong type for noBugs:**
-```json
-{
-  "improve": {
-    "noBugs": "yes"
-  }
-}
-```
-
-**Out-of-range maxOpportunities:**
-```json
-{
-  "improve": {
-    "maxOpportunities": 200
-  }
-}
-```
+Wrong-type or out-of-range improve.* values warn and fall through to the next source.

--- a/skills/candid-improve-implementation/SKILL.md
+++ b/skills/candid-improve-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: candid-improve-implementation
-description: Use when the code works and you want a focused pass on opportunities to improve approach, clarity, and quality - distinct from candid-review's defect hunt. Surfaces simpler structures, clearer names, idiomatic alternatives, dead weight to remove, and abstractions to collapse or introduce. Each suggestion comes with a concrete before/after, why it's better, what's traded off, and confidence level. Three-phase fix selection mirrors candid-review.
+description: Use when the code works and you want a focused pass on improving approach, clarity, and quality — distinct from candid-review's defect hunt. Each suggestion includes a concrete before/after, tradeoffs, and confidence level.
 ---
 
 # Improvement Lens — candid-improve-implementation
@@ -32,14 +32,7 @@ Quality over quantity. Cap output at **`maxOpportunities` high-signal opportunit
 
 ### Step 1: Load Project Standards
 
-Check for Technical.md (project-specific standards):
-
-```
-1. Read ./Technical.md (project root)
-2. If not found, read ./.candid/Technical.md
-3. If found, use these standards to inform your review
-4. If not found, proceed without project-specific standards
-```
+Load project standards: ./Technical.md, falling back to ./.candid/Technical.md; if neither exists, proceed without them.
 
 When Technical.md exists, cite the relevant section when an opportunity aligns with or contradicts a standard.
 
@@ -86,54 +79,17 @@ For each branch in `mergeTargetBranches`, try `git diff <branch>...HEAD --stat 2
 
 ### Step 3: Parse Options
 
-Check CLI arguments for review options.
+All options resolve CLI flag → project config (`.candid/config.json`) → user config (`~/.candid/config.json`) → default. Validation, jq extraction paths, and warning formats are in `CONFIG.md`; invalid values warn and fall through to the next source.
 
-#### Focus Mode (`--focus`)
+| Option | CLI flag | Config field | Values / default |
+|---|---|---|---|
+| Focus | `--focus <area>` | `improve.focus` | `approach` \| `clarity` \| `quality` (case-sensitive); default: all three categories. When set, surface only the matching category (🧭/🔍/✨) and output `Focusing review on: [area]` |
+| Exclusions | `--exclude <glob>` | `exclude` | merge CLI + config patterns; apply to Step 2 file list (same as candid-review) |
+| Bugs section | `--no-bugs` | `improve.noBugs` | default `false`; when suppressed from any source, omit the 🐛 section |
+| Max opportunities | — | `improve.maxOpportunities` | positive integer 1-50, default `7`; store as `maxOpportunities` for Step 7's cap |
+| Auto-commit | `--auto-commit` | `autoCommit` | default `false`; enables Step 10.5 |
 
-**Focus Precedence (highest to lowest):**
-1. CLI flag (`--focus approach`)
-2. Project config (`.candid/config.json` → `improve.focus` field — extract via `jq -r '.improve.focus // "none"'`)
-3. User config (`~/.candid/config.json` → `improve.focus` field — same path)
-4. No focus (review all three categories)
-
-**Important:** the path is `improve.focus` (nested), not the top-level `focus` field. Top-level `focus` belongs to `candid-review` and uses different valid values (`security|performance|architecture|edge-case`). Reading the wrong field cross-contaminates the two skills.
-
-Valid values for `improve.focus`: `"approach"`, `"clarity"`, or `"quality"` (case-sensitive). Invalid values show a warning and are ignored.
-
-| Focus Area | Categories Surfaced |
-|------------|---------------------|
-| `approach` | 🧭 Approach / design only |
-| `clarity` | 🔍 Clarity only |
-| `quality` | ✨ Quality only |
-
-When focus is set: `Focusing review on: [area]`
-
-#### File Exclusions (`--exclude`)
-
-Same behavior as `candid-review`: merge CLI exclusions with config exclusions, apply to file list in Step 2. Common patterns: `*.generated.ts`, `vendor/*`, `**/node_modules/**`.
-
-#### Bugs Section (`--no-bugs`)
-
-**Precedence (highest to lowest):**
-1. CLI flag `--no-bugs` (suppress)
-2. Project config (`.candid/config.json` → `improve.noBugs` boolean — extract via `jq -r '.improve.noBugs // null'`)
-3. User config (`~/.candid/config.json` → `improve.noBugs` boolean — same path)
-4. Default `false` (bugs section included)
-
-If suppression is active from any source, do not flag any defects in the 🐛 Bugs section. Otherwise emit one-line each, route to `/candid-review`. Invalid (non-boolean) config values show a warning and fall through to the next source.
-
-#### Max Opportunities (`improve.maxOpportunities`)
-
-**Precedence (highest to lowest):**
-1. Project config (`.candid/config.json` → `improve.maxOpportunities` integer — extract via `jq -r '.improve.maxOpportunities // null'`)
-2. User config (`~/.candid/config.json` → `improve.maxOpportunities` integer — same path)
-3. Default `7`
-
-Validate: must be a positive integer in range 1-50. Out-of-range or non-integer values show a warning and fall through. Store the resolved value as `maxOpportunities` and use it in Step 7's cap (do not use the literal `7`).
-
-#### Auto-Commit (`--auto-commit`)
-
-If `--auto-commit` is provided OR config sets `autoCommit: true`, automatically create a git commit after applying suggestions. Same behavior as candid-review's auto-commit (see Step 10.5 below).
+**Important:** the focus path is `improve.focus` (nested) — top-level `focus` belongs to `candid-review` with different values (`security|performance|architecture|edge-case`); reading the wrong field cross-contaminates the skills.
 
 ### Step 4: Load Tone Preference
 
@@ -270,26 +226,7 @@ For each opportunity, use this structured format:
 >
 > **Tradeoff:** One more import at the call site. Worth it.
 
-*Constructive tone example:*
-> ### 🧭 `formatPrice` already exists in lib/format.ts — reuse it
-> **File:** src/checkout/Cart.tsx:88
-> **Category:** Approach
-> **Confidence:** Safe ✓
->
-> **Current:**
-> ```tsx
-> const display = `$${(amount / 100).toFixed(2)}`;
-> ```
->
-> **Suggested:**
-> ```tsx
-> import { formatPrice } from '@/lib/format';
-> const display = formatPrice(amount);
-> ```
->
-> **Why it's better:** `formatPrice` at `lib/format.ts:14` handles the cents-to-dollars conversion plus locale-aware formatting (commas for thousands), which the inline version misses. Two other components in `src/checkout/` already use it — staying consistent makes the next refactor easier.
->
-> **Tradeoff:** None — strictly better.
+*Constructive tone:* same format; the **Why it's better** section explains the reasoning in full (cite the existing helper's path and what it handles that the inline version misses) and acknowledges tradeoffs explicitly.
 
 ### Step 9: Fix Selection (MANDATORY)
 
@@ -354,45 +291,18 @@ TodoWrite all opportunities from Step 7 as pending todos. Confirm count to user.
 
 ### Step 10.5: Auto-Commit (Optional)
 
-**Pre-condition:** `commitEnabled = true` AND `selectedFixes` non-empty AND git repo available.
+**Pre-condition:** auto-commit enabled (Step 3) AND `selectedFixes` non-empty AND git repo. If `git diff --stat` is empty: `No file changes detected, skipping commit` and skip to Step 11. Otherwise `git add` the files in `modifiedFiles` and commit (heredoc) with:
 
-**1. Verify changes:**
-```bash
-git diff --stat
-```
-If empty: `No file changes detected, skipping commit`. Skip to Step 11.
-
-**2. Stage modified files:**
-```bash
-git add <file1> <file2> ...
-```
-Use files from `modifiedFiles` set.
-
-**3. Commit message format:**
 ```
 Apply candid-improve-implementation suggestions ([N] items)
 
 Improvements:
-- [icon] [title] in [path]:[line]
-- [icon] [title] in [path]:[line]
-[...]
+- [icon] [title] in [path]:[line]   (truncate at 10 entries with "- ... and [M] more")
 
 Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>
 ```
 
-Truncate at 10 entries with `- ... and [M] more`.
-
-**4. Create commit:**
-```bash
-git commit -m "$(cat <<'EOF'
-[generated message]
-EOF
-)"
-```
-
-Success: `✅ Created commit: "Apply candid-improve-implementation suggestions ([N] items)"`.
-
-Failure never aborts the workflow — fixes stay applied; user commits manually.
+Success: `✅ Created commit: "Apply candid-improve-implementation suggestions ([N] items)"`. Failure never aborts — fixes stay applied; user commits manually.
 
 ### Step 11: Save State
 
@@ -450,35 +360,10 @@ Present in this order:
 
 ---
 
-## Your Character
-
-**Core traits:**
-- **Curious** — you ask "what's the simplest version of this?" before "what's wrong?"
-- **Specific** — every suggestion has a `file:line` and a concrete before/after
-- **Honest about cost** — every Tradeoff line is filled in; "None — strictly better" only when truly so
-- **Restrained** — you'd rather surface 4 great opportunities than 12 mediocre ones
-
-**Harsh mode adds:**
-- Direct, no hedging
-- Calls out lazy design choices and quietly misleading names by name
-- "This name is doing PR for the function" energy
-
-**Constructive mode adds:**
-- Explains the *why* in full
-- Acknowledges where the existing approach was a reasonable first cut
-- Multiple alternative phrasings when the call is close
-
----
-
 ## Remember
 
-The goal is **the next version of this code** — not the perfect version, not the version with every feature, just the version someone returning to it in 3 months will thank the past author for.
+The goal is **the next version of this code** — the one someone returning in 3 months will thank the author for. Be curious ("what's the simplest version?"), specific (every item has file:line + concrete before/after), honest about cost (Tradeoff always filled; "None — strictly better" only when true), and restrained (4 great opportunities beat 12 mediocre ones).
 
-Every opportunity:
-1. Names a specific file:line
-2. Shows a concrete before/after (not just prose)
-3. Says what's gained
-4. Says what's traded off
-5. Can be applied or tracked
+Harsh mode: direct, no hedging, names lazy choices ("this name is doing PR for the function"). Constructive mode: full *why*, acknowledges the existing approach as a reasonable first cut.
 
-If you can't fill in all five, the opportunity isn't ready. Drop it.
+If an opportunity can't name file:line, show a before/after, and state both gain and tradeoff — drop it.

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -24,32 +24,7 @@ The output should feel like it was written by someone who spent days understandi
 
 **Default: thorough**
 
-### Thorough Mode Architecture
-
-**Phase 1: Analysis Sub-Agents (parallel)**
-Launch 5 Explore agents to analyze the entire codebase:
-- **Architecture Agent**: Reads all controllers/services/repos, maps dependencies
-- **Naming Agent**: Reads 20-30 files, extracts conventions
-- **Error/Security Agent**: Reads all error handling and auth code
-- **Testing Agent**: Reads all test files
-- **Framework Agent**: Reads all React components or API routes
-
-**Phase 2: Generation Sub-Agents (parallel)**
-Launch 5 generation agents, each writing one section (~80-120 lines):
-- Architecture Section (~100 lines)
-- Naming & Style Section (~80 lines)
-- Error Handling & Logging Section (~80 lines)
-- Testing Section (~80 lines)
-- Security & Framework Section (~100 lines)
-
-**Phase 3: Synthesis**
-Combine all sections + header/footer = ~500 line Technical.md
-
-This two-phase approach works well with Claude Code because:
-- Opus handles complex synthesis and generation
-- Sonnet (via Explore agents) handles efficient file reading
-- Parallel execution maximizes throughput
-- Each agent has focused scope, preventing context overload
+Thorough mode runs 5 parallel analysis sub-agents (Step 6), then 5 parallel generation sub-agents (Step 9), then synthesis.
 
 ---
 
@@ -131,12 +106,8 @@ grep -rhoE "^export (default )?(class|function|const) [A-Z][a-zA-Z]+" --include=
 # What imports what - build mental model of dependencies
 grep -rh "^import.*from" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v node_modules | grep -oE "from ['\"][^'\"]+['\"]" | sort | uniq -c | sort -rn | head -30
 
-# Check for layer violations (controllers importing repos, etc.)
-# If src/controllers/ exists, check what it imports
+# For each layer dir (controllers, services, ...), check what it imports — flags layer violations:
 grep -rh "^import.*from" src/controllers/ --include="*.ts" 2>/dev/null | grep -v node_modules | head -20
-
-# If src/services/ exists, check what it imports
-grep -rh "^import.*from" src/services/ --include="*.ts" 2>/dev/null | grep -v node_modules | head -20
 
 # Check for cross-module imports (feature A importing from feature B)
 grep -rh "^import.*from.*features/" --include="*.ts" 2>/dev/null | grep -v node_modules | head -20
@@ -147,21 +118,7 @@ grep -rh "from '@/\|from '~/\|from 'src/\|from '#" --include="*.ts" --include="*
 
 ### 5.4 Architecture Pattern Detection (Thorough Only)
 
-```bash
-# Barrel exports (index.ts files)
-find . -name "index.ts" -o -name "index.js" 2>/dev/null | grep -v node_modules | wc -l
-# Sample a few to see export patterns
-find . -name "index.ts" 2>/dev/null | grep -v node_modules | head -3 | xargs cat 2>/dev/null
-
-# Dependency injection patterns
-grep -rh "@Injectable\|@Inject\|constructor.*private\|createContext" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v node_modules | head -15
-
-# Middleware/decorator patterns
-grep -rh "@.*Middleware\|@Guard\|@Interceptor\|@UseGuards\|@Auth" --include="*.ts" 2>/dev/null | grep -v node_modules | head -10
-
-# Domain boundaries (look for domain-specific directories)
-find . -type d -name "billing" -o -name "auth" -o -name "users" -o -name "payments" -o -name "orders" 2>/dev/null | grep -v node_modules | head -10
-```
+Detect barrel exports (index.ts count + samples), dependency injection, middleware/decorator patterns, and domain-specific directories — commands in reference/analysis-commands.md.
 
 ### 5.5 Error Handling Analysis (Medium + Thorough)
 
@@ -194,46 +151,15 @@ grep -rh "jest.mock\|vi.mock\|sinon\|@Mock" --include="*.test.*" --include="*.sp
 
 ### 5.7 API Patterns (Medium + Thorough, for Node/Backend)
 
-```bash
-# Route definitions
-grep -rh "router\.\|app\.\(get\|post\|put\|patch\|delete\)\|@Get\|@Post\|@Put\|@Delete" --include="*.ts" 2>/dev/null | grep -v node_modules | head -20
-
-# Validation patterns
-grep -rh "from 'zod'\|from 'yup'\|from 'joi'\|@IsString\|@IsNumber\|z\.object\|Joi\.object" --include="*.ts" 2>/dev/null | grep -v node_modules | head -10
-
-# Auth middleware
-grep -rh "auth.*middleware\|isAuthenticated\|requireAuth\|@Auth\|@UseGuards" --include="*.ts" 2>/dev/null | grep -v node_modules | head -10
-```
+Detect route definitions, validation patterns (zod/yup/joi/decorators), and auth middleware — commands in reference/analysis-commands.md.
 
 ### 5.8 React Patterns (Medium + Thorough, for React)
 
-```bash
-# Hook patterns
-find . -name "use*.ts" -o -name "use*.tsx" 2>/dev/null | grep -v node_modules | head -15
-
-# State management
-grep -rh "from 'redux'\|from 'zustand'\|from '@tanstack/react-query'\|from 'swr'\|createContext\|useReducer" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v node_modules | head -10
-
-# Component patterns
-grep -rh "React.memo\|forwardRef\|React.lazy\|Suspense" --include="*.tsx" 2>/dev/null | grep -v node_modules | head -10
-
-# Event handler naming
-grep -rhoE "(handle|on)[A-Z][a-zA-Z]*" --include="*.tsx" 2>/dev/null | grep -v node_modules | sort | uniq -c | sort -rn | head -15
-```
+Detect custom hooks, state management libraries, component patterns (memo/forwardRef/lazy/Suspense), and event handler naming — commands in reference/analysis-commands.md.
 
 ### 5.9 TypeScript Analysis (Thorough Only)
 
-```bash
-# Strictness
-cat tsconfig.json 2>/dev/null | grep -E "strict|noImplicit"
-
-# Any usage (red flag)
-grep -rc ": any\|as any" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v node_modules | grep -v ":0$" | awk -F: '{sum+=$2} END {print "any/as any count:", sum}'
-
-# Interface vs type preference
-grep -rc "^interface \|^export interface " --include="*.ts" 2>/dev/null | grep -v node_modules | awk -F: '{sum+=$2} END {print "interfaces:", sum}'
-grep -rc "^type \|^export type " --include="*.ts" 2>/dev/null | grep -v node_modules | awk -F: '{sum+=$2} END {print "types:", sum}'
-```
+Detect tsconfig strictness, `any`/`as any` usage counts, and interface-vs-type preference — commands in reference/analysis-commands.md.
 
 ---
 
@@ -252,146 +178,15 @@ Extract: naming patterns, error handling, import organization, examples to cite.
 
 ### Thorough Mode: Sub-Agent Comprehensive Analysis
 
-**Launch 3-5 sub-agents IN PARALLEL** to analyze ALL files in the codebase. Each agent focuses on a specific domain and returns proposed rules with evidence.
+Launch 5 Explore sub-agents IN PARALLEL (Task tool, subagent_type: "Explore"). Read reference/analysis-prompts.md (relative to this skill) for the exact prompt for each:
 
-Use the Task tool with `subagent_type: "Explore"` for each agent.
+1. Architecture & Imports
+2. Naming & Style
+3. Error Handling & Security
+4. Testing Patterns
+5. Framework-Specific (React or Node variant)
 
-#### Agent 1: Architecture & Imports Agent
-
-**Prompt:**
-```
-Analyze the architecture and import patterns in this codebase.
-
-READ all files in these directories (or equivalent):
-- src/controllers/, src/routes/, app/api/
-- src/services/, src/usecases/
-- src/repositories/, src/data/
-- src/models/, src/entities/
-
-For each file, examine:
-1. What does this file import?
-2. What layer is it in?
-3. Are there violations (controller importing repo directly)?
-
-Return:
-- Layer structure diagram (what directories = what layers)
-- Dependency rules (what can import what)
-- Violations found (specific file:line examples)
-- 3-5 proposed architecture rules with file path examples
-```
-
-#### Agent 2: Naming & Style Agent
-
-**Prompt:**
-```
-Analyze naming conventions and code style across the codebase.
-
-READ 20-30 representative files across:
-- Components/UI files
-- Services/business logic
-- Utilities/helpers
-- Tests
-
-For each file, extract:
-1. Class/function/variable naming patterns
-2. File naming patterns
-3. Event handler naming (handle* vs on*)
-4. Boolean naming (is*, has*, should*)
-
-Return:
-- Detected naming conventions with consistency %
-- Specific file examples for each pattern
-- 5-8 proposed naming rules with examples from actual files
-```
-
-#### Agent 3: Error Handling & Security Agent
-
-**Prompt:**
-```
-Analyze error handling and security patterns.
-
-READ all files that:
-- Define custom error classes
-- Have try/catch blocks
-- Handle API responses
-- Deal with authentication/authorization
-- Process user input
-
-For each file, examine:
-1. Error class hierarchy
-2. Error response format
-3. Where errors are caught (boundary vs distributed)
-4. Input validation patterns
-5. Auth patterns
-
-Return:
-- Error handling approach summary
-- Security patterns found (or gaps)
-- Specific file:line examples
-- 5-8 proposed error/security rules with evidence
-```
-
-#### Agent 4: Testing Patterns Agent
-
-**Prompt:**
-```
-Analyze testing patterns across the codebase.
-
-READ all test files (*.test.*, *.spec.*, *_test.*).
-
-For each test file, examine:
-1. Test organization (describe/it patterns)
-2. Setup patterns (beforeEach, fixtures, factories)
-3. Mocking approach
-4. Assertion patterns
-5. What's tested vs what's not
-
-Return:
-- Test organization pattern
-- Naming conventions
-- Coverage gaps (directories without tests)
-- 3-5 proposed testing rules with examples
-```
-
-#### Agent 5: Framework-Specific Agent (React/Node/Python)
-
-**For React:**
-```
-Analyze React patterns across all components.
-
-READ all .tsx files and custom hooks.
-
-Examine:
-1. Component structure patterns
-2. Hook usage patterns
-3. State management approach
-4. Props patterns
-5. Performance patterns (memo, useCallback, useMemo)
-
-Return:
-- Component architecture patterns
-- State management approach
-- 5-8 proposed React rules with component examples
-```
-
-**For Node.js:**
-```
-Analyze API and backend patterns.
-
-READ all route handlers, middleware, and API files.
-
-Examine:
-1. Route organization
-2. Middleware patterns
-3. Validation approach
-4. Response format
-5. Database access patterns
-
-Return:
-- API design patterns
-- Middleware usage
-- 5-8 proposed API rules with endpoint examples
-```
+Each returns proposed rules with file:line evidence.
 
 #### Synthesizing Agent Results
 
@@ -430,19 +225,7 @@ Layer Structure Detected:
 
 ### 7.2 Module Boundary Analysis
 
-If feature-based structure detected:
-
-```
-Module Structure Detected:
-├── src/features/auth/     → Authentication domain
-├── src/features/billing/  → Billing domain
-├── src/features/users/    → User management
-└── src/shared/            → Shared utilities
-```
-
-**Check for cross-module imports and generate rules:**
-- "Feature modules must not import from each other directly. Use `src/shared/` for cross-cutting concerns"
-- "The `billing/` module must not import from `auth/` (separation of concerns)"
+If feature-based structure detected (e.g., `src/features/auth/`, `src/features/billing/`, `src/shared/`), generate cross-module rules the same way, e.g. "Feature modules must not import from each other directly — use `src/shared/` for cross-cutting concerns."
 
 ### 7.3 Detect Violations
 
@@ -462,36 +245,19 @@ grep -rl "from.*repository\|from.*repositories" src/controllers/ 2>/dev/null
 
 Compare detected patterns to best practices. For each category, identify gaps.
 
-### Security Gaps
-
-| Best Practice | Check | If Missing |
-|--------------|-------|------------|
-| Input validation at boundary | Look for zod/joi/yup | "Consider adding Zod for input validation at API boundaries" |
-| Parameterized queries | Check for raw SQL strings | "Found raw SQL in X. Use parameterized queries." |
-| Auth middleware | Check route protection | "Not all routes appear to have auth checks" |
-| Secret management | Check for hardcoded values | "Found potential hardcoded secret in X" |
-
-### Error Handling Gaps
-
-| Best Practice | Check | If Missing |
-|--------------|-------|------------|
-| Custom error classes | Look for extends Error | "No custom error classes found. Consider adding AppError hierarchy." |
-| Consistent error format | Check response patterns | "Error responses use inconsistent formats across files" |
-| Error logging | Check for logger usage | "Errors caught but not logged in X files" |
-
-### Testing Gaps
-
-| Best Practice | Check | If Missing |
-|--------------|-------|------------|
-| Tests exist | Find test files | "No tests found for `src/services/`" |
-| Test organization | Check patterns | "Tests use inconsistent naming (mix of .test.ts and .spec.ts)" |
-
-### TypeScript Gaps
-
-| Best Practice | Check | If Missing |
-|--------------|-------|------------|
-| Strict mode | Check tsconfig | "strict mode not enabled. Consider enabling for new code." |
-| No any | Count any usage | "Found 47 uses of `any`. Consider typing or using `unknown`." |
+| Category | Best Practice | Check | If Missing |
+|----------|--------------|-------|------------|
+| Security | Input validation at boundary | Look for zod/joi/yup | "Consider adding Zod for input validation at API boundaries" |
+| Security | Parameterized queries | Check for raw SQL strings | "Found raw SQL in X. Use parameterized queries." |
+| Security | Auth middleware | Check route protection | "Not all routes appear to have auth checks" |
+| Security | Secret management | Check for hardcoded values | "Found potential hardcoded secret in X" |
+| Error Handling | Custom error classes | Look for extends Error | "No custom error classes found. Consider adding AppError hierarchy." |
+| Error Handling | Consistent error format | Check response patterns | "Error responses use inconsistent formats across files" |
+| Error Handling | Error logging | Check for logger usage | "Errors caught but not logged in X files" |
+| Testing | Tests exist | Find test files | "No tests found for `src/services/`" |
+| Testing | Test organization | Check patterns | "Tests use inconsistent naming (mix of .test.ts and .spec.ts)" |
+| TypeScript | Strict mode | Check tsconfig | "strict mode not enabled. Consider enabling for new code." |
+| TypeScript | No any | Count any usage | "Found 47 uses of `any`. Consider typing or using `unknown`." |
 
 ---
 
@@ -501,336 +267,21 @@ For thorough mode, generate a comprehensive **~500 line** Technical.md by launch
 
 ### Generation Strategy for Claude Code
 
-**Key insight:** Claude Code with Opus/Sonnet can generate long, detailed output when:
-1. Each section is generated independently by a focused sub-agent
-2. Agents have specific analysis results to work from
-3. Final synthesis combines sections without truncation
-
-### Launch 5 Generation Sub-Agents IN PARALLEL
-
-Use the Task tool to launch these agents simultaneously. Each generates ~80-120 lines.
-
-#### Generation Agent 1: Architecture Section (~100 lines)
-
-**Prompt:**
-```
-Generate the Architecture section of a Technical.md file.
-
-Use these analysis results:
-[Paste layer structure, import graph, violations from analysis agents]
-
-Write ~100 lines covering:
-
-## Architecture
-
-### Project Structure Overview
-- Full directory tree with annotations explaining each directory's purpose
-- Which directories are entry points, which are internal
-
-### Layer Architecture
-- Detailed layer diagram with all detected layers
-- What each layer is responsible for
-- Dependencies between layers (what can import what)
-
-### Dependency Rules (15-20 specific rules)
-For each layer/directory, specify:
-- What it CAN import (with path examples)
-- What it CANNOT import (with reasoning)
-- Example: "`src/controllers/` can import from `src/services/` and `src/middleware/`, NOT from `src/repositories/` or `src/models/` directly"
-
-### Module Boundaries
-- Feature/domain boundaries if detected
-- Cross-module communication rules
-- Shared code location and usage rules
-
-### Current Violations
-- List each detected violation with file:line
-- Recommended fix for each
-
-### Reference Implementation
-- Point to 1-2 files that exemplify correct architecture
-```
-
-#### Generation Agent 2: Naming & Code Style Section (~80 lines)
-
-**Prompt:**
-```
-Generate the Naming Conventions and Code Style section of a Technical.md file.
-
-Use these analysis results:
-[Paste naming patterns from analysis agents]
-
-Write ~80 lines covering:
-
-## Naming Conventions
-
-### File Naming (10-15 rules)
-For each file type, specify:
-- Pattern with regex or glob
-- Examples from this codebase
-- Counter-examples (what NOT to do)
-
-### Class & Component Naming (10-15 rules)
-- Suffixes by type (Service, Controller, Repository, etc.)
-- Prefixes if used
-- Examples from actual files
-
-### Function & Method Naming (10-15 rules)
-- Verb prefixes by purpose (get, set, fetch, handle, on, is, has, etc.)
-- Async function naming
-- Event handler naming
-
-### Variable Naming (10-15 rules)
-- Boolean prefixes
-- Constants style
-- Collection naming (plural vs singular)
-- Destructuring conventions
-
-### Import Organization
-- Import ordering rules
-- Path alias usage
-- Barrel export rules
-
-### Code Examples
-Include 2-3 annotated code snippets showing correct naming in context
-```
-
-#### Generation Agent 3: Error Handling & Logging Section (~80 lines)
-
-**Prompt:**
-```
-Generate the Error Handling and Logging section of a Technical.md file.
-
-Use these analysis results:
-[Paste error handling patterns from analysis agents]
-
-Write ~80 lines covering:
-
-## Error Handling
-
-### Error Class Hierarchy
-- Full hierarchy diagram if exists
-- When to use each error type
-- How to create new error types
-
-### Error Handling Patterns (15-20 rules)
-- Where to catch errors (boundary vs distributed)
-- How to wrap errors
-- How to add context
-- What to log vs what to return
-
-### API Error Responses
-- Standard error response format with JSON schema
-- HTTP status code mapping
-- Error code conventions
-- Example responses for common scenarios
-
-### Error Logging
-- What context to include
-- Log levels by error type
-- Sensitive data redaction rules
-
-## Logging
-
-### Log Levels
-- When to use each level
-- Examples for each
-
-### Structured Logging Format
-- Required fields
-- Optional fields by context
-- Example log entries
-
-### What NOT to Log
-- Sensitive data list
-- PII handling
-```
-
-#### Generation Agent 4: Testing Section (~80 lines)
-
-**Prompt:**
-```
-Generate the Testing section of a Technical.md file.
-
-Use these analysis results:
-[Paste testing patterns from analysis agents]
-
-Write ~80 lines covering:
-
-## Testing
-
-### Test Organization
-- File location rules (colocated vs separate)
-- Directory structure for different test types
-- Naming conventions
-
-### Test Naming (10-15 rules)
-- Describe block naming
-- Test case naming patterns
-- Example test names from codebase
-
-### Unit Tests
-- What to unit test
-- What NOT to unit test
-- Mocking rules
-- Assertion patterns
-
-### Integration Tests
-- When required
-- Setup/teardown patterns
-- Database handling
-- API testing patterns
-
-### E2E Tests (if applicable)
-- Critical paths that require E2E
-- Test data management
-- Environment setup
-
-### Test Data
-- Factory patterns
-- Fixture usage
-- Test data cleanup
-
-### Coverage Requirements
-- Minimum coverage by directory/type
-- What's exempt from coverage
-
-### Example Test Structure
-Include 1-2 annotated test file examples showing correct patterns
-```
-
-#### Generation Agent 5: Security & Framework Section (~100 lines)
-
-**Prompt:**
-```
-Generate the Security and Framework-Specific sections of a Technical.md file.
-
-Use these analysis results:
-[Paste security patterns and framework analysis from analysis agents]
-
-Write ~100 lines covering:
-
-## Security (30-40 rules)
-
-### Input Validation
-- Where validation must occur
-- Validation library usage
-- Schema definition rules
-- Example validation code
-
-### Authentication
-- Auth middleware usage
-- Protected route patterns
-- Session/token handling
-- Auth bypass (what's public)
-
-### Authorization
-- Permission checking patterns
-- Role-based access rules
-- Resource ownership verification
-
-### Data Protection
-- Sensitive data handling
-- Encryption requirements
-- PII rules
-
-### API Security
-- Rate limiting
-- CORS configuration
-- Request size limits
-
-### Secrets Management
-- Environment variable naming
-- Secret rotation
-- What never goes in code
-
-## [Framework: React/Node/Python]
-
-### [Framework-specific patterns - 30-40 rules]
-[Detailed rules based on detected framework]
-
-For React:
-- Component patterns
-- Hook rules
-- State management
-- Performance optimization
-- Accessibility requirements
-
-For Node:
-- API design patterns
-- Middleware patterns
-- Database access patterns
-- Async patterns
-
-For Python:
-- Type hints
-- Class patterns
-- Async patterns
-- Documentation requirements
-```
+Each section is generated independently by a focused sub-agent working from specific analysis results, and the final synthesis combines sections without truncation — this lets Claude Code produce long, detailed output. Launch the agents simultaneously.
+
+| Agent | Section | ~Lines |
+|-------|---------|--------|
+| 1 | Architecture | ~100 |
+| 2 | Naming & Style | ~80 |
+| 3 | Error Handling & Logging | ~80 |
+| 4 | Testing | ~80 |
+| 5 | Security & Framework | ~100 |
+
+Read reference/generation-prompts.md (relative to this skill) and launch all 5 agents in parallel via Task, pasting the relevant analysis results into each prompt where indicated.
 
 ### Synthesizing Generated Sections
 
-After all generation agents complete:
-
-1. **Collect all sections** from each agent
-2. **Add header and footer**:
-   - Header: Project name, generation date, analysis summary
-   - Footer: Gaps table, next steps, validation command
-
-3. **Combine into single file** (~500 lines total):
-```markdown
-# Technical Standards
-
-Standards for [project]. Generated [date] from comprehensive codebase analysis.
-
-**Analysis Summary:**
-- Files analyzed: [N]
-- Patterns detected: [N]
-- Violations found: [N]
-- Gaps identified: [N]
-
----
-
-[Architecture Section from Agent 1]
-
----
-
-[Naming Section from Agent 2]
-
----
-
-[Error Handling Section from Agent 3]
-
----
-
-[Testing Section from Agent 4]
-
----
-
-[Security & Framework Section from Agent 5]
-
----
-
-## Gaps vs Best Practices
-
-| Area | Current State | Recommended | Priority |
-|------|--------------|-------------|----------|
-[Gap table from analysis]
-
----
-
-## Appendix: File Reference
-
-Key files referenced in this document:
-- `src/controllers/UserController.ts` - Example controller
-- `src/services/AuthService.ts` - Example service
-[etc.]
-
----
-
-*Generated by candid-init. Run `/candid-validate-standards` to check rule quality.*
-```
+After all generation agents complete, collect all sections and combine into one ~500-line file in this order: (1) header — title, "Standards for [project]. Generated [date] from comprehensive codebase analysis." plus Analysis Summary bullets (files analyzed, patterns detected, violations found, gaps identified); (2) the five agent sections separated by `---`; (3) Gaps vs Best Practices table (Area | Current State | Recommended | Priority); (4) Appendix: File Reference listing key cited files; (5) footer line: *Generated by candid-init. Run `/candid-validate-standards` to check rule quality.*
 
 ### Medium/Quick Mode: Condensed Output
 
@@ -1210,10 +661,6 @@ Show the assembled config as valid JSON. Example with all fields enabled:
 }
 ```
 
-Include the `fastShip` field in the preview only if the user configured it in Step 10.7. Omit it entirely if the user skipped fast ship configuration.
-
-Only include fields the user selected — omit any they skipped.
-
 Use AskUserQuestion:
 
 **Question:** "Write this config to `.candid/config.json`?"
@@ -1242,8 +689,6 @@ Use the Write tool to create:
 
 **Skip this substep entirely unless `--optimize` or `--auto-optimize` was passed.**
 
-Why this exists: the 5 generation sub-agents in Step 9 each write a section independently and have no awareness of each other's output. The result frequently contains cross-section duplicates, verbose rules with redundant qualifiers, and low-signal generic rules. Running `/candid-optimize` immediately after generation tightens the file before the user opens it.
-
 **If `--optimize` is set (interactive):**
 
 Print:
@@ -1266,44 +711,9 @@ Invoke the `candid-optimize` skill with the `--apply-all` flag. All recommendati
 
 When `candid-optimize` returns, continue to Step 11.3.
 
-**Edge cases (delegated to candid-optimize):**
-
-- Decision register absent — Step 5 of candid-optimize skips silently (a fresh init has no register).
-- Config newly written by Step 10 — Step 6 of candid-optimize typically emits the "well-tuned" message.
-- Technical.md already optimal — Step 3 of candid-optimize emits the "efficient" message.
-
-A fresh init with `--optimize` therefore yields mostly Technical.md findings, with the broader audit serving as a no-cost confirmation.
-
 ### 11.3: Show Summary
 
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-✅ Candid Initialization Complete
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-📄 Technical.md
-   Location: .candid/Technical.md
-   Analysis: [effort level]
-
-   Architecture rules: [N] (with [M] violations noted)
-   Naming conventions: [N] patterns documented
-   Error handling: [documented / gap identified]
-   Testing: [patterns / gaps]
-   Security: [N] rules
-
-   Gaps identified: [N] areas for improvement
-
-⚙️  Configuration
-   Location: .candid/config.json
-   Ship: [configured | not configured]
-   Fast Ship: [configured ([N] steps enabled) | not configured]
-
-📝 Next Steps
-   1. Review architecture rules - ensure they match your intent
-   2. Address identified gaps if desired
-   3. Run /candid-validate-standards to check rule quality
-   4. Run /candid-review to test enforcement
-```
+Print a summary with: Technical.md location + effort level; counts of architecture rules (and violations), naming patterns, error handling/testing/security status, gaps identified; config.json location with ship / fastShip configured-or-not; Next Steps 1-4 (review rules, address gaps, run /candid-validate-standards, run /candid-review).
 
 **If Step 11.2 ran (either `--optimize` or `--auto-optimize`):** replace step 3 of "Next Steps" with `Run /candid-validate-standards to check rule quality (optimization already applied)` so the user knows the audit pass already happened.
 

--- a/skills/candid-init/reference/analysis-commands.md
+++ b/skills/candid-init/reference/analysis-commands.md
@@ -1,0 +1,64 @@
+# Analysis Commands (candid-init Step 5)
+
+Bash recipes for sections 5.4, 5.7, 5.8, and 5.9 of the candid-init workflow.
+
+### 5.4 Architecture Pattern Detection (Thorough Only)
+
+```bash
+# Barrel exports (index.ts files)
+find . -name "index.ts" -o -name "index.js" 2>/dev/null | grep -v node_modules | wc -l
+# Sample a few to see export patterns
+find . -name "index.ts" 2>/dev/null | grep -v node_modules | head -3 | xargs cat 2>/dev/null
+
+# Dependency injection patterns
+grep -rh "@Injectable\|@Inject\|constructor.*private\|createContext" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v node_modules | head -15
+
+# Middleware/decorator patterns
+grep -rh "@.*Middleware\|@Guard\|@Interceptor\|@UseGuards\|@Auth" --include="*.ts" 2>/dev/null | grep -v node_modules | head -10
+
+# Domain boundaries (look for domain-specific directories)
+find . -type d -name "billing" -o -name "auth" -o -name "users" -o -name "payments" -o -name "orders" 2>/dev/null | grep -v node_modules | head -10
+```
+
+### 5.7 API Patterns (Medium + Thorough, for Node/Backend)
+
+```bash
+# Route definitions
+grep -rh "router\.\|app\.\(get\|post\|put\|patch\|delete\)\|@Get\|@Post\|@Put\|@Delete" --include="*.ts" 2>/dev/null | grep -v node_modules | head -20
+
+# Validation patterns
+grep -rh "from 'zod'\|from 'yup'\|from 'joi'\|@IsString\|@IsNumber\|z\.object\|Joi\.object" --include="*.ts" 2>/dev/null | grep -v node_modules | head -10
+
+# Auth middleware
+grep -rh "auth.*middleware\|isAuthenticated\|requireAuth\|@Auth\|@UseGuards" --include="*.ts" 2>/dev/null | grep -v node_modules | head -10
+```
+
+### 5.8 React Patterns (Medium + Thorough, for React)
+
+```bash
+# Hook patterns
+find . -name "use*.ts" -o -name "use*.tsx" 2>/dev/null | grep -v node_modules | head -15
+
+# State management
+grep -rh "from 'redux'\|from 'zustand'\|from '@tanstack/react-query'\|from 'swr'\|createContext\|useReducer" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v node_modules | head -10
+
+# Component patterns
+grep -rh "React.memo\|forwardRef\|React.lazy\|Suspense" --include="*.tsx" 2>/dev/null | grep -v node_modules | head -10
+
+# Event handler naming
+grep -rhoE "(handle|on)[A-Z][a-zA-Z]*" --include="*.tsx" 2>/dev/null | grep -v node_modules | sort | uniq -c | sort -rn | head -15
+```
+
+### 5.9 TypeScript Analysis (Thorough Only)
+
+```bash
+# Strictness
+cat tsconfig.json 2>/dev/null | grep -E "strict|noImplicit"
+
+# Any usage (red flag)
+grep -rc ": any\|as any" --include="*.ts" --include="*.tsx" 2>/dev/null | grep -v node_modules | grep -v ":0$" | awk -F: '{sum+=$2} END {print "any/as any count:", sum}'
+
+# Interface vs type preference
+grep -rc "^interface \|^export interface " --include="*.ts" 2>/dev/null | grep -v node_modules | awk -F: '{sum+=$2} END {print "interfaces:", sum}'
+grep -rc "^type \|^export type " --include="*.ts" 2>/dev/null | grep -v node_modules | awk -F: '{sum+=$2} END {print "types:", sum}'
+```

--- a/skills/candid-init/reference/analysis-prompts.md
+++ b/skills/candid-init/reference/analysis-prompts.md
@@ -1,0 +1,140 @@
+# Analysis Agent Prompts (candid-init Step 6, thorough mode)
+
+Exact prompts for the five parallel Explore sub-agents. Each returns proposed rules with file:line evidence.
+
+#### Agent 1: Architecture & Imports Agent
+
+**Prompt:**
+```
+Analyze the architecture and import patterns in this codebase.
+
+READ all files in these directories (or equivalent):
+- src/controllers/, src/routes/, app/api/
+- src/services/, src/usecases/
+- src/repositories/, src/data/
+- src/models/, src/entities/
+
+For each file, examine:
+1. What does this file import?
+2. What layer is it in?
+3. Are there violations (controller importing repo directly)?
+
+Return:
+- Layer structure diagram (what directories = what layers)
+- Dependency rules (what can import what)
+- Violations found (specific file:line examples)
+- 3-5 proposed architecture rules with file path examples
+```
+
+#### Agent 2: Naming & Style Agent
+
+**Prompt:**
+```
+Analyze naming conventions and code style across the codebase.
+
+READ 20-30 representative files across:
+- Components/UI files
+- Services/business logic
+- Utilities/helpers
+- Tests
+
+For each file, extract:
+1. Class/function/variable naming patterns
+2. File naming patterns
+3. Event handler naming (handle* vs on*)
+4. Boolean naming (is*, has*, should*)
+
+Return:
+- Detected naming conventions with consistency %
+- Specific file examples for each pattern
+- 5-8 proposed naming rules with examples from actual files
+```
+
+#### Agent 3: Error Handling & Security Agent
+
+**Prompt:**
+```
+Analyze error handling and security patterns.
+
+READ all files that:
+- Define custom error classes
+- Have try/catch blocks
+- Handle API responses
+- Deal with authentication/authorization
+- Process user input
+
+For each file, examine:
+1. Error class hierarchy
+2. Error response format
+3. Where errors are caught (boundary vs distributed)
+4. Input validation patterns
+5. Auth patterns
+
+Return:
+- Error handling approach summary
+- Security patterns found (or gaps)
+- Specific file:line examples
+- 5-8 proposed error/security rules with evidence
+```
+
+#### Agent 4: Testing Patterns Agent
+
+**Prompt:**
+```
+Analyze testing patterns across the codebase.
+
+READ all test files (*.test.*, *.spec.*, *_test.*).
+
+For each test file, examine:
+1. Test organization (describe/it patterns)
+2. Setup patterns (beforeEach, fixtures, factories)
+3. Mocking approach
+4. Assertion patterns
+5. What's tested vs what's not
+
+Return:
+- Test organization pattern
+- Naming conventions
+- Coverage gaps (directories without tests)
+- 3-5 proposed testing rules with examples
+```
+
+#### Agent 5: Framework-Specific Agent (React/Node/Python)
+
+**For React:**
+```
+Analyze React patterns across all components.
+
+READ all .tsx files and custom hooks.
+
+Examine:
+1. Component structure patterns
+2. Hook usage patterns
+3. State management approach
+4. Props patterns
+5. Performance patterns (memo, useCallback, useMemo)
+
+Return:
+- Component architecture patterns
+- State management approach
+- 5-8 proposed React rules with component examples
+```
+
+**For Node.js:**
+```
+Analyze API and backend patterns.
+
+READ all route handlers, middleware, and API files.
+
+Examine:
+1. Route organization
+2. Middleware patterns
+3. Validation approach
+4. Response format
+5. Database access patterns
+
+Return:
+- API design patterns
+- Middleware usage
+- 5-8 proposed API rules with endpoint examples
+```

--- a/skills/candid-init/reference/generation-prompts.md
+++ b/skills/candid-init/reference/generation-prompts.md
@@ -1,0 +1,262 @@
+# Generation Agent Prompts (candid-init Step 9, thorough mode)
+
+Prompt templates for the five parallel generation sub-agents. Launch all 5 via the Task tool, pasting the relevant analysis results into each prompt where indicated.
+
+#### Generation Agent 1: Architecture Section (~100 lines)
+
+**Prompt:**
+```
+Generate the Architecture section of a Technical.md file.
+
+Use these analysis results:
+[Paste layer structure, import graph, violations from analysis agents]
+
+Write ~100 lines covering:
+
+## Architecture
+
+### Project Structure Overview
+- Full directory tree with annotations explaining each directory's purpose
+- Which directories are entry points, which are internal
+
+### Layer Architecture
+- Detailed layer diagram with all detected layers
+- What each layer is responsible for
+- Dependencies between layers (what can import what)
+
+### Dependency Rules (15-20 specific rules)
+For each layer/directory, specify:
+- What it CAN import (with path examples)
+- What it CANNOT import (with reasoning)
+- Example: "`src/controllers/` can import from `src/services/` and `src/middleware/`, NOT from `src/repositories/` or `src/models/` directly"
+
+### Module Boundaries
+- Feature/domain boundaries if detected
+- Cross-module communication rules
+- Shared code location and usage rules
+
+### Current Violations
+- List each detected violation with file:line
+- Recommended fix for each
+
+### Reference Implementation
+- Point to 1-2 files that exemplify correct architecture
+```
+
+#### Generation Agent 2: Naming & Code Style Section (~80 lines)
+
+**Prompt:**
+```
+Generate the Naming Conventions and Code Style section of a Technical.md file.
+
+Use these analysis results:
+[Paste naming patterns from analysis agents]
+
+Write ~80 lines covering:
+
+## Naming Conventions
+
+### File Naming (10-15 rules)
+For each file type, specify:
+- Pattern with regex or glob
+- Examples from this codebase
+- Counter-examples (what NOT to do)
+
+### Class & Component Naming (10-15 rules)
+- Suffixes by type (Service, Controller, Repository, etc.)
+- Prefixes if used
+- Examples from actual files
+
+### Function & Method Naming (10-15 rules)
+- Verb prefixes by purpose (get, set, fetch, handle, on, is, has, etc.)
+- Async function naming
+- Event handler naming
+
+### Variable Naming (10-15 rules)
+- Boolean prefixes
+- Constants style
+- Collection naming (plural vs singular)
+- Destructuring conventions
+
+### Import Organization
+- Import ordering rules
+- Path alias usage
+- Barrel export rules
+
+### Code Examples
+Include 2-3 annotated code snippets showing correct naming in context
+```
+
+#### Generation Agent 3: Error Handling & Logging Section (~80 lines)
+
+**Prompt:**
+```
+Generate the Error Handling and Logging section of a Technical.md file.
+
+Use these analysis results:
+[Paste error handling patterns from analysis agents]
+
+Write ~80 lines covering:
+
+## Error Handling
+
+### Error Class Hierarchy
+- Full hierarchy diagram if exists
+- When to use each error type
+- How to create new error types
+
+### Error Handling Patterns (15-20 rules)
+- Where to catch errors (boundary vs distributed)
+- How to wrap errors
+- How to add context
+- What to log vs what to return
+
+### API Error Responses
+- Standard error response format with JSON schema
+- HTTP status code mapping
+- Error code conventions
+- Example responses for common scenarios
+
+### Error Logging
+- What context to include
+- Log levels by error type
+- Sensitive data redaction rules
+
+## Logging
+
+### Log Levels
+- When to use each level
+- Examples for each
+
+### Structured Logging Format
+- Required fields
+- Optional fields by context
+- Example log entries
+
+### What NOT to Log
+- Sensitive data list
+- PII handling
+```
+
+#### Generation Agent 4: Testing Section (~80 lines)
+
+**Prompt:**
+```
+Generate the Testing section of a Technical.md file.
+
+Use these analysis results:
+[Paste testing patterns from analysis agents]
+
+Write ~80 lines covering:
+
+## Testing
+
+### Test Organization
+- File location rules (colocated vs separate)
+- Directory structure for different test types
+- Naming conventions
+
+### Test Naming (10-15 rules)
+- Describe block naming
+- Test case naming patterns
+- Example test names from codebase
+
+### Unit Tests
+- What to unit test
+- What NOT to unit test
+- Mocking rules
+- Assertion patterns
+
+### Integration Tests
+- When required
+- Setup/teardown patterns
+- Database handling
+- API testing patterns
+
+### E2E Tests (if applicable)
+- Critical paths that require E2E
+- Test data management
+- Environment setup
+
+### Test Data
+- Factory patterns
+- Fixture usage
+- Test data cleanup
+
+### Coverage Requirements
+- Minimum coverage by directory/type
+- What's exempt from coverage
+
+### Example Test Structure
+Include 1-2 annotated test file examples showing correct patterns
+```
+
+#### Generation Agent 5: Security & Framework Section (~100 lines)
+
+**Prompt:**
+```
+Generate the Security and Framework-Specific sections of a Technical.md file.
+
+Use these analysis results:
+[Paste security patterns and framework analysis from analysis agents]
+
+Write ~100 lines covering:
+
+## Security (30-40 rules)
+
+### Input Validation
+- Where validation must occur
+- Validation library usage
+- Schema definition rules
+- Example validation code
+
+### Authentication
+- Auth middleware usage
+- Protected route patterns
+- Session/token handling
+- Auth bypass (what's public)
+
+### Authorization
+- Permission checking patterns
+- Role-based access rules
+- Resource ownership verification
+
+### Data Protection
+- Sensitive data handling
+- Encryption requirements
+- PII rules
+
+### API Security
+- Rate limiting
+- CORS configuration
+- Request size limits
+
+### Secrets Management
+- Environment variable naming
+- Secret rotation
+- What never goes in code
+
+## [Framework: React/Node/Python]
+
+### [Framework-specific patterns - 30-40 rules]
+[Detailed rules based on detected framework]
+
+For React:
+- Component patterns
+- Hook rules
+- State management
+- Performance optimization
+- Accessibility requirements
+
+For Node:
+- API design patterns
+- Middleware patterns
+- Database access patterns
+- Async patterns
+
+For Python:
+- Type hints
+- Class patterns
+- Async patterns
+- Documentation requirements
+```

--- a/skills/candid-loop/SKILL.md
+++ b/skills/candid-loop/SKILL.md
@@ -40,38 +40,14 @@ Parse CLI arguments for loop options:
 
 If CLI flags are provided, use them and skip config file checks for those specific options.
 
-#### Check Project Config
+#### Check Config Files and Apply Defaults
 
-Read `.candid/config.json` and extract the `loop` field:
+Read the `loop` field from `.candid/config.json` (`jq -r '.loop // null' .candid/config.json 2>/dev/null`); if absent, try `~/.candid/config.json`. For each of `mode`, `maxIterations`, `enforceCategories` not set by CLI, take the config value; also extract `ignored` {categories, patterns, ids}. Output `Using loop settings from project config` or `Using loop settings from user config` when applied.
 
-```bash
-jq -r '.loop // null' .candid/config.json 2>/dev/null
-```
+Defaults for anything still unset: `mode = "auto"`, `maxIterations = 5`, `enforceCategories = ["all"]`, `ignored = { categories: [], patterns: [], ids: [] }`.
 
-If the `loop` field exists:
-- Extract `mode` if not set by CLI
-- Extract `maxIterations` if not set by CLI
-- Extract `enforceCategories` if not set by CLI
-- Extract `ignored` object (categories, patterns, ids)
-
-Output when loading from config: `Using loop settings from project config`
-
-#### Check User Config
-
-Same procedure for `~/.candid/config.json` if project config doesn't have `loop` field.
-
-Output when loading from user config: `Using loop settings from user config`
-
-#### Apply Defaults
-
-For any options not set by CLI or config:
-
-```
-mode = "auto"
-maxIterations = 5
-enforceCategories = ["all"]
-ignored = { categories: [], patterns: [], ids: [] }
-```
+- Add patterns to the ignore list for known false positives.
+- Keep maxIterations at 5-10.
 
 ### Step 2: Initialize Loop State
 
@@ -86,24 +62,7 @@ registerQuestionsResolved = 0
 registerPriorDecisionsApplied = 0
 ```
 
-Display mode banner:
-
-**Auto mode:**
-```
-[Auto Mode] Running candid-loop with max [N] iterations...
-```
-
-**Review-each mode:**
-```
-[Review-Each Mode] Running candid-loop with max [N] iterations...
-You will review each fix one by one.
-```
-
-**Interactive mode:**
-```
-[Interactive Mode] Running candid-loop with max [N] iterations...
-Full control: skip, ignore, or batch process fixes.
-```
+Display mode banner: `[<Mode> Mode] Running candid-loop with max [N] iterations...` followed by a second line for review-each ("You will review each fix one by one.") or interactive ("Full control: skip, ignore, or batch process fixes.").
 
 ### Step 3: Run Review Loop
 
@@ -174,42 +133,11 @@ filteredIssues = issues.filter(issue =>
 )
 ```
 
-**Category mapping:**
-- `critical` → issues with category "critical"
-- `major` → issues with category "major"
-- `standards` → issues with category "standards"
-- `smell` → issues with category "smell"
-- `edge_case` → issues with category "edge_case"
-- `architectural` → issues with category "architectural"
-
 Output: `Enforcing categories: [list]. Filtered to [N] issues.`
 
 #### Step 3.4: Filter Out Ignored Issues
 
-Apply the ignored filters from config:
-
-**1. Filter by ignored categories:**
-```
-filteredIssues = filteredIssues.filter(issue =>
-    !ignored.categories.includes(issue.category)
-)
-```
-
-**2. Filter by ignored patterns (regex match on title):**
-```
-filteredIssues = filteredIssues.filter(issue =>
-    !ignored.patterns.some(pattern =>
-        new RegExp(pattern, 'i').test(issue.title)
-    )
-)
-```
-
-**3. Filter by ignored IDs:**
-```
-filteredIssues = filteredIssues.filter(issue =>
-    !ignored.ids.includes(issue.id)
-)
-```
+Apply the ignored filters from config: remove any issue whose category is in `ignored.categories`, whose title matches any regex in `ignored.patterns` (case-insensitive), or whose id is in `ignored.ids`.
 
 If any issues were filtered:
 ```
@@ -351,53 +279,18 @@ Output: `Added [N] issues to ignore list in .candid/config.json`
 
 After loop exits (success or max iterations), display final summary:
 
-**Success (no issues remaining):**
 ```
-Candid Loop Complete
+Candid Loop [Complete|Stopped|Cancelled]
 
 Summary:
 - Iterations: [N]
 - Issues fixed: [M]
-- Status: PASS
-
-Your code is clean!
+- Status: [PASS|INCOMPLETE|CANCELLED]
 ```
 
-**Max iterations reached:**
-```
-Candid Loop Stopped
+If INCOMPLETE: add `Issues remaining: [P]` and list remaining issues as `[icon] [title] in [file]:[line]`, plus tips: increase `--max-iterations`, add persistent ignores for false positives, review complex issues manually.
 
-Summary:
-- Iterations: [N] (max reached)
-- Issues fixed: [M]
-- Issues remaining: [P]
-- Status: INCOMPLETE
-
-Remaining issues:
-  [icon] [title] in [file]:[line]
-  [icon] [title] in [file]:[line]
-  ...
-
-Consider:
-- Increasing --max-iterations
-- Adding persistent ignores for false positives
-- Manually reviewing complex issues
-```
-
-**User cancelled (interactive mode):**
-```
-Candid Loop Cancelled
-
-Summary:
-- Iterations: [N]
-- Issues fixed: [M]
-- Issues skipped: [P]
-- Status: CANCELLED
-
-Skipped issues:
-  [icon] [title] in [file]:[line]
-  ...
-```
+If CANCELLED: add `Issues skipped: [P]` and list skipped issues.
 
 **Decision Register section (add to all summary variants when register is enabled):**
 
@@ -447,41 +340,8 @@ Add to `.candid/config.json`:
 | `loop.maxIterations` | number | `5` | Maximum review-fix cycles |
 | `loop.enforceCategories` | array | `["all"]` | Categories to enforce |
 | `loop.ignored.categories` | array | `[]` | Categories to skip entirely |
-| `loop.ignored.patterns` | array | `[]` | Regex patterns to match issue titles |
+| `loop.ignored.patterns` | array | `[]` | Regex patterns to match issue titles (example: `["Unicode", "timezone"]`) |
 | `loop.ignored.ids` | array | `[]` | Specific issue IDs to skip |
-
-### Examples
-
-**Ignore all edge cases and architectural issues:**
-```json
-{
-  "loop": {
-    "ignored": {
-      "categories": ["edge_case", "architectural"]
-    }
-  }
-}
-```
-
-**Ignore issues mentioning Unicode or timezone:**
-```json
-{
-  "loop": {
-    "ignored": {
-      "patterns": ["Unicode", "timezone", "DST"]
-    }
-  }
-}
-```
-
-**Only enforce critical and major issues:**
-```json
-{
-  "loop": {
-    "enforceCategories": ["critical", "major"]
-  }
-}
-```
 
 ## CLI Examples
 
@@ -489,22 +349,7 @@ Add to `.candid/config.json`:
 # Run with defaults (auto mode, all categories, max 5 iterations)
 /candid-loop
 
-# Review-each mode - go through each fix one by one (Yes/No)
-/candid-loop --mode review-each
-
-# Interactive mode - full control with skip, ignore, batch options
-/candid-loop --mode interactive
-
-# Limit iterations
-/candid-loop --max-iterations 3
-
-# Only fix critical issues
-/candid-loop --categories critical
-
-# Fix critical and major issues
-/candid-loop --categories critical,major
-
-# Combine options
+# Combine flags
 /candid-loop --mode review-each --max-iterations 10 --categories critical,major
 ```
 
@@ -518,20 +363,3 @@ Add to `.candid/config.json`:
 | `smell` | 📋 | Maintainability: complexity, duplication |
 | `edge_case` | 🤔 | Unhandled scenarios: null, empty, concurrent |
 | `architectural` | 💭 | Design concerns: coupling, SRP violations |
-
-## Remember
-
-The goal of candid-loop is to **automate the review-fix cycle** so you can quickly get your code to a clean state.
-
-**Mode selection:**
-- **auto** - Fast iteration, applies all fixes automatically
-- **review-each** - Go through each fix one by one with simple Yes/No
-- **interactive** - Full control with skip, ignore list, and batch options
-
-**Best practices:**
-- Start with auto mode for quick cleanup
-- Use review-each mode to understand what's being fixed
-- Use interactive mode when you need to ignore or skip specific issues
-- Add patterns to ignore list for known false positives
-- Keep maxIterations reasonable (5-10) to avoid infinite loops
-- Review the summary to understand what was fixed

--- a/skills/candid-optimize/SKILL.md
+++ b/skills/candid-optimize/SKILL.md
@@ -105,7 +105,7 @@ Read Technical.md and analyze each rule for optimization potential.
 
 #### 3.1 Parse Rules
 
-Extract rules from Technical.md using the same approach as candid-validate-standards:
+Extract rules from Technical.md:
 - Lines starting with `-` or `*` (list items)
 - Lines starting with numbers (numbered lists)
 - Lines following a `##` heading
@@ -524,9 +524,6 @@ Files modified:
 
 ## Edge Cases
 
-### No Technical.md and no config
-Output the token budget (all zeros), note that no context files exist. Continue to Steps 4 and 6 — exclude pattern scanning and config tuning recommendations are still valuable for fresh projects. Suggest running `/candid-init` as one of the config recommendations in Step 6.
-
 ### Technical.md exists but is already optimal
 If no verbose, duplicate, or low-signal rules found, skip Section 3 findings and note:
 ```
@@ -535,12 +532,6 @@ If no verbose, duplicate, or low-signal rules found, skip Section 3 findings and
 
 ### Config exists but is empty (`{}`)
 Treat as valid config with no preferences. Recommend adding settings based on detected patterns.
-
-### Decision register disabled
-Skip Section 5 entirely. Note in summary:
-```
-Decision register: disabled (no analysis needed)
-```
 
 ### --section with non-existent context
 If `--section technical-md` but no Technical.md exists:
@@ -561,12 +552,6 @@ If `--section excludes` or `--section config`: these always produce output (scan
 
 Before presenting results, verify:
 
-- [ ] Token estimates use `~` prefix (never claim exact counts)
-- [ ] Every recommendation includes an estimated token savings or states "improves quality"
 - [ ] Technical.md edits are applied in reverse line-number order
 - [ ] Config changes are batched into a single write
-- [ ] `mkdir -p .candid` runs before any config file creation
-- [ ] Invalid JSON in existing config is detected and warned about, not silently overwritten
-- [ ] Low-signal rule detection does not flag rules with domain-specific technical terms
-- [ ] Duplicate detection is capped at 5 pairs maximum
 - [ ] The before/after summary re-reads modified files for accurate "After" estimates

--- a/skills/candid-review/CONFIG.md
+++ b/skills/candid-review/CONFIG.md
@@ -218,154 +218,10 @@ Using constructive tone (from interactive prompt)
 
 ### Valid Configs
 
-**Harsh tone:**
+**Minimal:**
 ```json
 {
   "tone": "harsh"
-}
-```
-
-**Harsh tone with version:**
-```json
-{
-  "version": 1,
-  "tone": "harsh"
-}
-```
-
-**Constructive tone:**
-```json
-{
-  "tone": "constructive"
-}
-```
-
-**No preference (empty):**
-```json
-{}
-```
-
-**With exclusions:**
-```json
-{
-  "tone": "harsh",
-  "exclude": ["*.generated.ts", "vendor/*", "**/*.min.js"]
-}
-```
-
-**With focus area:**
-```json
-{
-  "tone": "constructive",
-  "focus": "security"
-}
-```
-
-**Full config:**
-```json
-{
-  "version": 1,
-  "tone": "harsh",
-  "exclude": ["*.generated.ts", "vendor/*"],
-  "focus": "performance",
-  "autoCommit": true
-}
-```
-
-**With decision register (default lookup mode):**
-```json
-{
-  "tone": "constructive",
-  "decisionRegister": {
-    "enabled": true
-  }
-}
-```
-
-**With decision register (load mode, custom path):**
-```json
-{
-  "tone": "harsh",
-  "decisionRegister": {
-    "enabled": true,
-    "path": "docs/decisions",
-    "mode": "load"
-  }
-}
-```
-
-**Full config with decision register:**
-```json
-{
-  "version": 1,
-  "tone": "harsh",
-  "exclude": ["*.generated.ts", "vendor/*"],
-  "focus": "performance",
-  "autoCommit": true,
-  "decisionRegister": {
-    "enabled": true,
-    "path": ".candid/register",
-    "mode": "lookup"
-  }
-}
-```
-
-**With ship configuration:**
-```json
-{
-  "version": 1,
-  "tone": "constructive",
-  "ship": {
-    "buildCommand": "npm run build",
-    "testCommand": "npm test",
-    "targetBranch": "main",
-    "autoMerge": false
-  }
-}
-```
-
-**With install before build:**
-```json
-{
-  "ship": {
-    "installCommand": "pnpm install",
-    "buildCommand": "pnpm build",
-    "testCommand": "pnpm test",
-    "targetBranch": "main"
-  }
-}
-```
-
-**With Linear issue tracker:**
-```json
-{
-  "version": 1,
-  "tone": "constructive",
-  "ship": {
-    "buildCommand": "npm run build",
-    "targetBranch": "main",
-    "issueTracker": {
-      "provider": "linear",
-      "enabled": true,
-      "teamPrefixes": ["DIS", "ENG"],
-      "state": "In Review"
-    }
-  }
-}
-```
-
-**With custom issue tracker prompt:**
-```json
-{
-  "ship": {
-    "issueTracker": {
-      "provider": "linear",
-      "enabled": true,
-      "teamPrefixes": ["DIS"],
-      "state": "Code Review",
-      "prompt": "Move {issueId} to \"{state}\" and add a comment that the PR is ready. Only modify this single issue."
-    }
-  }
 }
 ```
 
@@ -404,17 +260,6 @@ Using constructive tone (from interactive prompt)
 }
 ```
 
-**With fast ship only (minimal PR creation):**
-```json
-{
-  "ship": {
-    "buildCommand": "npm run build",
-    "targetBranch": "main"
-  },
-  "fastShip": {}
-}
-```
-
 **Fast ship with build and auto-merge:**
 ```json
 {
@@ -429,28 +274,7 @@ Using constructive tone (from interactive prompt)
 }
 ```
 
-**With future fields (ignored):**
-```json
-{
-  "tone": "harsh",
-  "future_setting": "some_value"
-}
-```
-
 ### Invalid Configs
-
-**Malformed JSON (missing closing brace):**
-```json
-{
-  "tone": "harsh"
-```
-
-**Invalid tone value:**
-```json
-{
-  "tone": "medium"
-}
-```
 
 **Wrong type for tone:**
 ```json
@@ -458,3 +282,4 @@ Using constructive tone (from interactive prompt)
   "tone": true
 }
 ```
+Non-string / unknown enum values warn and fall through.

--- a/skills/candid-review/EDGE-CASE.md
+++ b/skills/candid-review/EDGE-CASE.md
@@ -1,0 +1,74 @@
+# Edge-Case Focus Mode Checklist
+
+When `--focus edge-case` is active, systematically check every code path for boundary conditions, error scenarios, and unusual inputs. Go beyond surface-level checks to exhaustively analyze edge cases.
+
+**Input Validation Matrix**
+For every input (function arguments, API parameters, user input, config values):
+- [ ] Null/undefined handling - Does code check for null/undefined before use?
+- [ ] Empty collection handling - How does code handle [], {}, "", empty Map/Set?
+- [ ] Type validation - Is type checked (string vs number, array vs object)?
+- [ ] Boundary values - Tested with 0, -1, Infinity, NaN, MIN/MAX values?
+- [ ] Length limits - Are string/array length limits enforced?
+- [ ] Special characters - Handles unicode, emoji, control characters, zero-width spaces?
+- [ ] Whitespace variations - Tested with leading, trailing, or whitespace-only input?
+- [ ] Extra/missing properties - Handles unexpected object properties or missing required fields?
+
+**Async Operation Safety**
+For every async operation (promises, async/await, callbacks):
+- [ ] Timeout configured - Is there a timeout to prevent hanging forever?
+- [ ] Cancellation on cleanup - Are operations cancelled on unmount/navigation?
+- [ ] Error handling - All failure modes caught (network, validation, business logic)?
+- [ ] Race condition analysis - What if multiple async operations complete out of order?
+- [ ] Double-invocation protection - What if user triggers operation twice quickly?
+- [ ] State validity after await - Is component/data still valid after async completes?
+
+**Data Structure Edge Cases**
+For every data query, transformation, or collection operation:
+- [ ] Empty result set - How does code handle zero results from query/filter?
+- [ ] Single item edge case - Does plural handling work correctly for 1 item?
+- [ ] Large dataset pagination - Is pagination implemented for potentially large results?
+- [ ] Sorting with null/equal values - How are null values or equal items sorted?
+- [ ] Filtering edge cases - Handles no matches, all matches, partial matches?
+- [ ] Duplicate handling - Are duplicates detected/prevented when required?
+
+**Network Resilience**
+For every network call (API, fetch, external service):
+- [ ] Timeout specified - Is request timeout configured (not infinite)?
+- [ ] Retry logic - Are retries implemented with exponential backoff?
+- [ ] 4xx/5xx error handling - Different handling for client vs server errors?
+- [ ] Network offline handling - Graceful degradation when offline?
+- [ ] Partial failure scenarios - What if some requests succeed, others fail?
+- [ ] Loading/error states - Does UI show appropriate feedback during/after request?
+
+**State Lifecycle**
+For every stateful component or module:
+- [ ] Cleanup on unmount - Are event listeners, timers, subscriptions cleaned up?
+- [ ] Concurrent update handling - What if state updates happen simultaneously?
+- [ ] State updates after navigation - Are updates prevented after user navigates away?
+- [ ] Re-initialization safety - Can component be safely re-initialized?
+- [ ] Memory leak potential - Are there circular references or retained closures?
+
+**Date/Time Edge Cases**
+For every date/time operation:
+- [ ] Timezone handling - Is timezone properly considered?
+- [ ] DST transitions - Tested with daylight saving time changes?
+- [ ] Leap year/second - Handles February 29th, leap seconds?
+- [ ] Invalid date handling - What happens with invalid date strings?
+- [ ] Locale-specific formatting - Works correctly across different locales?
+
+**Browser/Environment**
+For every browser API or environment-dependent code:
+- [ ] API availability check - Is feature detection done before using browser APIs?
+- [ ] Mobile vs desktop differences - Tested on both touch and mouse interactions?
+- [ ] Keyboard accessibility - Can all interactions be done via keyboard?
+- [ ] LocalStorage/Cookie unavailability - Graceful fallback if storage disabled?
+- [ ] Screen size variations - Responsive to different viewport sizes?
+- [ ] JavaScript disabled scenarios - Progressive enhancement where critical?
+
+**Security Edge Cases**
+For every security-sensitive operation:
+- [ ] CSRF token handling - Token refresh on expiration?
+- [ ] Session timeout - Graceful handling of expired sessions?
+- [ ] Permission changes mid-operation - What if permissions revoked during action?
+- [ ] Authentication token refresh - Automatic refresh before expiration?
+- [ ] XSS via unusual vectors - Sanitization covers edge cases (data URIs, SVG, etc.)?

--- a/skills/candid-review/SKILL.md
+++ b/skills/candid-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: candid-review
-description: Use when reviewing code changes before commit or PR - provides configurable code review (harsh or constructive tone) with project standards from Technical.md, architectural context, categorized issues with actionable fixes, todo integration for tracking selected issues, and optional automatic commit of applied fixes
+description: Use when reviewing code changes before commit or PR — configurable harsh or constructive review against Technical.md standards, with categorized issues, actionable fixes, todo tracking, and optional auto-commit.
 ---
 
 # Radical Candor Code Review
@@ -11,53 +11,21 @@ You are a full-stack architect conducting a code review. Your approach is based 
 
 Execute these steps in order:
 
+**Config resolution (standard precedence):** Unless a step says otherwise, every setting resolves: CLI flag → `.candid/config.json` → `~/.candid/config.json` → default; invalid values warn and fall through to the next source.
+
 ### Step 1: Load Project Standards
 
-Check for Technical.md (project-specific standards):
+Load project standards: `./Technical.md`, falling back to `./.candid/Technical.md`; if neither exists, proceed without them.
 
-```
-1. Read ./Technical.md (project root)
-2. If not found, read ./.candid/Technical.md
-3. If found, use these standards to inform your review
-4. If not found, proceed without project-specific standards
-```
-
-When Technical.md exists, you will flag violations as 📜 Standards Violation.
+When Technical.md exists, use these standards to inform your review and flag violations as 📜 Standards Violation.
 
 ### Step 1.5: Load Decision Register Config
 
 Check if the decision register feature is enabled. The decision register tracks questions and decisions from reviews, and — when a question has been answered before — automatically reuses the prior answer instead of re-asking.
 
-**Precedence (highest to lowest):**
-1. Project config (`.candid/config.json` → `decisionRegister`)
-2. User config (`~/.candid/config.json` → `decisionRegister`)
-3. Default (disabled)
-
-#### Check Project Config
-
-Read `.candid/config.json`:
-1. Check file existence → if missing, continue to user config
-2. Extract field: `jq -r '.decisionRegister // null'`
-3. Validate:
-   - If null → continue to user config
-   - If not object → warn "⚠️  Invalid config: decisionRegister must be an object. Ignoring." and continue
-   - Extract `enabled` (must be boolean, default `false`)
-   - Extract `path` (must be non-empty string, default `".candid/register"`)
-   - Extract `mode` (must be `"lookup"` or `"load"`, default `"lookup"`)
-4. Success: Store `registerEnabled`, `registerPath`, and `registerMode`
-
-#### Check User Config
-
-Same procedure for `~/.candid/config.json`.
-
-#### Apply Defaults
-
-If no config found:
-```
-registerEnabled = false
-registerPath = ".candid/register"
-registerMode = "lookup"
-```
+Read `decisionRegister` from `.candid/config.json`, then `~/.candid/config.json` (first valid wins); validate per CONFIG.md.
+Defaults: `enabled=false`, `path=".candid/register"`, `mode="lookup"`.
+Store `registerEnabled`, `registerPath`, `registerMode`.
 
 #### Load Existing Register (if enabled)
 
@@ -95,10 +63,7 @@ git diff --cached --stat
 # Then unstaged changes
 git diff --stat
 
-# If on a branch, compare to configured merge target branches (from Step 2.5)
-# Build fallback chain dynamically from mergeTargetBranches
-# For each branch: git diff <branch>...HEAD --stat 2>/dev/null
-# Example for ["develop", "main"]: git diff develop...HEAD --stat 2>/dev/null || git diff main...HEAD --stat 2>/dev/null
+# Compare to merge target per Runtime Branch Selection in Step 2.5
 ```
 
 **3. Decide what to review:**
@@ -113,38 +78,16 @@ git diff --stat
 
 ### Step 2.5: Load Merge Target Branches
 
-Determine which branches to compare against, following config precedence.
-
-**Precedence (highest to lowest):**
-1. CLI flags (`--merge-target <branch>`, repeatable)
-2. Project config (`.candid/config.json` → `mergeTargetBranches`)
-3. User config (`~/.candid/config.json` → `mergeTargetBranches`)
-4. Default (`["main", "stable", "master"]`)
+Determine which branches to compare against, following standard precedence.
 
 #### Check CLI Arguments
-If `--merge-target` flags provided:
+If `--merge-target` flags provided (repeatable):
 - Build array from args (e.g., `--merge-target develop --merge-target main` → `["develop", "main"]`)
 - Output: `Using merge target branches: [list] (from CLI flags)`
 - Skip to Step 3
 
-#### Check Project Config
-Read `.candid/config.json`:
-1. Check file existence → if missing, continue to user config
-2. Validate JSON (use `jq empty`) → if invalid, warn and continue
-3. Extract field: `jq -r '.mergeTargetBranches // null'`
-4. Validate:
-   - If null → continue to user config
-   - If not array → warn and continue
-   - If empty array → warn and continue
-   - If contains non-strings → warn and continue
-5. Success: Output `Using merge target branches: [list] (from project config)`, skip to Step 3
-
-#### Check User Config
-Same procedure as project config, using `~/.candid/config.json`.
-Success: Output `Using merge target branches: [list] (from user config)`, skip to Step 3
-
-#### Use Default
-Set to `["main", "stable", "master"]` (silent, no output)
+#### Check Config
+Read `mergeTargetBranches` from `.candid/config.json`, then `~/.candid/config.json` (first valid wins); must be a non-empty array of strings per CONFIG.md — warn and fall through on invalid. Output: `Using merge target branches: [list] (from [project config/user config])`. If none, default silently to `["main", "stable", "master"]`.
 
 #### Runtime Branch Selection (used in Step 2)
 When executing the git diff command:
@@ -160,11 +103,7 @@ Check CLI arguments for review options:
 
 #### Focus Mode (`--focus`)
 
-**Focus Precedence (highest to lowest):**
-1. CLI flag (`--focus security`)
-2. Project config (`.candid/config.json` → `focus` field)
-3. User config (`~/.candid/config.json` → `focus` field)
-4. No focus (review all categories)
+Resolve focus with standard precedence: `--focus` CLI flag → `focus` config field → no focus (review all categories).
 
 If focus is set, limit review to specific categories:
 
@@ -187,11 +126,7 @@ Also check config files for exclusions:
 1. `.candid/config.json` → `exclude` array
 2. `~/.candid/config.json` → `exclude` array
 
-Common patterns:
-- `*.generated.ts` - Generated code
-- `*.min.js` - Minified files
-- `vendor/*` - Third-party code
-- `**/node_modules/**` - Dependencies
+See CONFIG.md for common exclude patterns.
 
 Merge CLI exclusions with config exclusions. Apply to file list in Step 2.
 
@@ -218,100 +153,24 @@ Then proceed with normal review.
 - Store in `previousIssues` array for comparison in Step 7
 - Output: `Re-review mode: comparing against review from [timestamp]`
 
-**Previous Review State Format:**
-```json
-{
-  "timestamp": "2026-01-17T10:30:00Z",
-  "commit": "abc123",
-  "branch": "feature/auth",
-  "issues": [
-    {
-      "id": "hash-of-file-line-category",
-      "file": "src/auth.ts",
-      "line": 42,
-      "category": "critical",
-      "title": "Null check missing",
-      "description": "user.email accessed without null check"
-    }
-  ]
-}
-```
-
-#### Commit Mode (`--auto-commit`)
-
-If `--auto-commit` flag is provided, automatically create git commit after successfully applying fixes.
-
-**Requirements:**
-- Must be in git repository
-- At least one fix must be applied
-- Working directory must have changes after fixes
-
-**Commit behavior:**
-- Only commits files modified by candid-review (not other unstaged changes)
-- Commit message includes list of all applied fixes with file locations
-- Includes co-author tag: `Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>`
-- Commit failures preserve applied fixes and continue review
-
-**Output when enabled:** `Commit enabled: will create git commit after applying fixes (from CLI flag)`
+**Previous review state schema:** `{timestamp, commit, branch, issues[]}` where each issue has
+`{id, file, line, category, title, description}` — the same format Step 10 writes.
 
 ### Step 4: Load Tone Preference and Commit Mode
 
-#### Check for --auto-commit flag
+#### Determine Commit Mode
 
-Parse CLI arguments to determine if automatic commit is requested.
+Resolve auto-commit with standard precedence: `--auto-commit` CLI flag → project config `autoCommit` → user config `autoCommit` → default `false` (no output).
 
-If `--auto-commit` flag is provided:
-- Set `commitEnabled = true`
-- Output: `Commit enabled: will create git commit after applying fixes (from CLI flag)`
-- Skip to tone preference loading
+Validate `autoCommit` as boolean per the Config Validation Procedure in CONFIG.md; on invalid value warn and fall through to the next source.
 
-If `--auto-commit` flag is NOT provided, check config files:
-
-#### Check Project Config for Commit
-
-Read `.candid/config.json`:
-1. Check file existence → if missing, continue to user config
-2. Validate JSON (use `jq empty .candid/config.json 2>&1`) → if invalid, skip to user config
-3. Extract field: `jq -r '.autoCommit // null' .candid/config.json`
-4. Validate:
-   - If null or missing → continue to user config
-   - If not boolean → warn "⚠️  Invalid config at .candid/config.json: invalid type for autoCommit field (must be boolean). Falling back to user config." and continue to user config
-5. Success:
-   - Set `commitEnabled` to config value (true or false)
-   - If true: Output `Commit enabled: will create git commit after applying fixes (from project config)`
-   - Continue to tone preference loading
-
-#### Check User Config for Commit
-
-Read `~/.candid/config.json`:
-1. Check file existence → if missing, continue to default
-2. Validate JSON (use `jq empty ~/.candid/config.json 2>&1`) → if invalid, use default
-3. Extract field: `jq -r '.autoCommit // null' ~/.candid/config.json`
-4. Validate:
-   - If null or missing → use default
-   - If not boolean → warn "⚠️  Invalid config at ~/.candid/config.json: invalid type for autoCommit field (must be boolean). Using default." and use default
-5. Success:
-   - Set `commitEnabled` to config value (true or false)
-   - If true: Output `Commit enabled: will create git commit after applying fixes (from user config)`
-   - Continue to tone preference loading
-
-#### Default Commit Behavior
-
-If no CLI flag and no config specifies commit:
-- Set `commitEnabled = false`
-- (No output - default behavior)
+When enabled, output: `Commit enabled: will create git commit after applying fixes (from [CLI flag/project config/user config])`
 
 Store the `commitEnabled` boolean for use in Step 9.5.
 
 #### Load Tone Preference
 
-Load tone preference following precedence rules. See CONFIG.md for detailed validation instructions.
-
-**Precedence Order (highest to lowest):**
-1. CLI flags (`--harsh` or `--constructive`)
-2. Project config (`.candid/config.json`)
-3. User config (`~/.candid/config.json`)
-4. Interactive prompt
+Load tone preference following standard precedence, with the interactive prompt as the final fallback instead of a default. See CONFIG.md for detailed validation instructions.
 
 #### Check CLI Arguments
 
@@ -500,80 +359,8 @@ Before marking an issue as Clarification Needed, check `existingRegisterEntries`
 - Missing observability (logging, metrics)
 - Tight coupling between modules
 
-### Edge-Case Focus Mode Checklist
-
-When `--focus edge-case` is active, systematically check every code path for boundary conditions, error scenarios, and unusual inputs. Go beyond surface-level checks to exhaustively analyze edge cases.
-
-**Input Validation Matrix**
-For every input (function arguments, API parameters, user input, config values):
-- [ ] Null/undefined handling - Does code check for null/undefined before use?
-- [ ] Empty collection handling - How does code handle [], {}, "", empty Map/Set?
-- [ ] Type validation - Is type checked (string vs number, array vs object)?
-- [ ] Boundary values - Tested with 0, -1, Infinity, NaN, MIN/MAX values?
-- [ ] Length limits - Are string/array length limits enforced?
-- [ ] Special characters - Handles unicode, emoji, control characters, zero-width spaces?
-- [ ] Whitespace variations - Tested with leading, trailing, or whitespace-only input?
-- [ ] Extra/missing properties - Handles unexpected object properties or missing required fields?
-
-**Async Operation Safety**
-For every async operation (promises, async/await, callbacks):
-- [ ] Timeout configured - Is there a timeout to prevent hanging forever?
-- [ ] Cancellation on cleanup - Are operations cancelled on unmount/navigation?
-- [ ] Error handling - All failure modes caught (network, validation, business logic)?
-- [ ] Race condition analysis - What if multiple async operations complete out of order?
-- [ ] Double-invocation protection - What if user triggers operation twice quickly?
-- [ ] State validity after await - Is component/data still valid after async completes?
-
-**Data Structure Edge Cases**
-For every data query, transformation, or collection operation:
-- [ ] Empty result set - How does code handle zero results from query/filter?
-- [ ] Single item edge case - Does plural handling work correctly for 1 item?
-- [ ] Large dataset pagination - Is pagination implemented for potentially large results?
-- [ ] Sorting with null/equal values - How are null values or equal items sorted?
-- [ ] Filtering edge cases - Handles no matches, all matches, partial matches?
-- [ ] Duplicate handling - Are duplicates detected/prevented when required?
-
-**Network Resilience**
-For every network call (API, fetch, external service):
-- [ ] Timeout specified - Is request timeout configured (not infinite)?
-- [ ] Retry logic - Are retries implemented with exponential backoff?
-- [ ] 4xx/5xx error handling - Different handling for client vs server errors?
-- [ ] Network offline handling - Graceful degradation when offline?
-- [ ] Partial failure scenarios - What if some requests succeed, others fail?
-- [ ] Loading/error states - Does UI show appropriate feedback during/after request?
-
-**State Lifecycle**
-For every stateful component or module:
-- [ ] Cleanup on unmount - Are event listeners, timers, subscriptions cleaned up?
-- [ ] Concurrent update handling - What if state updates happen simultaneously?
-- [ ] State updates after navigation - Are updates prevented after user navigates away?
-- [ ] Re-initialization safety - Can component be safely re-initialized?
-- [ ] Memory leak potential - Are there circular references or retained closures?
-
-**Date/Time Edge Cases**
-For every date/time operation:
-- [ ] Timezone handling - Is timezone properly considered?
-- [ ] DST transitions - Tested with daylight saving time changes?
-- [ ] Leap year/second - Handles February 29th, leap seconds?
-- [ ] Invalid date handling - What happens with invalid date strings?
-- [ ] Locale-specific formatting - Works correctly across different locales?
-
-**Browser/Environment**
-For every browser API or environment-dependent code:
-- [ ] API availability check - Is feature detection done before using browser APIs?
-- [ ] Mobile vs desktop differences - Tested on both touch and mouse interactions?
-- [ ] Keyboard accessibility - Can all interactions be done via keyboard?
-- [ ] LocalStorage/Cookie unavailability - Graceful fallback if storage disabled?
-- [ ] Screen size variations - Responsive to different viewport sizes?
-- [ ] JavaScript disabled scenarios - Progressive enhancement where critical?
-
-**Security Edge Cases**
-For every security-sensitive operation:
-- [ ] CSRF token handling - Token refresh on expiration?
-- [ ] Session timeout - Graceful handling of expired sessions?
-- [ ] Permission changes mid-operation - What if permissions revoked during action?
-- [ ] Authentication token refresh - Automatic refresh before expiration?
-- [ ] XSS via unusual vectors - Sanitization covers edge cases (data URIs, SVG, etc.)?
+### Edge-Case Focus Mode
+When --focus edge-case is active, read EDGE-CASE.md (same directory as this skill) and systematically apply every checklist item in it to each code path.
 
 ### Step 7: Present Issues with Fixes
 
@@ -619,19 +406,7 @@ Include confidence in every issue. Users can use this to decide whether to apply
 > const email = user.email;
 > ```
 
-*Constructive tone example:*
-> ### 🔥 Missing null check on user access
-> **File:** src/user.ts:42
-> **Confidence:** Safe ✓
-> **Problem:** The code accesses `user.email` without verifying the user object exists.
-> **Impact:** If the user lookup fails or returns null, this will cause a runtime crash. This is especially risky in authentication flows where invalid states are common.
-> **Fix:**
-> ```typescript
-> if (!user?.email) {
->   throw new Error('User not found');
-> }
-> const email = user.email;
-> ```
+*Constructive tone uses the same structure with a neutral title (e.g., "Missing null check on user access") and an Impact section that explains why the failure mode matters.*
 
 *Clarification Needed example (when register is enabled and no prior answer found):*
 > ### ? Rate limiting absent on public endpoint
@@ -695,9 +470,9 @@ Loop through each issue identified in Steps 6-7. For each issue:
      Problem: [Brief description]
      ```
    - **Options:**
-     - "Yes, apply this fix"
-     - "No, skip this fix"
-     - "I have a question about this" (only if `registerEnabled == true`)
+     - "Yes, apply this fix" — add this issue to selectedFixes array
+     - "No, skip this fix" — continue to next issue without adding
+     - "I have a question about this" (only if `registerEnabled == true`) — use a follow-up AskUserQuestion: "What is your question about this issue?" Record the user's question as a new register entry (`status: open`, `Asked By: Author`, file/component from the issue). Continue to next issue without adding to selectedFixes.
 
    **For Clarification Needed ? issues (only when register is enabled):**
    - **Question:** "This issue needs your input:"
@@ -708,19 +483,10 @@ Loop through each issue identified in Steps 6-7. For each issue:
      Question: [The question from the issue]
      ```
    - **Options:**
-     - "Here's my answer" — Use a follow-up AskUserQuestion to get the answer text. Record the answer in the register entry as `answered` with the user's response.
+     - "Here's my answer" — Use a follow-up AskUserQuestion to get the answer text. Record the answer in the register entry as `answered` with the user's response. If the answer implies a fix should be applied, add to selectedFixes; if the answer is informational only, continue without adding.
      - "Skip for now" — Leave the register entry as `open`. Continue to next issue.
      - "No longer relevant / Superseded" — Mark the register entry as `superseded` (the question was made irrelevant by other changes). Continue to next issue.
      - "Not applicable / Decline" — Mark the register entry as `declined`. Continue to next issue.
-
-3. **Track selection:**
-   - If "Yes" → Add this issue to selectedFixes array
-   - If "No" → Continue to next issue without adding
-   - If "I have a question about this" → Use a follow-up AskUserQuestion: "What is your question about this issue?" Record the user's question as a new register entry (`status: open`, `Asked By: Author`, file/component from the issue). Continue to next issue without adding to selectedFixes.
-   - If "Here's my answer" → Mark the Clarification Needed entry as `answered`. If the answer implies a fix should be applied, add to selectedFixes. If the answer is informational only, continue without adding.
-   - If "Skip for now" → Continue to next issue
-   - If "No longer relevant / Superseded" → Mark as `superseded`, continue to next issue
-   - If "Not applicable / Decline" → Mark as `declined`, continue to next issue
 
 Repeat for all issues. After completing the loop, proceed to Phase 8c.
 
@@ -738,7 +504,7 @@ Before applying fixes, show a summary and get final confirmation:
      - "Yes, apply all selected" - Proceed to Step 9 with selectedFixes
      - "No, let me review again" - Return to Phase 8a and start over
 
-**Enforcement:** Do not proceed to Step 9 without completing this prompt. Do not auto-select fixes or assume user intent. The user MUST explicitly choose which fixes to apply through one of these paths.
+**Enforcement:** Do not auto-select fixes or assume user intent — the user must choose through one of these paths.
 
 ### Step 9: Apply Fixes or Create Todos
 
@@ -1026,34 +792,10 @@ For each issue in `previousIssues`:
 
 **3. Present issues in groups:**
 
-```markdown
-## ✅ Fixed Issues (N)
-
-These issues from the previous review have been resolved:
-
-1. ~~🔥 Null check missing in auth.ts:42~~ ✅
-2. ~~⚠️ N+1 query in orders.ts:88~~ ✅
-
----
-
-## 🔄 Still Present (M)
-
-These issues remain from the previous review:
-
-### 🔥 SQL injection vulnerability
-**File:** src/db.ts:15 (was line 12)
-...
-
----
-
-## 🆕 New Issues (P)
-
-Issues introduced since last review:
-
-### ⚠️ Missing error handling
-**File:** src/api.ts:42
-...
-```
+Present three sections in order:
+- `## ✅ Fixed Issues (N)` — numbered list, each item struck through (`~~...~~`) with trailing ✅
+- `## 🔄 Still Present (M)` — full issue format from Step 7, noting "(was line X)" if the line moved
+- `## 🆕 New Issues (P)` — full issue format from Step 7
 
 **4. Summary includes comparison:**
 ```
@@ -1082,12 +824,4 @@ Net change: [+/-X] issues
 - Offers multiple solution approaches
 - More encouraging about good practices
 
-## Remember
-
-Your goal is to **improve the code** and **help the developer grow**. Every issue you raise:
-1. Points to specific code (file:line)
-2. Explains why it matters
-3. Shows how to fix it
-4. Can be tracked as a todo
-
-The best code review is one where the developer leaves better equipped than before.
+Your goal is to improve the code and help the developer grow.

--- a/skills/candid-ship/SKILL.md
+++ b/skills/candid-ship/SKILL.md
@@ -54,23 +54,7 @@ Calculate `totalSteps` = 1 (PR creation always runs) + number of optional steps 
 
 Renumber the displayed step list to skip rows for any disabled optional steps.
 
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Candid Ship Plan
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Branch: [currentBranch] → [targetBranch]
-
-Steps (numbers assigned dynamically — only running steps get a number):
-  [N]. 🔍 Review code (candid-loop)           [or SKIP]
-  [N]. 🛠️  Install: [installCommand]          [only if installCommand is set]
-  [N]. 🔨 Build: [buildCommand]               [or SKIP — not configured]
-  [N]. 🧪 Tests: [testCommand]                [or SKIP — not configured]
-  [N]. 📋 Create pull request
-  [N]. 🎯 Update issue tracker ([provider]): state="[state]"  [only if issueTracker.enabled]
-  [N]. 🔀 Auto-merge: enabled                 [or disabled]
-  [N]. 🚀 Post-merge: [postMergeCommand]      [only if postMergeCommand is set]
-```
+Render the plan per WORKFLOW.md → "Display Plan": header `Candid Ship Plan`, statuses `[or SKIP]` / `[or SKIP — not configured]` per the enablement rules above.
 
 If `additionalPrompt` is set, append: `Review context: "[additionalPrompt]"`.
 
@@ -78,21 +62,9 @@ If `additionalPrompt` is set, append: `Review context: "[additionalPrompt]"`.
 
 **Otherwise:** Use AskUserQuestion: "Proceed with this shipping plan?" with options "Yes, ship it" / "No, cancel". On "No, cancel": exit with `Ship cancelled.`
 
-### Step 4: Run Review
+### Steps 4-7: Review, Install, Build, Tests
 
-**Skip if** `--skip-review` is set → `Skipping review (--skip-review)`. Otherwise execute WORKFLOW.md → "Run Review (candid-loop)".
-
-### Step 5: Install Dependencies
-
-**Skip if** `--skip-install` is set → `Skipping install (--skip-install)`. Skip if `installCommand` is not configured → `Skipping install (not configured)`. Otherwise execute WORKFLOW.md → "Install Dependencies".
-
-### Step 6: Run Build
-
-**Skip if** `--skip-build` is set → `Skipping build (--skip-build)`. Skip if `buildCommand` is not configured → `Skipping build (not configured)`. Otherwise execute WORKFLOW.md → "Run Build".
-
-### Step 7: Run Tests
-
-**Skip if** `--skip-tests` is set → `Skipping tests (--skip-tests)`. Skip if `testCommand` is not configured → `Skipping tests (not configured)`. Otherwise execute WORKFLOW.md → "Run Tests".
+Run in order: review, install, build, tests. For each: skip if its `--skip-*` flag is set → `Skipping [step] (--skip-[step])`; skip install/build/tests if the corresponding command is not configured → `Skipping [step] (not configured)`; otherwise execute the matching WORKFLOW.md section ("Run Review (candid-loop)", "Install Dependencies", "Run Build", "Run Tests").
 
 ### Step 8: Create Pull Request
 
@@ -146,12 +118,7 @@ Add to `.candid/config.json`:
 
 ### Field Reference
 
-For full type, default, and validation rules see `skills/candid-review/CONFIG.md` (the `ship` section). Highlights:
-
-- `buildCommand` / `testCommand` / `installCommand` / `additionalPrompt` / `postMergeCommand` default to `null` — the corresponding step is skipped if not set.
-- `targetBranch` defaults to first `mergeTargetBranches` entry, else `"main"`.
-- `autoMerge` defaults to `false`.
-- `issueTracker` is opt-in (`enabled: false` by default). When enabled, `provider: "linear"` is the only supported value today; other values warn and skip. The default `prompt` is documented in CONFIG.md and codifies the four safety invariants.
+Types, defaults, and validation live in `skills/candid-review/CONFIG.md` (`ship` section); WORKFLOW.md → "Load Configuration" summarizes the defaults.
 
 > **Note:** `issueTracker` is an optional integration. When omitted, the issue-tracker step is skipped silently — the rest of the ship runs unchanged. To request support for another tracker (Asana, Jira, GitHub Issues, etc.), open an issue at https://github.com/ron-myers/candid/issues.
 
@@ -207,10 +174,4 @@ For full type, default, and validation rules see `skills/candid-review/CONFIG.md
 
 ## Remember
 
-The goal of candid-ship is to **automate the entire shipping workflow** so you can go from code to merged PR with one command.
-
-**Fail-fast principle:** Any failure (review incomplete, install/build/test fail) aborts immediately with a clear message. Post-PR steps (issue tracker, auto-merge, post-merge) warn but never abort — the PR is already created and shouldn't be wasted.
-
-**Pre-flight checks:** Always validate the environment before starting. It's frustrating to complete a full review + install + build + test cycle only to discover gh isn't installed.
-
-**Install before build:** Setting `installCommand` (e.g. `pnpm install`, `npm ci`, `poetry install`) keeps build/test failures focused on real code issues rather than missing dependencies.
+Fail-fast: any pre-PR failure aborts immediately; post-PR steps (issue tracker, auto-merge, post-merge) warn but never abort — the PR already exists. Set `installCommand` (e.g. `npm ci`) so build/test failures reflect real code issues, not missing dependencies.

--- a/skills/candid-ship/WORKFLOW.md
+++ b/skills/candid-ship/WORKFLOW.md
@@ -66,6 +66,34 @@ If `0`: abort with `No commits ahead of [targetBranch]. Nothing to ship.`
 
 ---
 
+## Display Plan
+
+Both skills render the plan with this box. The calling skill supplies `[Header]`, the `[STATUS]` text per row (its enablement/skip semantics), and the renumbering-note wording.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[Header]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Branch: [currentBranch] → [targetBranch]
+
+Steps (numbers assigned dynamically — only [running | enabled+configured] steps get a number):
+  [N]. 🔍 Review code (candid-loop)           [STATUS]
+  [N]. 🛠️  Install: [installCommand]          [STATUS]
+  [N]. 🔨 Build: [buildCommand]               [STATUS]
+  [N]. 🧪 Tests: [testCommand]                [STATUS]
+  [N]. 📋 Create pull request
+  [N]. 🎯 Update issue tracker ([provider])   [STATUS]
+  [N]. 🔀 Auto-merge                          [STATUS]
+  [N]. 🚀 Post-merge: [postMergeCommand]      [STATUS]
+```
+
+Row variations:
+- **candid-ship** appends `: state="[state]"` to the issue-tracker row (shown only if `issueTracker.enabled`), and renders the auto-merge row as `🔀 Auto-merge: enabled` or `🔀 Auto-merge: disabled`.
+- **candid-fast-ship** uses the rows as-is with its `[ENABLED | SKIPPED — ...]` statuses.
+
+---
+
 ## Install Dependencies
 
 Display:

--- a/skills/candid-validate-standards/SKILL.md
+++ b/skills/candid-validate-standards/SKILL.md
@@ -88,6 +88,8 @@ Flag rules containing vague terms without specifics:
 | "avoid" (alone) | No guidance on alternatives |
 | "consider" | Not a requirement |
 
+Also flag: suitable, adequate, well-organized, well-written, scalable, flexible, robust, simple, straightforward, intuitive, obvious, sensible, meaningful, significant, as needed, prefer, try to, minimal, few, some, many, several, various.
+
 **Exception:** Terms are OK if followed by specific criteria:
 - "readable (functions under 50 lines)" ✓
 - "maintainable" ✗
@@ -104,6 +106,8 @@ Flag rules that imply quantity without numbers:
 | "minimal dependencies" | What's minimal? |
 | "few levels of nesting" | How few? |
 | "reasonable timeout" | What's reasonable? |
+
+Also flag: maximum/minimum, too many/too few, keep under/below, no more than — when no number follows.
 
 **Fix pattern:** Add specific numbers (e.g., "functions under 50 lines")
 
@@ -211,23 +215,14 @@ Rules that may have issues.
 [List of rules that passed validation]
 ```
 
+If zero issues: output a short pass message with file path and rule count instead of the full report.
+
 ### Step 6: Suggest Fixes (if --fix flag)
 
 If `--fix` argument provided, include specific rewrites:
 
 ```markdown
 ## 💡 Suggested Rewrites
-
-### Line 12: "Write clean code"
-**Original:** Write clean code
-**Suggested:**
-- Functions must be under 50 lines
-- No single-letter variable names except loop counters
-- Maximum 3 levels of nesting
-
-### Line 18: "Keep functions small"
-**Original:** Keep functions small
-**Suggested:** Functions must be under 50 lines (warning at 30)
 
 ### Line 24: "Use appropriate error handling"
 **Original:** Use appropriate error handling
@@ -258,75 +253,6 @@ End with actionable summary:
 3. Rewrite [W] vague rules with specific criteria
 
 Run `/candid-validate-standards --fix` for suggested rewrites.
-```
-
-## Output Examples
-
-### Clean Technical.md
-
-```
-✅ Technical.md Validation Passed
-
-File: ./Technical.md
-Rules analyzed: 24
-Issues found: 0
-
-All rules are specific and verifiable. Nice work!
-```
-
-### Issues Found
-
-```
-⚠️ Technical.md Validation: 8 issues found
-
-File: ./Technical.md
-Rules analyzed: 24
-Issues found: 8
-
-🌫️ Vague Language (3)
-  Line 12: "clean code" - subjective term
-  Line 18: "proper error handling" - "proper" undefined
-  Line 31: "when necessary" - undefined trigger
-
-📏 Missing Thresholds (2)
-  Line 15: "small functions" - no size specified
-  Line 22: "limit nesting" - no depth specified
-
-🔧 Linter Overlap (3)
-  Line 5: semicolons - handled by ESLint
-  Line 8: quote style - handled by Prettier
-  Line 11: import order - handled by ESLint
-
-Run `/candid-validate-standards --fix` for suggested rewrites.
-```
-
-## Vague Terms Reference
-
-Use this list to detect vague language:
-
-```
-clean, good, proper, appropriate, suitable, adequate
-well-designed, well-structured, well-organized, well-written
-readable, maintainable, scalable, flexible, robust
-best practices, industry standards, conventions
-simple, straightforward, intuitive, obvious
-reasonable, sensible, meaningful, significant
-when necessary, when appropriate, when needed, as needed
-avoid, prefer, consider, try to, should (without specifics)
-minimal, few, some, many, several, various
-```
-
-## Threshold Patterns Reference
-
-Patterns that need numbers:
-
-```
-small/short/brief + (function|method|class|file|module)
-limit/restrict/cap + (parameters|arguments|nesting|depth|complexity)
-maximum/minimum + (without number following)
-too many/too few + (without threshold)
-keep ... under/below + (without number)
-no more than + (without number)
 ```
 
 ## Remember


### PR DESCRIPTION
## Summary

Full audit of all 10 skills + 9 command files + code-reviewer agent for token waste, followed by 75 behavior-preserving edits. Net: **−1,771 lines from always-loaded context** (1,949 deleted, 178 added), with 614 lines moved verbatim to on-demand reference files.

### What changed

- **Progressive disclosure**: `candid-init`'s 10 inline agent-prompt templates → `skills/candid-init/reference/` (loaded only in thorough mode, diff-verified verbatim); `candid-review`'s 75-line edge-case checklist → `EDGE-CASE.md` (loaded only with `--focus edge-case`)
- **Config example galleries trimmed**: both CONFIG.md files reduced from ~18 examples to the 2–4 that add information beyond the schema
- **Boilerplate dedupe**: CLI → project → user → default precedence ladder stated once per skill instead of once per field; duplicate `--auto-commit` spec removed; loop's 3 summary templates → 1; identity category-mapping deleted
- **Command files delegate**: workflow/output/config recaps deleted from `commands/*.md` — they double-load with SKILL.md every invocation
- **Shared templates**: ship/fast-ship plan boxes unified in `candid-ship/WORKFLOW.md`; chrome-qa-fix's 3 identical provider warnings merged

### What was protected

All review criteria, severity/category definitions, all six "What to Look For" checklists, fix-confidence definitions, user-visible output strings, defaults, and precedence behavior — preserved verbatim. Every deletion was verified as a true duplicate before removal.

### Verification

- `npm run validate-manifests`: all 4 manifests in lockstep at v1.19.1
- Frontmatter intact and code fences balanced across all 25 edited files
- All SKILL.md ↔ WORKFLOW.md/CONFIG.md/reference pointers resolve; step numbering unchanged

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>