### PR TITLE
Add /candid-improve — generic output-refinement loop (v1.22.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "name": "candid",
       "source": "./.codex-plugin",
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/ron-myers/candid.git"
       },
       "description": "Configurable code reviews with radical candor - choose between harsh or constructive tone. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "author": {
         "name": "Ron Myers",
         "email": "ron@fritterfactory.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "candid",
   "description": "Configurable code review with radical candor - choose between harsh direct feedback or constructive caring criticism. Features Technical.md for project standards, architectural context analysis, actionable fixes, decision register for tracking review decisions, seamless todo integration, and live browser QA via Chrome.",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "author": {
     "name": "Ron Myers",
     "email": "ron@fritterfactory.com"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Candid review state (user-specific)
 .candid/last-review.json
 .candid/last-improve.json
+.candid/last-improve-output.json
 .candid/register
 
 # macOS metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-07-07
+
+### Added
+
+- **`/candid-improve`** — a new skill that refines a **generic output** (marketing copy, docs, an answer, a plan, a prompt, any text) against your goal, distinct from the code-only `candid-review` and `candid-improve-implementation`:
+  - **Critique → refine loop**: each cycle names weaknesses across five lenses (🎯 Intent fit, 🧩 Completeness, 🔍 Clarity, ✂️ Concision, 🎨 Craft), then rewrites to address them with a before→after preview
+  - **Fully generic input**: improves whatever you point at — `--file <path>`, pasted text, or (default) the most recent substantive output in the session
+  - **Configurable stop conditions**: single pass by default; opt into `--iterations N`, `--until-converged`, or a `--criteria "..."` rubric, all capped by `--max-iterations` (default 5)
+  - **Modes mirroring candid-loop**: `auto` / `review-each` / `interactive` via `--mode` or `improveOutput.mode`
+  - **Source-aware destination**: file sources default to writing back (`--in-place`/`--out`, overwrite confirmed first); inline/session sources print to chat
+  - **Loop invariants**: convergence requires a fresh pass, no-progress and oscillation halt the loop
+  - New `skills/candid-improve/{SKILL.md,CONFIG.md}`, `commands/candid-improve.md`, docs page, and full site wiring (core-features nav, slash-commands reference, homepage command list, Codex command mapping)
+  - Config namespace `improveOutput` and state file `.candid/last-improve-output.json` — deliberately separate from `candid-improve-implementation`'s `improve` block
+
 ## [1.21.0] - 2026-07-04
 
 ### Added

--- a/commands/candid-improve.md
+++ b/commands/candid-improve.md
@@ -1,0 +1,59 @@
+---
+command: candid-improve
+description: Improve an output — copy, a doc, an answer, a plan, any text — against your goal via a critique→refine loop
+skill: candid-improve
+args:
+  - name: file
+    description: Read the artifact to improve from this path (default is the last session output)
+    required: false
+  - name: criteria
+    description: Explicit success bar / rubric — loop until met
+    required: false
+  - name: iterations
+    description: Number of critique→refine cycles (default 1, single pass)
+    required: false
+  - name: until-converged
+    description: Loop until a cycle yields no meaningful improvement (capped by max-iterations)
+    required: false
+  - name: max-iterations
+    description: Hard cap for converge/rubric loops (default 5)
+    required: false
+  - name: mode
+    description: Interaction level (auto, review-each, interactive)
+    required: false
+  - name: out
+    description: Write the improved output to this path
+    required: false
+  - name: in-place
+    description: Overwrite the source file with the improved output
+    required: false
+  - name: harsh
+    description: Use harsh/blunt tone (skips tone prompt)
+    required: false
+  - name: constructive
+    description: Use constructive/supportive tone (skips tone prompt)
+    required: false
+---
+
+Improve an output you already have — marketing copy, documentation, an answer, a
+plan, a prompt, an email — against your goal. Runs a **critique → refine** loop:
+name what's weak, rewrite to fix it, repeat until the stop condition is met.
+
+Distinct from `/candid-review` (hunts defects in code) and
+`/candid-improve-implementation` (code-quality pass). This is a **generic text
+artifact refiner**.
+
+By default it improves the **last output in this session** in a **single pass**,
+using the current context to decide what "better" means.
+
+Usage:
+```
+/candid-improve                                  # refine the last session output, single pass
+/candid-improve --file README.md --iterations 2  # two cycles on a file
+/candid-improve --until-converged --criteria "punchier, under 120 words, active voice"
+/candid-improve --mode interactive --file pitch.md
+/candid-improve --harsh --criteria "no marketing fluff, concrete claims only"
+/candid-improve --file draft.md --in-place        # overwrite the source (confirmed first)
+```
+
+Full workflow, stop conditions, and configuration: the candid-improve skill.

--- a/docs/app/(marketing)/page.jsx
+++ b/docs/app/(marketing)/page.jsx
@@ -528,6 +528,10 @@ export default function HomePage() {
             <span>Review your changes. Pick tone (<code>--harsh</code>/<code>--constructive</code>) and focus area.</span>
           </li>
           <li>
+            <code>/candid-improve</code>
+            <span>Refine any output — copy, docs, an answer, a plan — against your goal in a critique→refine loop.</span>
+          </li>
+          <li>
             <code>/candid-ship</code>
             <span>Run install/build/test, open the PR, optionally auto-merge and update Linear.</span>
           </li>

--- a/docs/app/docs/core-features/_meta.js
+++ b/docs/app/docs/core-features/_meta.js
@@ -5,6 +5,7 @@ export default {
   'technical-md': 'Technical.md',
   'auto-commit': 'Auto-Commit',
   're-review': 'Re-Review',
+  'candid-improve': 'Candid Improve',
   'candid-loop': 'Candid Loop',
   'decision-register': 'Decision Register',
   'context-optimization': 'Context Optimization',

--- a/docs/app/docs/core-features/candid-improve/page.mdx
+++ b/docs/app/docs/core-features/candid-improve/page.mdx
@@ -1,0 +1,132 @@
+export const metadata = {
+  title: 'Candid Improve - Refine Any Output Against Your Goal',
+  description: 'Use candid-improve to make an output better — copy, a doc, an answer, a plan, any text — via a critique→refine loop with configurable stop conditions and auto/review-each/interactive modes.',
+}
+
+# Candid Improve
+
+Where `/candid-review` and `/candid-improve-implementation` work on **code**, this skill works on **any output you already have** — marketing copy, documentation, an answer, a plan, a prompt, an email, a spec. It runs a **critique → refine** loop: name what's weak against your goal, rewrite to fix it, repeat until the stop condition is met.
+
+## Quick Start
+
+```
+/candid-improve
+```
+
+With no arguments, it improves the **last output in this session** in a **single pass**, using the current context to decide what "better" means. Point it at a file or paste text to improve something else.
+
+## When to Use It
+
+- You have a draft — copy, docs, an email, a plan — and want a sharper version
+- An answer or explanation you just produced needs tightening
+- A prompt or spec that isn't landing the way you want
+- Any text artifact where you can name a goal ("punchier", "under 120 words", "no jargon")
+
+Not the right tool for: reviewing code for defects (use `/candid-review`), a code-quality pass (use `/candid-improve-implementation`), or generating something from scratch (just ask).
+
+## How It Works
+
+1. **Resolve the target** — `--file <path>`, inline text you paste, or (default) the most recent substantive output in the session. Ambiguous? It asks.
+2. **Resolve the goal** — your `--criteria`/rubric, the surrounding context, or (default) an intent inferred from the session, stated back so you can correct it.
+3. **Resolve the destination** — file source defaults to writing back (overwrite confirmed first); inline/session source prints to chat. Override with `--out`/`--in-place`.
+4. **Critique → refine loop** — each cycle names weaknesses across the active lenses, then rewrites to address them, showing a before→after preview.
+5. **Stop** — when the rubric is met, iterations are exhausted, the cycle converges, no progress is made, or `--max-iterations` is hit.
+6. **Save state** — writes `.candid/last-improve-output.json`.
+
+## Critique Lenses
+
+Each cycle critiques against the goal using these lenses (adapted to the artifact type; restrict the set via `improveOutput.lenses`):
+
+- 🎯 **Intent fit** — does it actually satisfy the goal / answer the ask?
+- 🧩 **Completeness** — missing pieces, unsupported claims, gaps?
+- 🔍 **Clarity** — ambiguous, confusing, poorly ordered, jargon?
+- ✂️ **Concision** — padding, redundancy, filler, hedging?
+- 🎨 **Craft** — tone, correctness, rhythm, polish for the medium.
+
+## Stop Conditions
+
+By default the loop runs **exactly one pass**. Opt into looping:
+
+| You want | Use |
+|----------|-----|
+| One pass (default) | *(nothing)* |
+| A fixed number of cycles | `--iterations N` |
+| Loop until it stops improving | `--until-converged` |
+| Loop until a bar is met | `--criteria "..."` |
+| Cap converge/rubric loops | `--max-iterations N` (default 5) |
+
+If `--criteria` is set it is the stop bar; else `--until-converged` loops to convergence; else `iterations` cycles run. All looping is capped by `--max-iterations`.
+
+## Modes
+
+Mirror `/candid-loop`. Set with `--mode` or `improveOutput.mode`.
+
+- **auto** (default) — accept every critique point and rewrite.
+- **review-each** — per-point Yes/No before it's applied (offers the rewrite as a preview).
+- **interactive** — per-point Apply / Skip / Edit-the-goal / Stop-all.
+
+## Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--file <path>` | Read the artifact from this path | Last session output |
+| `--criteria "<text>"` | Explicit success bar / rubric — loop until met | Inferred from context |
+| `--iterations <N>` | Critique→refine cycles | `1` |
+| `--until-converged` | Loop until no meaningful improvement | Off |
+| `--max-iterations <N>` | Hard cap for converge/rubric loops | `5` |
+| `--mode <m>` | `auto`, `review-each`, `interactive` | `auto` |
+| `--out <path>` | Write the improved output to this path | Source-based |
+| `--in-place` | Overwrite the source file (confirmed first) | Off |
+| `--harsh` / `--constructive` | Critique tone | Interactive prompt |
+
+## Examples
+
+```bash
+# Refine the last session output, single pass
+/candid-improve
+
+# Two cycles on a file
+/candid-improve --file README.md --iterations 2
+
+# Loop until it hits the bar
+/candid-improve --until-converged --criteria "punchier, under 120 words, active voice"
+
+# Step through each critique point on a draft
+/candid-improve --mode interactive --file pitch.md
+
+# Blunt tone, concrete criteria, overwrite the source
+/candid-improve --harsh --file draft.md --in-place --criteria "no marketing fluff, concrete claims only"
+```
+
+## Configuration
+
+Add to `.candid/config.json`:
+
+```json
+{
+  "tone": "constructive",
+  "improveOutput": {
+    "mode": "auto",
+    "iterations": 1,
+    "maxIterations": 5,
+    "lenses": ["intent", "completeness", "clarity", "concision", "craft"],
+    "defaultDestination": "chat"
+  }
+}
+```
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `improveOutput.mode` | `"auto" \| "review-each" \| "interactive"` | Interaction level | `"auto"` |
+| `improveOutput.iterations` | integer | Cycles when no other stop condition set | `1` |
+| `improveOutput.maxIterations` | integer (1-20) | Cap for converge/rubric loops | `5` |
+| `improveOutput.lenses` | array | Which critique lenses run | All five |
+| `improveOutput.defaultDestination` | `"chat" \| "file"` | Destination default | Source-based |
+
+The `improveOutput` block is deliberately separate from `/candid-improve-implementation`'s `improve` block — different jobs, no shared config or state. `tone` is shared with `/candid-review`.
+
+## See Also
+
+- [Candid Review](/docs/core-features/candid-review) — defect / risk / security review of code
+- [Candid Improve Implementation](/docs/core-features/candid-improve-implementation) — code-quality pass on working code
+- [Candid Loop](/docs/core-features/candid-loop) — fix-review-fix loop for code

--- a/docs/app/docs/core-features/page.mdx
+++ b/docs/app/docs/core-features/page.mdx
@@ -15,6 +15,7 @@ Everything Candid can do for your code reviews.
 
 - [Auto-Commit](/docs/core-features/auto-commit) — Automatically commit applied fixes
 - [Re-Review](/docs/core-features/re-review) — Track progress on fixing issues
+- [Candid Improve](/docs/core-features/candid-improve) — Refine any output against your goal in a critique→refine loop
 - [Candid Loop](/docs/core-features/candid-loop) — Run reviews in a loop until clean
 - [Decision Register](/docs/core-features/decision-register) — Track questions and decisions from reviews
 - [Context Optimization](/docs/core-features/context-optimization) — Audit and optimize review context

--- a/docs/app/docs/core-features/slash-commands/page.mdx
+++ b/docs/app/docs/core-features/slash-commands/page.mdx
@@ -30,6 +30,40 @@ Run a code review on your changes.
 /candid-review --re-review
 ```
 
+## /candid-improve
+
+Improve an output — copy, a doc, an answer, a plan, any text — against your goal via a critique→refine loop. Distinct from `/candid-review` and `/candid-improve-implementation` (both code-only); this refines generic text artifacts. Defaults to improving the last session output in a single pass.
+
+```
+/candid-improve
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--file <path>` | Read the artifact to improve from this path (default: last session output) |
+| `--criteria "<text>"` | Explicit success bar / rubric — loop until met |
+| `--iterations <N>` | Number of critique→refine cycles (default: 1, single pass) |
+| `--until-converged` | Loop until a cycle yields no meaningful improvement (capped by max-iterations) |
+| `--max-iterations <N>` | Hard cap for converge/rubric loops (default: 5) |
+| `--mode <auto\|review-each\|interactive>` | Interaction level (default: auto) |
+| `--out <path>` | Write the improved output to this path |
+| `--in-place` | Overwrite the source file (confirmed first) |
+| `--harsh` / `--constructive` | Critique tone |
+
+### Examples
+
+```
+/candid-improve
+/candid-improve --file README.md --iterations 2
+/candid-improve --until-converged --criteria "punchier, under 120 words, active voice"
+/candid-improve --mode interactive --file pitch.md
+/candid-improve --harsh --criteria "no marketing fluff, concrete claims only"
+```
+
+See [Candid Improve](/docs/core-features/candid-improve) for full documentation.
+
 ## /candid-loop
 
 Run code review in a loop until all issues are resolved.

--- a/docs/codex/install.md
+++ b/docs/codex/install.md
@@ -46,6 +46,7 @@ Codex has built-in slash commands (`/plugins`, `/skills`, `/model`, etc.) but no
 | `/candid-init` | `$candid-init` |
 | `/candid-optimize` | `$candid-optimize` |
 | `/candid-validate-standards` | `$candid-validate-standards` |
+| `/candid-improve` | `$candid-improve` |
 | `/candid-improve-implementation` | `$candid-improve-implementation` |
 | `/candid-chrome-qa` | `$candid-chrome-qa` |
 | `/candid-chrome-qa-fix` | `$candid-chrome-qa-fix` |

--- a/skills/candid-improve/CONFIG.md
+++ b/skills/candid-improve/CONFIG.md
@@ -1,0 +1,123 @@
+# Config File Handling for Candid Improve
+
+## Config File Locations
+
+- **User config:** `~/.candid/config.json`
+- **Project config:** `.candid/config.json` (in project root)
+
+`candid-improve` reads the same config file as the rest of the candid suite.
+This document covers the fields **specific to** the output-improvement skill.
+For `tone` and other shared fields, see `skills/candid-review/CONFIG.md`
+(canonical reference).
+
+**Namespace note:** this skill uses the `improveOutput` block. It is deliberately
+separate from `candid-improve-implementation`'s `improve` block — the two skills
+do different jobs (generic output refinement vs. code-quality pass) and must not
+share config or state. Reading the wrong block cross-contaminates the skills.
+
+## Schema Specification
+
+```json
+{
+  "version": 1,
+  "tone": "harsh" | "constructive",
+  "improveOutput": {
+    "mode": "auto" | "review-each" | "interactive",
+    "iterations": 1,
+    "maxIterations": 5,
+    "lenses": ["intent", "completeness", "clarity", "concision", "craft"],
+    "defaultDestination": "chat" | "file"
+  }
+}
+```
+
+**Field descriptions:**
+
+- `version` (optional): Config schema version. Defaults to `1`.
+- `tone` (optional): Critique tone. Exactly `"harsh"` or `"constructive"`. Shared with `candid-review`; same precedence loader.
+- `improveOutput` (optional): Settings specific to `candid-improve`. If absent, all defaults apply.
+  - `improveOutput.mode` (optional): Interaction level. Exactly `"auto"`, `"review-each"`, or `"interactive"`. CLI `--mode` overrides. Default `"auto"`.
+  - `improveOutput.iterations` (optional): Number of critique→refine cycles when no other stop condition is set. Positive integer. CLI `--iterations` overrides. Default `1` (single pass).
+  - `improveOutput.maxIterations` (optional): Hard cap for `--until-converged` / `--criteria` loops. Positive integer (1-20). CLI `--max-iterations` overrides. Default `5`.
+  - `improveOutput.lenses` (optional): Subset of `"intent"`, `"completeness"`, `"clarity"`, `"concision"`, `"craft"`. Restricts which critique lenses run. Default: all five.
+  - `improveOutput.defaultDestination` (optional): `"chat"` or `"file"`. Overrides the source-based destination default (see SKILL.md Step 5). CLI `--out`/`--in-place` override this.
+
+## Validation Rules
+
+1. **File must be valid JSON** — must parse without errors.
+2. **Tone field validation** — if present, exactly `"harsh"` or `"constructive"` (case-sensitive).
+3. **improveOutput field validation** — if present, must be an object.
+   - `improveOutput.mode`: if present, exactly `"auto"`, `"review-each"`, or `"interactive"`. Invalid values warn and are ignored.
+   - `improveOutput.iterations`: if present, positive integer. Out-of-range/non-integer values warn and are ignored (defaults to 1).
+   - `improveOutput.maxIterations`: if present, positive integer 1-20. Out-of-range values warn and are ignored (defaults to 5).
+   - `improveOutput.lenses`: if present, an array whose entries are all in the allowed set. Unknown entries are dropped with a warning; an empty result falls back to all five.
+   - `improveOutput.defaultDestination`: if present, exactly `"chat"` or `"file"`. Invalid values warn and are ignored.
+4. **Unknown fields ignored** — forward compatibility.
+5. **Empty object is valid** — `{}` is a valid config; the system continues to the next source.
+
+## Config Validation Procedure
+
+Same reusable procedure as `candid-review`. See `skills/candid-review/CONFIG.md`
+→ "Config Validation Procedure" for the canonical text. Extraction paths for
+this skill's fields:
+
+```bash
+jq -r '.improveOutput.mode // "none"' [config_path]
+jq -r '.improveOutput.iterations // "none"' [config_path]
+jq -r '.improveOutput.maxIterations // "none"' [config_path]
+jq -r '.improveOutput.defaultDestination // "none"' [config_path]
+```
+
+## Error Handling
+
+On any invalid value, show `⚠️  Invalid config at [path]: [specific error]. Falling back to [next source].` and continue to the next precedence level (or the default). Specific errors: `malformed JSON`; `invalid improveOutput.mode "[value]" (must be "auto", "review-each", or "interactive")`; `invalid improveOutput.iterations "[value]" (must be positive integer)`; `invalid improveOutput.maxIterations "[value]" (must be positive integer 1-20)`; `invalid improveOutput.defaultDestination "[value]" (must be "chat" or "file")`.
+
+## Success Message Template
+
+```
+Using [tone] tone (from [source])
+Mode: [mode] (from [source])
+Stop condition: [single pass | N iterations | until converged | rubric] (from [source])
+```
+
+### Source Values
+
+- `"CLI flag"` — when a flag provided the value
+- `"project config"` — from `.candid/config.json`
+- `"user config"` — from `~/.candid/config.json`
+- `"default"` — when no source set the value
+
+## Config File Examples
+
+**Full config:**
+```json
+{
+  "version": 1,
+  "tone": "harsh",
+  "improveOutput": {
+    "mode": "review-each",
+    "iterations": 1,
+    "maxIterations": 5,
+    "lenses": ["intent", "clarity", "concision"],
+    "defaultDestination": "chat"
+  }
+}
+```
+
+**Coexisting with candid-improve-implementation:**
+```json
+{
+  "version": 1,
+  "tone": "harsh",
+  "improve": {
+    "focus": "clarity",
+    "maxOpportunities": 5
+  },
+  "improveOutput": {
+    "mode": "auto"
+  }
+}
+```
+Here `improve.*` applies to `/candid-improve-implementation` (code-quality pass)
+and `improveOutput.*` applies to `/candid-improve` (output refinement). They do
+not interfere.

--- a/skills/candid-improve/SKILL.md
+++ b/skills/candid-improve/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: candid-improve
+description: Use when you have an output — copy, a doc, an answer, a plan, a prompt, any text artifact — and want it made better against your goal. Runs a critique→refine loop with configurable stop conditions and auto/review-each/interactive modes. Default is a single pass using the current session context to decide what "better" means.
+---
+
+# Output Improvement Loop — candid-improve
+
+You take an **output the user already has** and make it better against their
+goal. Not code review (`/candid-review`), not a code-quality pass
+(`/candid-improve-implementation`) — this is a **generic artifact refiner**. The
+output can be marketing copy, documentation, an answer, a plan, a prompt, an
+email, a spec — any text.
+
+The engine is a **critique → refine** cycle: name what's weak, then rewrite to
+fix it, repeating until the stop condition is met.
+
+## Scope
+
+- **Input is whatever the user points at** — a pasted block, a file, or the most recent substantive output in this session.
+- **"Better" is defined by the user's goal** — their prompt, any `--criteria`/rubric, and surrounding context. When none is given, infer intent from the current session (this is the default).
+- Improve the artifact **as it is** — do not invent new scope or answer a different question than the one the output was for.
+
+---
+
+## Workflow
+
+Execute in order.
+
+### Step 1: Load Configuration
+
+Resolve every option CLI flag → project config (`.candid/config.json` →
+`improveOutput` field) → user config (`~/.candid/config.json` → `improveOutput`)
+→ default. Validation, jq paths, and warning formats are in `CONFIG.md`; invalid
+values warn and fall through.
+
+| Option | CLI flag | Config field | Values / default |
+|---|---|---|---|
+| Mode | `--mode <m>` | `improveOutput.mode` | `auto` \| `review-each` \| `interactive`; default `auto` |
+| Iterations | `--iterations <N>` | `improveOutput.iterations` | positive integer; default `1` (single pass) |
+| Converge | `--until-converged` | — | loop until a cycle yields no meaningful change; capped by max-iterations |
+| Criteria/rubric | `--criteria "<text>"` | — | explicit success bar; loop stops when met |
+| Max iterations | `--max-iterations <N>` | `improveOutput.maxIterations` | hard cap for converge/rubric loops; default `5` |
+| Source file | `--file <path>` | — | read the artifact from this path |
+| Destination | `--out <path>` \| `--in-place` | `improveOutput.defaultDestination` | `chat` \| `file`; default resolved in Step 5 |
+| Lenses | — | `improveOutput.lenses` | subset of `intent, completeness, clarity, concision, craft`; default all |
+
+**Stop-condition precedence:** if `--criteria` is set, the rubric is the stop
+bar (loop until met or max hit). Else if `--until-converged`, loop until a cycle
+is a no-op or max hit. Else run exactly `iterations` cycles (default `1`).
+
+### Step 2: Load Tone Preference
+
+Mirror `candid-review`'s tone loader exactly (see `skills/candid-review/CONFIG.md`).
+
+**Precedence:** CLI (`--harsh`/`--constructive`) → project `tone` → user `tone` → interactive prompt.
+
+If falling through, AskUserQuestion — **Question:** "Choose your critique style"
+1. **Harsh** — Blunt about what's weak, vague, or padded. No hedging.
+2. **Constructive** — Same honesty, explains *why* each rewrite is stronger and what it trades.
+
+Output: `Using [tone] tone (from [source])`.
+
+### Step 3: Resolve the Target Output
+
+In priority order:
+
+1. `--file <path>` provided → read that file. Record `source = file:<path>`.
+2. Inline text passed with the command → use it. Record `source = inline`.
+3. Otherwise → the **most recent substantive output in this session** (the default). Identify it explicitly and record `source = session`.
+
+If the target is ambiguous (e.g. several candidate outputs, or no clear recent
+one), ask the user which output to improve before proceeding. Never guess
+silently.
+
+Echo what you locked onto: `Improving: [one-line description of the artifact] (source: [file|inline|session])`.
+
+### Step 4: Resolve Improvement Criteria
+
+Assemble the bar for "better":
+
+1. **Explicit** — `--criteria "..."` and/or a rubric the user gave.
+2. **Context** — the user's prompt in this turn plus relevant session context (what the artifact is for, audience, constraints, length limits).
+3. **Inferred** — if neither of the above pins it down, infer the goal from the current session and the artifact itself (the documented default). State your inferred goal in one line so the user can correct it.
+
+Also classify the **artifact type** (copy / doc / answer / plan / prompt / other)
+— it selects which lenses matter most in Step 6.
+
+Output: `Goal: [criteria] (from [explicit|context|inferred])`.
+
+### Step 5: Resolve Output Destination
+
+Destination depends on the source (Step 3):
+
+- **Source was a file** → default to writing back. Offer: overwrite in place (`--in-place`), a new file (`--out <path>`), or print to chat. **Confirm before overwriting** (destructive).
+- **Source was inline or session** → default to printing the improved output to chat; offer to write to a new file.
+- `--out`/`--in-place`/`improveOutput.defaultDestination` override the default without asking.
+
+Record the resolved destination for Step 7.
+
+### Step 6: Run the Refine Loop
+
+Initialize:
+```
+iteration = 0
+current = target output (from Step 3)
+history = [current]          # for oscillation checks
+```
+
+Loop:
+
+```
+WHILE not done:
+    iteration++
+
+    6.1 Critique pass — against the Step 4 goal, produce a short list of
+        specific, actionable weaknesses. Use the active lenses (Step 1),
+        adapted to the artifact type:
+          🎯 Intent fit   — does it actually satisfy the goal / answer the ask?
+          🧩 Completeness — missing pieces, unsupported claims, gaps?
+          🔍 Clarity      — ambiguous, confusing, poorly ordered, jargon?
+          ✂️ Concision    — padding, redundancy, filler, hedging?
+          🎨 Craft        — tone, correctness, rhythm, polish for the medium
+        Each point: one line naming the problem + where it is in the artifact.
+        If the artifact already meets the goal and nothing rises above the
+        noise floor → mark converged and break.
+
+    6.2 Gate by mode:
+          auto        → accept all critique points
+          review-each → per-point Yes/No (offer "show the rewrite")
+          interactive → per-point: Apply / Skip / Edit-the-goal / Stop-all
+
+    6.3 Refine pass — rewrite `current` into an improved version that addresses
+        the accepted points. Change only what the critique justifies; preserve
+        the artifact's intent, voice, and any correct content.
+
+    6.4 Show this iteration: the critique points, then a before→after preview
+        (full rewrite if short; a diff/section-level view if long).
+
+    6.5 Set current = refined output; append to history.
+
+    6.6 Stop check (see Invariants): stop when the rubric is met, iterations are
+        exhausted, the cycle converged, no progress was made, or max-iterations
+        is hit.
+```
+
+#### Loop Invariants — do not violate
+
+1. **Convergence requires a fresh pass.** Declare "converged/done" only after a critique pass that surfaced nothing meaningful (or the refine produced only trivial change). Never infer convergence from an earlier iteration.
+2. **No progress → stop.** If a cycle accepts nothing (or the rewrite is a no-op) and the goal is unmet, stop and report — repeating the identical critique cannot converge.
+3. **Oscillation check.** If a refined output matches an earlier entry in `history`, halt: `Oscillation detected — output reverted to iteration [k]`. Surface both versions for the user to choose.
+4. **Respect the cap.** `--max-iterations` (default 5) is a hard ceiling for converge/rubric loops. If hit with the goal unmet, stop and report INCOMPLETE.
+5. **Single pass by default.** With no `--criteria`, `--until-converged`, or `--iterations`, run exactly one cycle and stop.
+
+### Step 7: Emit Result
+
+1. Deliver `current` to the destination from Step 5:
+   - chat → print the final improved output in a fenced block.
+   - file → write it; confirm the path (and that a backup/original is preserved when not overwriting).
+2. Summary: `[N] iteration(s) · stop reason: [rubric met | converged | iterations done | no progress | max reached]` followed by a 1–3 line note on what changed across the run.
+
+### Step 8: Save State
+
+```bash
+mkdir -p .candid
+```
+
+Write `.candid/last-improve-output.json`:
+```json
+{
+  "timestamp": "ISO timestamp",
+  "skill": "candid-improve",
+  "source": "file:<path> | inline | session",
+  "goal": "resolved criteria",
+  "iterations": 2,
+  "stopReason": "converged",
+  "destination": "chat | file:<path>"
+}
+```
+
+Output: `Improvement state saved to .candid/last-improve-output.json`.
+
+**Note:** this file is user-specific state and belongs in `.gitignore` (separate from `candid-improve-implementation`'s `.candid/last-improve.json`).
+
+---
+
+## Output Structure
+
+Per iteration, in order:
+1. **Critique** — the active-lens points (🎯/🧩/🔍/✂️/🎨), one line each.
+2. **Rewrite** — before→after preview.
+
+After the loop:
+3. **Final output** — delivered to the destination.
+4. **Summary** — iterations + stop reason + what changed.
+
+In `review-each`/`interactive` modes, the per-point gate (Step 6.2) sits between
+Critique and Rewrite.
+
+---
+
+## Examples
+
+```
+/candid-improve                                  # refine the last session output, single pass, auto
+/candid-improve --file README.md --iterations 2  # two cycles on a file
+/candid-improve --until-converged --criteria "punchier, under 120 words, active voice"
+/candid-improve --mode interactive --file pitch.md
+/candid-improve --harsh --criteria "no marketing fluff, concrete claims only"
+```
+
+## Remember
+
+The user already has an output — they want the **next version of it**, aimed at
+their goal. Be specific (every critique point names a problem and where), honest
+about what each rewrite trades, and restrained (fix what the goal justifies, not
+everything you could touch). Default to one pass unless the user asked to loop.
+Harsh: name the weak, vague, and padded parts directly. Constructive: same
+honesty, explain why each rewrite is stronger.


### PR DESCRIPTION
## Summary
- Add /candid-improve — generic output-refinement loop (v1.22.0)

New skill `/candid-improve` refines any text output (copy, docs, an answer, a plan, a prompt) against the user's goal via a critique→refine loop — distinct from the code-only `candid-review` and `candid-improve-implementation`. Critique lenses: intent fit, completeness, clarity, concision, craft. Input: `--file`, pasted text, or the last session output. Stop conditions: single pass by default; `--iterations N`, `--until-converged`, or `--criteria` rubric, capped by `--max-iterations`. Modes: auto / review-each / interactive. Config namespace `improveOutput` (no collision with `improve`). Full site wiring + all 4 manifests bumped to 1.22.0.

## Ship Confidence: MEDIUM

| Signal | Result |
|--------|--------|
| Review | PASS — 1 iteration, 0 issues |
| Build | PASS — docs `next build`, exit 0 (new route prerendered) |
| Tests | SKIPPED — no test suite configured in this repo |
| QA findings | not checked — no findings directory |
| Untested changes | none — docs/config only, no source files |
| Diff risk | MEDIUM — docs + config + JS/JSX |

MEDIUM: no automated test suite configured; verification was the docs build + manifest validation.

## Rollback

Revert: `git revert -m 1 <merge-sha>` (squash merge: `git revert <squash-sha>`), then push.

---
*Shipped with [candid-ship](https://github.com/ron-myers/candid)*