### PR TITLE
Skill effectiveness pass — 10 improvements (v1.20.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "name": "candid",
       "source": "./.codex-plugin",
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.19.1",
+      "version": "1.20.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.19.1",
+      "version": "1.20.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-07-04
+
 ### Changed
 
 - **Effectiveness pass — 10 improvements to raise catch-rate and cut false positives** (+88 lines across 8 files):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Effectiveness pass — 10 improvements to raise catch-rate and cut false positives** (+88 lines across 8 files):
+  - `candid-review`: new Hard Rules (read the enclosing function and grep callers before flagging; every issue needs quoted evidence + a concrete trigger); untracked files now reviewed, rename detection (`-M`), staged/unstaged-mix warning; severity boundary test (🔥 Critical requires a nameable trigger); auto-select contradiction with candid-loop resolved (loop `--mode auto` counts as explicit selection)
+  - `candid-loop`: new Loop Invariants — PASS requires a fresh post-fix review, zero-progress iterations exit INCOMPLETE, oscillation (a fixed issue reappearing) halts the loop, rejected issues aren't re-asked
+  - `agents/code-reviewer`: receives diff hunks, must verify reachability before flagging, and returns a verbatim `evidence` quote per issue
+  - `candid-init`: generated rules carry provenance tags — `[observed N/M]` with known exceptions vs `[recommended]`; analysis agents must report adherence counts and negative evidence (patterns the codebase deliberately avoids)
+  - `candid-validate-standards`: new 4.6 Codebase Spot-Check — samples real files per rule and flags stale/untrue/contested rules
+  - `candid-chrome-qa-fix`: mandatory in-browser re-verification of each finding's repro steps before a fix may be marked ✓; new `⚠ applied-unverified` and `✗ still-reproduces` outcomes
+  - `candid-ship`: test step must report actual test counts + exit code; exit 0 with zero tests executed is a failure, not a pass
+
 ## [1.19.1] - 2026-07-04
 
 ### Changed

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -24,6 +24,7 @@ You will receive:
 2. **Technical.md content** - Project standards (if exists)
 3. **Files to review** - Specific files or domains assigned to you
 4. **Review focus** - What aspect to focus on (security, performance, architecture, etc.)
+5. **Diff hunks / changed line ranges per file** — anchor findings in changed code; flag unchanged code only when the change breaks it (cite both sites).
 
 ## Review Process
 
@@ -53,6 +54,8 @@ For each file in your scope:
    ```
    pattern: **/*{test,spec}*.{ts,js,tsx,jsx}
    ```
+
+5. **Verify reachability before flagging.** For any "missing check/validation" finding, Grep the call sites: if every caller already guards the case, drop it. For any changed function signature or export, Grep ALL callers and report each caller the change breaks.
 
 ### 3. Analyze Deeply
 
@@ -90,6 +93,7 @@ Return findings as structured JSON for the main skill to format:
       "file": "path/to/file.ts",
       "line": 42,
       "problem": "Description of the issue",
+      "evidence": "verbatim quote of the offending code",
       "impact": "Why this matters",
       "fix": "Code or description of fix",
       "standard": "Name of Technical.md standard if applicable"
@@ -125,6 +129,7 @@ Before returning, verify you've checked:
 - [ ] Test coverage assessed
 - [ ] Technical.md rules applied (if provided)
 - [ ] Each issue has file:line reference
+- [ ] Each issue includes a verbatim evidence quote
 - [ ] Each issue has concrete fix
 - [ ] No false positives (verified issues are real)
 

--- a/skills/candid-chrome-qa-fix/SKILL.md
+++ b/skills/candid-chrome-qa-fix/SKILL.md
@@ -224,16 +224,19 @@ For each selected finding, in severity order (P0 first, then P1, …):
 1. Print the finding's `id`, `severity`, `category`, `title`, `repro`, `expected`, `actual`, `suggestedFix`, and any `evidence.filesLikelyTouched`.
 2. Read the files in `evidence.filesLikelyTouched`. If a path doesn't exist, log `[WARN] F-... — filesLikelyTouched path missing: <path>` and skip the finding (mark as failed in the summary).
 3. Apply the smallest change that resolves `actual` to match `expected`, using `suggestedFix` as guidance. NEVER write outside `evidence.filesLikelyTouched` without surfacing it explicitly.
-4. Append a one-line entry to `.context/findings/<base>.fixes.md` (create if missing): `<ISO-timestamp> | F-<id> | <title> | <files-changed>`.
+4. **Re-verify in the browser — mandatory.** If `context.environment.url` responds (curl 2xx/3xx) and Chrome MCP is available, re-run the finding's `repro` steps against the running app, flushing console/network first, and confirm behavior now matches `expected` with fresh telemetry as proof. Only then may the summary show `✓`.
+   - Fix applied but re-verification impossible (server down, no Chrome MCP) → mark `⚠ applied-unverified` in the final summary, never `✓`.
+   - Repro still shows `actual` → mark `✗ still-reproduces` and do not ship that fix.
+5. Append a one-line entry to `.context/findings/<base>.fixes.md` (create if missing): `<ISO-timestamp> | F-<id> | <title> | <files-changed>`.
 
 After all selected findings:
 
-5. If `chromeQAFix.testCommand` is set, run it. If it fails, print the error and ask: `"Tests failed. (a) Stop and let me debug, (b) Continue and ship anyway, (c) Stop and rollback?"` via `AskUserQuestion`. On (c), restore from `git stash`.
-6. Build the PR title and body:
+6. If `chromeQAFix.testCommand` is set, run it. If it fails, print the error and ask: `"Tests failed. (a) Stop and let me debug, (b) Continue and ship anyway, (c) Stop and rollback?"` via `AskUserQuestion`. On (c), restore from `git stash`.
+7. Build the PR title and body:
    - **Title** (≤ 72 chars): if issue map has Linear IDs, `"Fix N QA findings (TEAM-123, TEAM-124, …): <top finding title>"`. Otherwise `"Fix N QA findings: <top finding title>"`. Truncate to 72 with `…`.
    - **Body**: see template in Step 8d below.
-7. Hand off to `/candid-fast-ship` (if `--fast` is set) or `/candid-ship` for the single PR. Pass `--skip-review` since we just edited deliberate fixes — re-reviewing them with `candid-loop` is duplicative and slow. Pass the title and body.
-8. Capture the PR URL.
+8. Hand off to `/candid-fast-ship` (if `--fast` is set) or `/candid-ship` for the single PR. Pass `--skip-review` since we just edited deliberate fixes — re-reviewing them with `candid-loop` is duplicative and slow. Pass the title and body.
+9. Capture the PR URL.
 
 #### Step 8b: Per-finding mode (Conductor deep links, parallel)
 
@@ -287,7 +290,7 @@ Reference this issue in the commit body and PR description.
 Steps:
 1. Rename the branch as above.
 2. Read the files listed in evidence.filesLikelyTouched.
-3. Apply the smallest change that resolves `actual` to match `expected`, using `suggestedFix` as guidance.
+3. Apply the smallest change that resolves `actual` to match `expected`, using `suggestedFix` as guidance. After applying, re-verify the finding's repro steps in the browser before reporting fixed; if unverifiable, report applied-unverified.
 4. If `.candid/config.json` has `chromeQAFix.testCommand` set, run it. Fix or stop on failure — do NOT proceed past failing tests.
 5. Commit with message: "Fix QA: {{title}}"
    Body must include:
@@ -304,7 +307,7 @@ DO NOT modify files unrelated to this finding. DO NOT touch other findings' file
 
 #### Step 8c: Local-only mode
 
-Run Step 8a's per-finding loop (steps 1–4) but stop before Step 8a/5 (test command, PR creation). Print a summary of files changed. The fixes remain uncommitted in the working tree for the user to review.
+Run Step 8a's per-finding loop (steps 1–5) but stop before Step 8a/6 (test command, PR creation). Print a summary of files changed. The fixes remain uncommitted in the working tree for the user to review.
 
 #### Step 8d: PR body template (used by 8a)
 
@@ -349,7 +352,7 @@ Per finding:
   …
 ```
 
-Glyph legend: `✓` = fixed + shipped (or applied), `✗` = fix failed, `◦` = issues-only / no fix attempted, `→` = dispatched to Conductor (per-finding mode).
+Glyph legend: `✓` = fixed + re-verified in browser + shipped (or applied), `⚠` = applied-unverified (fix applied, browser re-verification impossible), `✗` = fix failed or still-reproduces, `◦` = issues-only / no fix attempted, `→` = dispatched to Conductor (per-finding mode).
 
 Omit the `Issue:` column entirely if `issueTracker.enabled === false` or `provider !== "linear"`.
 

--- a/skills/candid-init/SKILL.md
+++ b/skills/candid-init/SKILL.md
@@ -288,6 +288,8 @@ After all generation agents complete, collect all sections and combine into one 
 For medium mode: Generate ~150 lines (condensed version of above)
 For quick mode: Generate ~50 lines (essential rules only)
 
+Tag each rule `[observed N/M]` (count via grep) or `[recommended]`, with known exceptions listed.
+
 ### Rule Quality Standards
 
 **Every rule MUST:**
@@ -307,6 +309,14 @@ For quick mode: Generate ~50 lines (essential rules only)
 4. **Note current state if it differs from the rule**
    - Good: "Use custom error classes. (Currently not implemented - see gaps section)"
    - Bad: "Use custom error classes"
+
+5. **Tag provenance and adherence**
+   - `[observed 12/14]` — convention followed by 12 of 14 relevant files. List the 2
+     violating files as `Known exceptions: path1, path2` so reviews flag only NEW violations,
+     not pre-existing code.
+   - `[recommended]` — best practice not yet present in this codebase. Must also appear in
+     the Gaps table; reviews should surface these as suggestions, never as hard violations.
+   - A rule with adherence below 60% must not ship as `[observed]` — move it to Gaps.
 
 ### What NOT to Include
 

--- a/skills/candid-init/reference/analysis-prompts.md
+++ b/skills/candid-init/reference/analysis-prompts.md
@@ -2,6 +2,19 @@
 
 Exact prompts for the five parallel Explore sub-agents. Each returns proposed rules with file:line evidence.
 
+## Required output format (all agents)
+
+For EVERY proposed rule, return:
+- Pattern statement (one line, concrete, checkable)
+- Evidence: 2-3 file:line citations that follow it
+- Adherence: N files follow / M violate — list the violating files (they become the
+  rule's known exceptions)
+- Negative evidence: patterns the codebase deliberately avoids (e.g., "0 of 47 modules
+  use default exports", "no barrel index.ts files") — propose these as explicit
+  "do not introduce X" rules; reviewers cannot infer absence from positive examples.
+
+Rules without adherence counts are discarded at synthesis.
+
 #### Agent 1: Architecture & Imports Agent
 
 **Prompt:**

--- a/skills/candid-loop/SKILL.md
+++ b/skills/candid-loop/SKILL.md
@@ -82,6 +82,13 @@ IF iteration >= maxIterations AND remainingIssues > 0:
     List remaining issues
 ```
 
+### Loop Invariants — do not violate
+
+1. **PASS requires a fresh clean review.** Status PASS only if the final iteration ran candid-review AFTER the last fix was applied and found 0 filtered issues. Verify `.candid/last-review.json` timestamp postdates the last Edit. Never infer PASS from an earlier iteration.
+2. **No progress → stop.** If an iteration applies 0 fixes and filtered issues remain, exit INCOMPLETE immediately — repeating the identical review cannot converge.
+3. **Oscillation check.** If an issue id already in `allFixedIssues` reappears in a later iteration, stop: `Oscillation detected: fix for [id] was undone or reintroduced.` List both fixes for manual resolution.
+4. **Don't re-ask rejected issues.** Add ids skipped via "No"/"Skip" to `sessionSkipped`; filter them in Step 3.4 in later iterations. They count toward INCOMPLETE, not re-prompts.
+
 #### Step 3.1: Run candid-review
 
 Display iteration header:

--- a/skills/candid-review/SKILL.md
+++ b/skills/candid-review/SKILL.md
@@ -7,6 +7,13 @@ description: Use when reviewing code changes before commit or PR — configurabl
 
 You are a full-stack architect conducting a code review. Your approach is based on Radical Candor: **Care Personally + Challenge Directly**. You catch real issues, provide actionable fixes, and make it easy to track what needs to be addressed.
 
+## Hard Rules — do not violate
+
+1. **Never flag a line you haven't read in context.** Before reporting, Read the full enclosing function and Grep its callers. If an upstream guard already handles the case, do not report it.
+2. **Every issue needs evidence:** file:line, the offending code quoted verbatim, and a concrete trigger (the input/state/sequence that causes the failure). No trigger → downgrade to 🤔 or drop.
+3. **Never report an issue in code the diff didn't touch** — unless the diff breaks it (changed signature, removed guard); then cite both sites.
+4. **Never skip Step 8 or auto-select fixes** when issues exist (sole exception: candid-loop auto mode, see Step 8).
+
 ## Workflow
 
 Execute these steps in order:
@@ -57,20 +64,26 @@ If this fails, inform user: "This directory is not a git repository. I need a gi
 
 **2. Check for changes in priority order:**
 ```bash
-# Check for staged changes first
-git diff --cached --stat
+# Get the full working-tree state (staged, unstaged, untracked)
+git status --porcelain
+
+# Check for staged changes first (-M detects renames)
+git diff --cached -M --stat
 
 # Then unstaged changes
-git diff --stat
+git diff -M --stat
 
 # Compare to merge target per Runtime Branch Selection in Step 2.5
 ```
 
 **3. Decide what to review:**
-- If staged changes exist → review with `git diff --cached`
-- Else if unstaged changes exist → review with `git diff`
-- Else if branch differs from merge target → review with `git diff <branch>...HEAD` (using first successful branch from mergeTargetBranches)
+- If staged changes exist → review with `git diff --cached -M`
+- Else if unstaged changes exist → review with `git diff -M`
+- Else if branch differs from merge target → review with `git diff -M <branch>...HEAD` (using first successful branch from mergeTargetBranches)
 - Else → inform user: "No changes detected to review"
+- **Untracked source files** (`git ls-files --others --exclude-standard`, minus excludes) are part of the change: Read and review them in full. New files hide the most issues because they have no diff to anchor on.
+- If BOTH staged and unstaged changes exist → review staged, then warn: `[N] file(s) also have unstaged changes excluded from this review: [list]`.
+- Use `-M` so renamed files review as edits to the rename, not as a whole-file addition.
 
 **4. Handle special cases:**
 - Skip binary files (note them but don't review content)
@@ -250,6 +263,7 @@ Use the Task tool with the code-reviewer agent. Provide:
 - Technical.md content (if loaded)
 - List of files assigned to the subagent
 - Specific focus area (security, performance, architecture)
+- The diff hunks / changed line ranges for the subagent's files — required so the subagent can anchor findings in changed code.
 
 **Merging results:**
 The subagent returns JSON. Convert each issue to the markdown format in Step 6:
@@ -275,6 +289,8 @@ Analyze every change with the chosen tone. Categorize issues by severity:
 | 5 | Edge Case | 🤔 | Unhandled scenarios: null, empty, concurrent, timeout |
 | 6 | Architectural | 💭 | Design concerns: coupling, SRP violations, patterns |
 | 7 | Clarification Needed | ? | Question for the author — cannot determine correct action from code alone |
+
+**Boundary test:** an issue is 🔥 Critical only if you can state the concrete trigger — the input, state, or call sequence on a reachable path — that causes the crash/exploit/data loss, and quote the code that fails. Reachable but requires unusual-yet-legal input → ⚠️ Major. Cannot name a trigger at all → 🤔 Edge Case or drop. Never inflate severity for attention; miscategorized findings train users to ignore 🔥.
 
 ### Clarification Needed ? (Decision Register)
 
@@ -504,7 +520,7 @@ Before applying fixes, show a summary and get final confirmation:
      - "Yes, apply all selected" - Proceed to Step 9 with selectedFixes
      - "No, let me review again" - Return to Phase 8a and start over
 
-**Enforcement:** Do not auto-select fixes or assume user intent — the user must choose through one of these paths.
+**Enforcement:** Do not auto-select fixes or assume user intent — the user must choose through one of these paths. **Sole exception:** when invoked by candid-loop with `--mode auto`, the user's mode choice IS the selection: select "Apply all fixes" (post-filtering per loop config) without prompting, and note `Auto-applied under candid-loop auto mode` in the output.
 
 ### Step 9: Apply Fixes or Create Todos
 

--- a/skills/candid-ship/WORKFLOW.md
+++ b/skills/candid-ship/WORKFLOW.md
@@ -143,7 +143,9 @@ Step [N]/[totalSteps]: Running tests...
 $ [testCommand]
 ```
 
-Execute. On non-zero exit: `Tests failed. Ship aborted.` Show output and abort. On success: `Tests passed.`
+Execute. On non-zero exit: `Tests failed. Ship aborted.` Show output and abort.
+
+On success, verify before declaring: extract the runner's own counts from the output (e.g. "Tests: 42 passed", "12 passing") and report `Tests passed (<N> tests, exit 0).` If the exit code is 0 but the output shows zero tests executed ("No tests found", "0 passed", empty match pattern), treat it as a FAILURE: `Test command matched zero tests — nothing was verified. Ship aborted.` Never print `Tests passed.` without the count and exit code from the run you just executed.
 
 ---
 

--- a/skills/candid-validate-standards/SKILL.md
+++ b/skills/candid-validate-standards/SKILL.md
@@ -158,6 +158,16 @@ Flag rules that can't be checked by reading code:
 - "Use common sense"
 - References to external documents without specifics
 
+#### 4.6 Codebase Spot-Check (🔬)
+
+For up to 10 rules that cite a path, glob, or naming pattern:
+1. Verify every cited file/directory exists (`ls` it). Missing → flag **stale**.
+2. Sample 3 files the rule applies to (find/grep by the rule's stated scope) and check
+   whether the rule actually holds in each.
+3. 0/3 hold → flag **untrue** ("rule contradicts this codebase — remove or move to Gaps").
+   1-2/3 hold → flag **contested** ("add known exceptions or relax the rule").
+Report in a `🔬 Spot-Check` section listing the sampled files per rule.
+
 ### Step 5: Generate Report
 
 Present findings organized by severity:
@@ -207,6 +217,12 @@ Rules that may have issues.
 | Line | Rule | Suggestion |
 |------|------|------------|
 | 22 | "Functions should be pure, small, and documented" | Split into 3 rules |
+
+---
+
+## 🔬 Spot-Check
+
+[Per rule checked: verdict (stale/untrue/contested) with the 3 sampled files]
 
 ---
 


### PR DESCRIPTION
## Summary

Ten targeted improvements to raise review catch-rate, cut false positives, and make skill workflows harder to shortcut. Sourced from a 3-agent effectiveness audit (review family, standards family, ship/qa family). +99/−16 lines across 9 files.

### Improvements

1. **candid-review — Hard Rules**: read the enclosing function + grep callers before flagging; every issue requires quoted code and a concrete trigger; never flag untouched code unless the diff breaks it
2. **candid-review — coverage**: untracked new files reviewed (previously zero coverage), rename detection (`-M`), warning when unstaged changes are excluded from a staged review
3. **candid-review — severity boundary test**: 🔥 Critical requires a nameable trigger on a reachable path
4. **candid-review ↔ candid-loop**: auto-select contradiction resolved — loop `--mode auto` counts as the user's explicit fix selection
5. **candid-loop — Loop Invariants**: PASS only from a fresh post-fix review; zero-progress iterations exit INCOMPLETE; oscillation detection; rejected issues not re-asked
6. **code-reviewer agent**: receives diff hunks, mandatory reachability verification, verbatim `evidence` field per issue
7. **candid-init — provenance**: rules tagged `[observed N/M]` (with known exceptions) vs `[recommended]`; analysis agents report adherence counts + negative evidence
8. **candid-validate-standards — spot-check**: samples 3 real files per rule; flags stale/untrue/contested rules instead of only linting prose
9. **candid-chrome-qa-fix — re-verification**: fixes must re-run the finding's repro steps in the browser before showing ✓; new `⚠ applied-unverified` / `✗ still-reproduces` outcomes
10. **candid-ship — test honesty**: reports actual test counts + exit code; exit 0 with zero tests executed aborts the ship

### Verification

- `npm run validate-manifests`: all 4 manifests in lockstep at v1.20.0
- Code fences balanced, step numbering intact, all SKILL.md ↔ WORKFLOW.md references resolve
- Fixers verified referenced variable/step names against actual file structure before inserting

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>