### PR TITLE
Clearer fix selection + ship confidence — 10 features (v1.21.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "name": "candid",
       "source": "./.codex-plugin",
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-07-04
+
+### Added
+
+- **Fix selection, clearer and safer** (candid-review, candid-improve-implementation, candid-loop):
+  - **Triage Queue**: reviews open with a ranked table — #, severity, file, title, fix confidence, estimated fix scope — and the `#N` ids stay canonical through selection prompts, todos, the status report, and the commit message
+  - **"Show me the exact diff"**: any fix can be previewed as a unified diff built from real file content before saying yes (all three selection UIs); a preview never counts as approval
+  - **Confidence-tier bulk apply**: "Apply a subset" now offers Critical+Major, Safe ✓ only (mechanical, no behavior change), or the intersection
+  - **Selection receipt + per-fix status**: one-screen receipt (applying/skipped/recorded) before apply, and a per-fix ✅ applied / ❌ failed table after; one failure never aborts the batch; edits apply bottom-up per file so anchors don't shift
+  - **`--triage` mode**: review + queue + saved state, nothing applied — for CI and quick checks (CLI-only by design)
+- **Ship confidence** (candid-ship, candid-fast-ship):
+  - **Ship Confidence Report**: evidence panel (review/build/tests/QA findings/untested changes/diff risk) with a HIGH/MEDIUM/LOW verdict, printed pre-PR and embedded in the PR body; skipped signals render as SKIPPED — absence of evidence is visible, never hidden; LOW verdict requires explicit confirmation
+  - **Diff risk classification**: migrations/auth/API contracts/dependencies/config classify the diff HIGH risk — blocking `--skip-review`/`--skip-tests` on candid-ship and routing fast-ship to the full pipeline
+  - **QA Findings Gate**: open P0/P1 chrome-qa findings newer than the merge-base that overlap the diff must be acknowledged or the ship aborts; acknowledgments are recorded in the PR body
+  - **Test-to-change mapping**: changed source files with no test change and no covering test file are reported as untested changes (a hard prompt when risk is HIGH)
+  - **Rollback note**: every PR body ends with the exact revert command plus risk-derived caveats (migrations, config, dependencies, auth)
+
 ## [1.20.0] - 2026-07-04
 
 ### Changed

--- a/commands/candid-review.md
+++ b/commands/candid-review.md
@@ -21,6 +21,9 @@ args:
   - name: commit
     description: Automatically create git commit after applying fixes with detailed message listing all changes
     required: false
+  - name: triage
+    description: Review + triage queue only; apply nothing (CLI-only)
+    required: false
 ---
 
 Run a code review on your current changes with configurable tone and focus.
@@ -34,6 +37,7 @@ Usage:
 /candid-review --focus performance       # Performance-focused review
 /candid-review --exclude "*.generated.ts"  # Exclude patterns
 /candid-review --re-review               # Compare to previous review
+/candid-review --triage                  # Review + triage queue only, apply nothing
 ```
 
 Full workflow, output format, and configuration: the candid-review skill.

--- a/skills/candid-fast-ship/SKILL.md
+++ b/skills/candid-fast-ship/SKILL.md
@@ -39,6 +39,10 @@ If both `--auto-merge` and `--no-auto-merge` are provided, `--no-auto-merge` win
 
 Priority: `fastShip.targetBranch` → `ship.targetBranch` → first `mergeTargetBranches` entry → `"main"`. Then run target-branch verification and branch-state validation per WORKFLOW.md → "Resolve targetBranch" / "Validate Branch State".
 
+#### Classify Diff Risk
+
+Execute skills/candid-ship/WORKFLOW.md → "Classify Diff Risk" with the fast-ship escalation: HIGH risk aborts (`Risk class HIGH ([signals]): use /candid-ship for this change.`) unless `fastShip.review` and `fastShip.tests` are both enabled and their `ship` commands are configured. Display `Diff risk: [class] ([signals])` below the `Branch:` line in the plan. This is the enforcement behind the "low-risk changes" promise in this skill's description.
+
 ### Step 3: Display Plan
 
 A step is **enabled** only when its `fastShip` toggle is `true` AND the underlying `ship` config is present:
@@ -70,6 +74,10 @@ If all optional steps are disabled, append `(All optional steps disabled — onl
 ### Steps 5-7: Install, Build, Tests
 
 For each of install/build/tests: skip if its `fastShip.[step]` toggle is `false` → `Skipping [step] (not enabled in fastShip config)`; skip if the toggle is `true` but the corresponding `ship` command (`installCommand`/`buildCommand`/`testCommand`) is unset → `Skipping [step] ([commandField] not configured in ship)`; otherwise execute the matching WORKFLOW.md section ("Install Dependencies", "Run Build", "Run Tests").
+
+### Step 7.5: Pre-PR Confidence Gates
+
+Always runs — these are read-only checks, not toggleable steps, and are not counted in `totalSteps`. Execute skills/candid-ship/WORKFLOW.md → "Map Tests to Changes", "QA Findings Gate", then "Ship Confidence Report". Steps disabled in `fastShip` config appear as `SKIPPED` rows in the report — the PR records exactly how little was verified, which is the honest cost of a fast ship.
 
 ### Step 8: Create Pull Request
 

--- a/skills/candid-improve-implementation/SKILL.md
+++ b/skills/candid-improve-implementation/SKILL.md
@@ -261,7 +261,7 @@ Loop through opportunities. For each:
 1. Show issue number `[1/N]`, icon, title, file location, brief problem
 2. AskUserQuestion:
    - **Question:** "Apply this suggestion?"
-   - **Options:** "Yes, apply", "No, skip"
+   - **Options:** "Yes, apply", "No, skip", "Show me the exact diff" (present a unified before/after diff built from current file content, then re-ask Yes/No — preview never counts as approval)
 3. If Yes → add to `selectedFixes`. If No → continue.
 
 After loop, proceed to 9c.
@@ -284,6 +284,7 @@ Do not proceed to Step 10 without explicit confirmation.
 2. Initialize `modifiedFiles` set
 3. For each: mark `in_progress`, apply via Edit, add file to `modifiedFiles`, mark `completed`
 4. Summarize: count applied + list of modified files
+5. End with a per-item status table (`| # | Item | File | Status |`) — `✅ applied` or `❌ failed — [reason]`; failures stay `pending` in todos and never abort the batch.
 
 **If `selectedFixes` is empty (user chose "None"):**
 

--- a/skills/candid-loop/SKILL.md
+++ b/skills/candid-loop/SKILL.md
@@ -226,6 +226,7 @@ Problem: [description]
 **Options:**
 1. "Yes, apply this fix"
 2. "No, skip this fix"
+3. "Show exact diff" — present the fix as a unified before/after diff from current file content, then re-ask with the Yes/No options only
 
 Track user choices:
 - If "Yes" → Apply the fix, increment totalFixesApplied

--- a/skills/candid-review/SKILL.md
+++ b/skills/candid-review/SKILL.md
@@ -12,7 +12,7 @@ You are a full-stack architect conducting a code review. Your approach is based 
 1. **Never flag a line you haven't read in context.** Before reporting, Read the full enclosing function and Grep its callers. If an upstream guard already handles the case, do not report it.
 2. **Every issue needs evidence:** file:line, the offending code quoted verbatim, and a concrete trigger (the input/state/sequence that causes the failure). No trigger → downgrade to 🤔 or drop.
 3. **Never report an issue in code the diff didn't touch** — unless the diff breaks it (changed signature, removed guard); then cite both sites.
-4. **Never skip Step 8 or auto-select fixes** when issues exist (sole exception: candid-loop auto mode, see Step 8).
+4. **Never skip Step 8 or auto-select fixes** when issues exist (exceptions: candid-loop auto mode, see Step 8, and `--triage`, see Step 3 — in both, the user's explicit mode/flag choice IS the selection).
 
 ## Workflow
 
@@ -168,6 +168,18 @@ Then proceed with normal review.
 
 **Previous review state schema:** `{timestamp, commit, branch, issues[]}` where each issue has
 `{id, file, line, category, title, description}` — the same format Step 10 writes.
+
+#### Triage-Only Mode (`--triage`)
+
+`--triage — review + triage queue only; apply nothing (CLI-only)`
+
+CLI-only flag (no config equivalent — apply-nothing must be an explicit per-run choice). When set:
+- Run Steps 1-7 and Step 10 normally: full triage queue, detailed issues, state saved to `.candid/last-review.json`.
+- Skip Steps 8, 9, and 9.5 entirely. The flag IS the user's selection — it satisfies Hard Rule 4 the same way candid-loop auto mode does: the user chose "review only" up front.
+- Create no todos and apply nothing; the queue + saved state is the deliverable (CI, pre-commit sanity checks, quick looks).
+- End with: `Triage complete: [N] issues (🔥[a] ⚠️[b] 📜[c] 📋[d] 🤔[e] 💭[f]). Nothing applied. Re-run without --triage to select fixes, or --re-review after fixing.`
+
+Output when active: `Triage-only mode: review and queue only, no fixes will be applied`
 
 ### Step 4: Load Tone Preference and Commit Mode
 
@@ -380,10 +392,23 @@ When --focus edge-case is active, read EDGE-CASE.md (same directory as this skil
 
 ### Step 7: Present Issues with Fixes
 
+#### Triage Queue (print first, right after the Summary paragraph)
+
+Number issues #1..#N in Step 6 severity order (🔥 first; Safe ✓ before Verify ⚡ before Careful ⚠️ within a severity). These numbers are canonical — reuse them in Step 8 prompts, todos, the Step 9 status report, and the commit message.
+
+| # | Sev | File | Title | Confidence | Est. scope |
+|---|-----|------|-------|------------|------------|
+| 1 | 🔥 | src/user.ts:42 | Missing null check on user | Safe ✓ | ~3 lines, 1 file |
+| 2 | ⚠️ | src/orders.ts:88 | N+1 query in findAll | Verify ⚡ | ~15 lines, 2 files |
+
+- **Est. scope** = lines/files the *fix* touches, not the issue.
+- Skip the table when there are 2 or fewer issues.
+- The detailed listing below MUST follow the same order, with the number in each heading: `### [Icon] #[N] [Title]`.
+
 For each issue, provide this structured format:
 
 ```markdown
-### [Icon] [Title]
+### [Icon] #[N] [Title]
 **File:** path/to/file.ts:42-45
 **Confidence:** [Safe ✓ | Verify ⚡ | Careful ⚠️]
 **Problem:** Clear description of what's wrong
@@ -457,15 +482,22 @@ Use AskUserQuestion to offer bulk action shortcuts:
 
 **Options:**
 1. "Apply all fixes" - Apply all proposed fixes without individual review
-2. "Apply Critical + Major only" - Apply only 🔥 and ⚠️ fixes automatically
+2. "Apply a subset" - Bulk-apply by severity or fix confidence (follow-up question)
 3. "Review each fix individually" - Go through each fix one by one (proceeds to Phase 8b)
 4. "None (track as todos)" - Don't apply any fixes, add all to todo list
 
 Store the user's choice and proceed based on their selection:
 - If "Apply all fixes" → Add all issues to selectedFixes array, skip to Phase 8c
-- If "Apply Critical + Major only" → Add only 🔥 and ⚠️ issues to selectedFixes array, skip to Phase 8c
+- If "Apply a subset" → see routing below
 - If "Review each fix individually" → Proceed to Phase 8b
 - If "None (track as todos)" → Set selectedFixes to empty array, skip to Step 9
+
+Routing for option 2 (AskUserQuestion allows max 4 options, so subsets live in a follow-up):
+- If "Apply a subset" → follow-up AskUserQuestion "Which subset?" with options:
+  1. "Critical + Major (🔥⚠️)" → add only 🔥 and ⚠️ issues to selectedFixes
+  2. "Safe ✓ only" → add only Safe ✓-confidence issues (mechanical, no behavior change) — matches candid-improve-implementation Phase 9a
+  3. "Critical + Major that are Safe ✓" → intersection of both filters
+  Then skip to Phase 8c.
 
 #### Phase 8b: Individual Fix Review (Only if "Review individually" was chosen)
 
@@ -481,13 +513,14 @@ Loop through each issue identified in Steps 6-7. For each issue:
    - **Question:** "Apply this fix?"
    - **Context to display before options:**
      ```
-     [Icon] [Title]
+     [Icon] #[N] [Title]
      File: [path/to/file.ts:line]
      Problem: [Brief description]
      ```
    - **Options:**
      - "Yes, apply this fix" — add this issue to selectedFixes array
      - "No, skip this fix" — continue to next issue without adding
+     - "Show me the exact diff" — Read the current file at the cited lines and present the precise change as a unified diff (built from real file content, not the Step 7 sketch), then re-ask "Apply this fix?" with Yes/No options only. A preview never counts as approval.
      - "I have a question about this" (only if `registerEnabled == true`) — use a follow-up AskUserQuestion: "What is your question about this issue?" Record the user's question as a new register entry (`status: open`, `Asked By: Author`, file/component from the issue). Continue to next issue without adding to selectedFixes.
 
    **For Clarification Needed ? issues (only when register is enabled):**
@@ -513,6 +546,13 @@ Before applying fixes, show a summary and get final confirmation:
 1. **Display summary:**
    - Show count: "Ready to apply [N] selected fixes:"
    - List each selected fix with: number, icon, short title, file:line
+   - Append a one-screen receipt so nothing is silently dropped (omit zero-count lines):
+     ```
+     Applying: [N] fixes → files touched: [deduped list]
+     Skipped: [K] — #s + short titles, one line each
+     Questions recorded in register: [Q]
+     ```
+     When invoked by candid-loop, also show `Ignored persistently: [I]`.
 
 2. **Call AskUserQuestion for confirmation:**
    - **Question:** "Apply these fixes?"
@@ -520,7 +560,7 @@ Before applying fixes, show a summary and get final confirmation:
      - "Yes, apply all selected" - Proceed to Step 9 with selectedFixes
      - "No, let me review again" - Return to Phase 8a and start over
 
-**Enforcement:** Do not auto-select fixes or assume user intent — the user must choose through one of these paths. **Sole exception:** when invoked by candid-loop with `--mode auto`, the user's mode choice IS the selection: select "Apply all fixes" (post-filtering per loop config) without prompting, and note `Auto-applied under candid-loop auto mode` in the output.
+**Enforcement:** Do not auto-select fixes or assume user intent — the user must choose through one of these paths. **Exceptions:** `--triage` skips Step 8 entirely (see Step 3); and when invoked by candid-loop with `--mode auto`, the user's mode choice IS the selection: select "Apply all fixes" (post-filtering per loop config) without prompting, and note `Auto-applied under candid-loop auto mode` in the output.
 
 ### Step 9: Apply Fixes or Create Todos
 
@@ -529,9 +569,10 @@ Use the selectedFixes array from Step 8 to determine what action to take.
 **If selectedFixes contains fixes to apply (not empty):**
 
 1. Create a todo list of the selected fixes using TodoWrite (all as `pending`)
-   - Use format: `[Icon] Fix: [issue summary] at [file:line]`
+   - Use format: `[Icon] #[N] Fix: [issue summary] at [file:line]` (reusing the canonical Triage Queue numbers from Step 7)
 2. Initialize empty set `modifiedFiles` to track changed files
 3. Work through each fix sequentially:
+   - **Order the queue first:** within each file apply bottom-up (highest start line first) so earlier edits don't shift later anchors.
    - Mark the current fix as `in_progress`
    - Apply the fix using Edit tool
    - Add the file path to `modifiedFiles` set
@@ -539,6 +580,9 @@ Use the selectedFixes array from Step 8 to determine what action to take.
 4. After all fixes are applied, summarize what was changed:
    - State how many fixes were applied
    - List the files that were modified
+5. **Per-fix status report:** end with a table, one row per selected fix:
+   `| # | Fix | File | Status |` — Status is `✅ applied` or `❌ failed — [one-line reason]`.
+   On an Edit failure: leave that todo `pending`, do not add the file to `modifiedFiles`, continue with remaining fixes (one failure never aborts the batch), and list failed items as todos at the end.
 
 **If selectedFixes is empty (user chose "None" in Step 8):**
 
@@ -546,16 +590,16 @@ Create todos for ALL issues found in Steps 6-7 using TodoWrite:
 
 ```json
 {
-  "content": "[Icon] Fix: [issue summary] at [file:line]",
+  "content": "[Icon] #[N] Fix: [issue summary] at [file:line]",
   "activeForm": "Fixing [issue summary] in [file]",
   "status": "pending"
 }
 ```
 
 **Example todos:**
-- `🔥 Fix: null check missing in UserService.getUser() at user.ts:42`
-- `⚠️ Fix: N+1 query in OrderRepository.findAll() at orders.ts:88`
-- `📜 Fix: missing error handling per Technical.md at api.ts:15`
+- `🔥 #1 Fix: null check missing in UserService.getUser() at user.ts:42`
+- `⚠️ #2 Fix: N+1 query in OrderRepository.findAll() at orders.ts:88`
+- `📜 #3 Fix: missing error handling per Technical.md at api.ts:15`
 
 After creating todos, confirm to user how many were added and remind them they can review the todos later.
 
@@ -598,8 +642,8 @@ Create detailed commit message with this format:
 Apply candid-review fixes ([N] issues)
 
 Fixed issues:
-- [icon] [title] in [relative-path]:[line]
-- [icon] [title] in [relative-path]:[line]
+- [icon] #[N] [title] in [relative-path]:[line]
+- [icon] #[N] [title] in [relative-path]:[line]
 [... list continues ...]
 
 Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>
@@ -765,7 +809,7 @@ Consider committing [registerPath]/review-decision-register.md to preserve decis
 
 Present your review in this order:
 
-1. **Summary** - One paragraph overview of the changes and overall assessment
+1. **Summary** - One paragraph overview of the changes and overall assessment, followed immediately by the Triage Queue table (Step 7)
 2. **🔥 Critical Issues** - Must fix before commit (if any)
 3. **⚠️ Major Concerns** - Should fix (if any)
 4. **📜 Standards Violations** - Technical.md violations (if any)

--- a/skills/candid-ship/SKILL.md
+++ b/skills/candid-ship/SKILL.md
@@ -41,6 +41,10 @@ If both `--auto-merge` and `--no-auto-merge` are provided, `--no-auto-merge` win
 
 After loading, run the `targetBranch` resolution and branch-state validation from WORKFLOW.md → "Resolve targetBranch" / "Validate Branch State".
 
+### Step 2.5: Classify Diff Risk
+
+Execute WORKFLOW.md → "Classify Diff Risk". Enforce the candid-ship escalation defined there: HIGH risk with `--skip-review` or `--skip-tests` aborts before the plan is shown. Display `Diff risk: [class] ([signals])` in the plan box, directly below the `Branch:` line.
+
 ### Step 3: Display Plan
 
 Calculate `totalSteps` = 1 (PR creation always runs) + number of optional steps that will run. An optional step counts when:
@@ -65,6 +69,14 @@ If `additionalPrompt` is set, append: `Review context: "[additionalPrompt]"`.
 ### Steps 4-7: Review, Install, Build, Tests
 
 Run in order: review, install, build, tests. For each: skip if its `--skip-*` flag is set → `Skipping [step] (--skip-[step])`; skip install/build/tests if the corresponding command is not configured → `Skipping [step] (not configured)`; otherwise execute the matching WORKFLOW.md section ("Run Review (candid-loop)", "Install Dependencies", "Run Build", "Run Tests").
+
+### Step 7.5: Pre-PR Confidence Gates
+
+Always runs (read-only checks; not counted in `totalSteps`). Execute, in order, from WORKFLOW.md:
+
+1. "Map Tests to Changes"
+2. "QA Findings Gate"
+3. "Ship Confidence Report" — its LOW-verdict prompt decides whether the ship continues.
 
 ### Step 8: Create Pull Request
 

--- a/skills/candid-ship/WORKFLOW.md
+++ b/skills/candid-ship/WORKFLOW.md
@@ -66,6 +66,32 @@ If `0`: abort with `No commits ahead of [targetBranch]. Nothing to ship.`
 
 ---
 
+## Classify Diff Risk
+
+Classify immediately after branch-state validation, from changed paths only:
+
+```bash
+git diff --name-only $target_ref..HEAD
+```
+
+Assign the **highest** matching class and record which signals matched:
+
+| Class | Signals (path match, case-insensitive) |
+|-------|----------------------------------------|
+| **HIGH** | DB migrations (`migrat`, `*.sql`); auth/session (`auth`, `session`, `token`, `passw`, `crypt`); API contracts (`openapi`, `*.proto`, `routes`, `api/`); dependency manifests/lockfiles (`package.json`, `*.lock`, `go.mod`, `Gemfile`, `requirements`); config/env/CI (`.env*`, `Dockerfile`, `.github/workflows/`) |
+| **LOW** | every changed file is docs (`*.md`), tests (`*test*`, `*spec*`), styles (`*.css`, `*.scss`), or fixtures |
+| **MEDIUM** | everything else |
+
+Store as `riskClass` + `riskSignals`. Output: `Diff risk: [class] ([signal]: [example files])`.
+
+**Escalation at HIGH:**
+- candid-ship: abort if `--skip-review` or `--skip-tests` was passed — `Risk class HIGH ([signals]): [flag] not allowed. Run the full pipeline or split out the risky files.` If `testCommand` is unset, warn that confidence will be capped at LOW.
+- candid-fast-ship: abort with `Risk class HIGH ([signals]): use /candid-ship for this change.` unless `fastShip.review` AND `fastShip.tests` are both enabled.
+
+`riskClass` feeds the Ship Confidence Report, the "Map Tests to Changes" exception, and the PR Rollback note.
+
+---
+
 ## Display Plan
 
 Both skills render the plan with this box. The calling skill supplies `[Header]`, the `[STATUS]` text per row (its enablement/skip semantics), and the renumbering-note wording.
@@ -149,6 +175,71 @@ On success, verify before declaring: extract the runner's own counts from the ou
 
 ---
 
+## Map Tests to Changes
+
+Read-only heuristic; runs whether or not tests ran. Do not execute tests here.
+
+1. Changed source files: `git diff --name-only $target_ref..HEAD`, excluding docs (`*.md`), styles, fixtures, and test files (`*test*`, `*spec*`).
+2. For each, look for a coverage signal, in order:
+   - a test file **in the same diff** whose name references it (`foo.test.ts`, `foo.spec.js`, `test_foo.py`, `foo_test.go`);
+   - an existing covering test file in the repo: `git ls-files '*test*' '*spec*' | grep -i "<basename>"`, or a test file importing the module.
+3. Files with neither signal → `untestedChanges`.
+
+Output (warning, not a gate):
+```
+Untested changes: src/auth/session.ts, src/api/rates.ts (no test change, no covering test file — heuristic filename/import match)
+```
+or `All changed source files have coverage signals.`
+
+**Exception — HIGH risk:** if `riskClass` is HIGH and `untestedChanges` is non-empty, AskUserQuestion: "HIGH-risk files have no test coverage: [files]. Ship anyway?" with "Yes, ship" / "No, abort". On abort: `Ship aborted: untested high-risk changes.`
+
+Feeds the "Untested changes" row of the Ship Confidence Report.
+
+---
+
+## QA Findings Gate
+
+Check candid-chrome-qa output for unresolved high-severity findings before the PR exists.
+
+1. Findings dir: `.context/findings`. If it doesn't exist: `QA findings: not checked (no findings directory)` — stop here.
+2. Select findings files newer than the branch point:
+```bash
+merge_base=$(git merge-base $target_ref HEAD)
+find .context/findings -name '*.json' -newermt "$(git show -s --format=%ci $merge_base)"
+```
+3. From each matching file, collect findings with severity `P0` or `P1`. The findings schema has no lifecycle status — treat every P0/P1 as open unless the user says otherwise.
+4. Keep findings that plausibly overlap the diff: `repro`/`suggestedFix`/`evidence` mentions a changed file path, or the finding's `url` maps to a changed route/component. **If overlap cannot be determined, keep the finding** (safe default).
+5. None kept → `QA findings: none open (N files checked since merge-base)`.
+6. Any kept → list each as `[P0|P1] <id> <title> — <url>`, then AskUserQuestion: "N open P0/P1 QA findings may touch this change. Ship anyway?" with "Yes — acknowledge and ship" / "No, abort". On abort: `Ship aborted: open P0/P1 QA findings.` On acknowledge, record the finding IDs.
+
+Outcome (`none open` | `N acknowledged: <ids>` | `not checked`) feeds the "QA findings" row of the Ship Confidence Report and PR body — the acknowledgment is permanently visible to reviewers.
+
+---
+
+## Ship Confidence Report
+
+Build after the last pre-PR step, before pushing. Every row uses evidence captured **this run** — never from memory or a previous session.
+
+| Signal | Evidence |
+|--------|----------|
+| Review | candid-loop outcome (iterations, issues found/fixed), cross-checked against `.candid/last-review.json` (its `branch` must equal `currentBranch`). `SKIPPED` if not run. |
+| Build | `PASS (exit 0)` from "Run Build", or `SKIPPED`. |
+| Tests | runner-reported count + exit code from "Run Tests" (e.g. `42 tests, exit 0`). Zero tests executed = FAIL per the test-honesty rule. |
+| QA findings | outcome of "QA Findings Gate": `none open`, `N acknowledged: <ids>`, or `not checked`. |
+| Untested changes | outcome of "Map Tests to Changes": `none` or the file list. |
+| Diff risk | `riskClass` + signals from "Classify Diff Risk". |
+
+Verdict:
+- **HIGH** — review, build, and tests all ran and passed; QA findings row is `none open` (or `not checked` because no findings dir exists); and risk is LOW/MEDIUM, or risk is HIGH with zero untested changes.
+- **MEDIUM** — everything that ran passed, but at least one row is `SKIPPED`, lists untested changes, or has acknowledged QA findings.
+- **LOW** — risk HIGH with review or tests skipped; or tests matched zero tests; or any evidence could not be verified.
+
+Print the panel before "Create Pull Request": `Ship Confidence: [verdict]`, the table, then one reason line per row keeping the verdict below HIGH. Embed the identical table in the PR body (see "Generate Body"), and repeat `Confidence: [verdict]` as the first row of "Display Summary".
+
+If verdict is **LOW**: AskUserQuestion "Confidence is LOW ([reasons]). Ship anyway?" with "Yes, ship at LOW confidence" / "No, abort". On abort: `Ship aborted: low confidence.`
+
+---
+
 ## Create Pull Request
 
 Display:
@@ -182,17 +273,35 @@ Store output as `commitSubjects` (one commit subject per line).
 ## Summary
 [each line of commitSubjects prefixed with "- "]
 
-## Verification
-- Install: [PASS | SKIPPED]
-- Review: [PASS — N iterations, M issues fixed | SKIPPED]
-- Build: [PASS | SKIPPED]
-- Tests: [PASS | SKIPPED]
+## Ship Confidence: [HIGH | MEDIUM | LOW]
+
+| Signal | Result |
+|--------|--------|
+| Review | [PASS — N iterations, M issues fixed | SKIPPED] |
+| Build | [PASS (exit 0) | SKIPPED] |
+| Tests | [PASS (N tests, exit 0) | SKIPPED] |
+| QA findings | [none open | N acknowledged: <ids> | not checked] |
+| Untested changes | [none | file list] |
+| Diff risk | [LOW | MEDIUM | HIGH — <signals>] |
+
+[One line per reason the verdict is below HIGH. Omit when HIGH.]
+
+## Rollback
+
+Revert: `git revert -m 1 <merge-sha>` (squash merge: `git revert <squash-sha>`), then push.
+[Only when `riskClass` is HIGH — one caveat line per matched `riskSignals` entry:]
+- DB migrations changed — `git revert` does not undo applied schema changes; run the down-migration first.
+- Config/env changed — redeploy after revert so services re-read configuration.
+- Dependency manifests changed — run `[installCommand]` after revert to restore the lockfile state.
+- Auth/session code changed — sessions/tokens issued by the new code may need invalidation after revert.
 
 ---
 *Shipped with [candid-ship](https://github.com/ron-myers/candid)*
 ```
 
-Omit any Verification row whose step was skipped. (Or keep with `SKIPPED` — match the calling skill's footer convention.)
+Never omit rows — a signal that didn't run renders as `SKIPPED`/`not checked`. Absence of evidence must be visible to reviewers, not hidden.
+
+Rollback caveats derive from `riskSignals` (see "Classify Diff Risk"). If risk classification is unavailable, emit only the Revert line. Keep the whole Rollback block ≤ 6 lines in the rendered PR.
 
 ### Push and Create
 
@@ -302,6 +411,7 @@ Execute. On non-zero exit: warn `⚠️  Post-merge command failed: [error outpu
 [Candid Ship Complete | Candid Fast Ship Complete]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+Confidence: [HIGH | MEDIUM | LOW]
 Install:  [PASS | SKIPPED]
 Review:   [PASS (N iterations, M issues fixed) | SKIPPED]
 Build:    [PASS | SKIPPED]


### PR DESCRIPTION
## Summary

Ten features targeting two goals: make the decide-which-fixes-to-apply moment better and clearer, and make the ship process generate more confidence. +222/−25 across 12 files.

### Fix selection (candid-review, candid-improve-implementation, candid-loop)

1. **Triage Queue** — reviews open with a ranked table (#, severity, file, title, fix confidence, estimated fix scope); `#N` ids stay canonical through selection, todos, status report, and commit message
2. **"Show me the exact diff"** — any fix can be previewed as a unified diff built from real file content before approval, in all three selection UIs; preview never counts as approval
3. **Confidence-tier bulk apply** — "Apply a subset": Critical+Major, Safe ✓ only, or the intersection
4. **Selection receipt + per-fix status** — receipt before apply, ✅/❌ table after; one failure never aborts the batch; bottom-up apply ordering per file
5. **`--triage` mode** — review + queue + saved state, nothing applied (CI / quick checks); CLI-only by design

### Ship confidence (candid-ship, candid-fast-ship)

6. **Ship Confidence Report** — evidence panel (review/build/tests/QA findings/untested changes/diff risk) with HIGH/MEDIUM/LOW verdict, printed pre-PR and embedded in the PR body; skipped signals render as SKIPPED; LOW requires explicit confirmation
7. **Diff risk classification** — migrations/auth/API/deps/config ⇒ HIGH: blocks `--skip-review`/`--skip-tests`, routes fast-ship to the full pipeline
8. **QA Findings Gate** — open P0/P1 chrome-qa findings overlapping the diff must be acknowledged or the ship aborts; acknowledgment recorded in PR body
9. **Test-to-change mapping** — changed source files with no coverage signal reported as untested changes; hard prompt at HIGH risk
10. **Rollback note** — exact revert command + risk-derived caveats in every PR body

### Verification

- `npm run validate-manifests`: all 4 manifests in lockstep at v1.21.0
- Fences balanced; WORKFLOW.md section order verified; all SKILL.md ↔ WORKFLOW.md references resolve; no step renumbering; zero stale references to replaced options

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>